### PR TITLE
Use sniper printer as the default printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The arguments are the following:
         source code will be printed and its formatting might change (such as
         indentation), and 'SNIPER', which means that only statements changed
         towards the repair of sonar rule violations will be printed. (default:
-        NORMAL)
+        SNIPER)
 
   [--fileOutputStrategy <fileOutputStrategy>]
         Mode for outputting files: 'CHANGED_ONLY', which means that only changed

--- a/src/main/java/sorald/Main.java
+++ b/src/main/java/sorald/Main.java
@@ -53,7 +53,7 @@ public class Main {
 		opt = new FlaggedOption(Constants.ARG_PRETTY_PRINTING_STRATEGY);
 		opt.setLongFlag(Constants.ARG_PRETTY_PRINTING_STRATEGY);
 		opt.setStringParser(JSAP.STRING_PARSER);
-		opt.setDefault(PrettyPrintingStrategy.NORMAL.name());
+		opt.setDefault(PrettyPrintingStrategy.SNIPER.name());
 		opt.setHelp("Mode for pretty printing the source code: 'NORMAL', which means that all source code will be printed and its formatting might change (such as indentation), and 'SNIPER', which means that only statements changed towards the repair of Sonar rule violations will be printed.");
 		jsap.registerParameter(opt);
 

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -52,6 +52,7 @@ public class FileOutputStrategyTest {
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,Constants.PATH_TO_RESOURCES_FOLDER,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"4973",
 				Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY, FileOutputStrategy.ALL.name(),
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE, fileOutputStrategyTestWorkspace});
 
 		File spooned = new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);

--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -17,7 +17,6 @@ public class MultipleProcessorsTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2111,2184,2204",
-				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.SNIPER.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());

--- a/src/test/java/sorald/processor/ArrayHashCodeAndToStringProcessorTest.java
+++ b/src/test/java/sorald/processor/ArrayHashCodeAndToStringProcessorTest.java
@@ -20,6 +20,7 @@ public class ArrayHashCodeAndToStringProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2116",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new ArrayHashCodeAndToStringCheck());
@@ -35,7 +36,7 @@ public class ArrayHashCodeAndToStringProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2116",
-				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.SNIPER.name(),
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new ArrayHashCodeAndToStringCheck());

--- a/src/test/java/sorald/processor/BigDecimalDoubleConstructorProcessorTest.java
+++ b/src/test/java/sorald/processor/BigDecimalDoubleConstructorProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class BigDecimalDoubleConstructorProcessorTest {
@@ -19,6 +20,7 @@ public class BigDecimalDoubleConstructorProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2111",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());

--- a/src/test/java/sorald/processor/CastArithmeticOperandTest.java
+++ b/src/test/java/sorald/processor/CastArithmeticOperandTest.java
@@ -5,7 +5,6 @@ import org.sonar.java.checks.CastArithmeticOperandCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
-import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class CastArithmeticOperandTest {
@@ -20,7 +19,6 @@ public class CastArithmeticOperandTest {
         Main.main(new String[]{
                 Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
                 Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2184",
-                Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.SNIPER.name(),
                 Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
         TestHelper.removeComplianceComments(pathToRepairedFile);
         JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new CastArithmeticOperandCheck());

--- a/src/test/java/sorald/processor/EqualsOnAtomicClassProcessorTest.java
+++ b/src/test/java/sorald/processor/EqualsOnAtomicClassProcessorTest.java
@@ -5,7 +5,6 @@ import org.sonar.java.checks.EqualsOnAtomicClassCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
-import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class EqualsOnAtomicClassProcessorTest {
@@ -20,7 +19,6 @@ public class EqualsOnAtomicClassProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH, pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS, "2204",
-				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.SNIPER.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE, Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new EqualsOnAtomicClassCheck());

--- a/src/test/java/sorald/processor/GetClassLoaderProcessorTest.java
+++ b/src/test/java/sorald/processor/GetClassLoaderProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.GetClassLoaderCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class GetClassLoaderProcessorTest {
@@ -19,6 +20,7 @@ public class GetClassLoaderProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"3032",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new GetClassLoaderCheck());

--- a/src/test/java/sorald/processor/MathOnFloatProcessorTest.java
+++ b/src/test/java/sorald/processor/MathOnFloatProcessorTest.java
@@ -5,7 +5,6 @@ import org.sonar.java.checks.MathOnFloatCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
-import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class MathOnFloatProcessorTest {
@@ -20,7 +19,6 @@ public class MathOnFloatProcessorTest {
         Main.main(new String[]{
                 Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
                 Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2164",
-                Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.SNIPER.name(),
                 Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
         TestHelper.removeComplianceComments(pathToRepairedFile);
         JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new MathOnFloatCheck());

--- a/src/test/java/sorald/processor/SelfAssignementProcessorTest.java
+++ b/src/test/java/sorald/processor/SelfAssignementProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import org.sonar.java.checks.SelfAssignementCheck;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class SelfAssignementProcessorTest {
@@ -19,6 +20,7 @@ public class SelfAssignementProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"1656",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SelfAssignementCheck());

--- a/src/test/java/sorald/processor/SerializableFieldInSerializableClassProcessorTest.java
+++ b/src/test/java/sorald/processor/SerializableFieldInSerializableClassProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.serialization.SerializableFieldInSerializableClassC
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class SerializableFieldInSerializableClassProcessorTest {
@@ -19,6 +20,7 @@ public class SerializableFieldInSerializableClassProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"1948",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SerializableFieldInSerializableClassCheck());

--- a/src/test/java/sorald/processor/SynchronizationOnGetClassProcessorTest.java
+++ b/src/test/java/sorald/processor/SynchronizationOnGetClassProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.synchronization.SynchronizationOnGetClassCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class SynchronizationOnGetClassProcessorTest {
@@ -19,6 +20,7 @@ public class SynchronizationOnGetClassProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"3067",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SynchronizationOnGetClassCheck());

--- a/src/test/java/sorald/processor/SynchronizationOnStringOrBoxedProcessorTest.java
+++ b/src/test/java/sorald/processor/SynchronizationOnStringOrBoxedProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.SynchronizationOnStringOrBoxedCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class SynchronizationOnStringOrBoxedProcessorTest {
@@ -19,6 +20,7 @@ public class SynchronizationOnStringOrBoxedProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH, pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS, "1860",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE, Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SynchronizationOnStringOrBoxedCheck());

--- a/src/test/java/sorald/processor/UnclosedResourcesProcessorTest.java
+++ b/src/test/java/sorald/processor/UnclosedResourcesProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import org.sonar.java.se.checks.UnclosedResourcesCheck;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class UnclosedResourcesProcessorTest {
@@ -19,6 +20,7 @@ public class UnclosedResourcesProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2095",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new UnclosedResourcesCheck());

--- a/src/test/java/sorald/processor/UnusedThrowableProcessorTest.java
+++ b/src/test/java/sorald/processor/UnusedThrowableProcessorTest.java
@@ -5,6 +5,7 @@ import org.sonar.java.checks.unused.UnusedThrowableCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sorald.Constants;
 import sorald.Main;
+import sorald.PrettyPrintingStrategy;
 import sorald.TestHelper;
 
 public class UnusedThrowableProcessorTest {
@@ -19,6 +20,7 @@ public class UnusedThrowableProcessorTest {
 		Main.main(new String[]{
 				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
 				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"3984",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
 				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new UnusedThrowableCheck());


### PR DESCRIPTION
This PR fixes points 1 and 2 in https://github.com/SpoonLabs/sorald/issues/74#issuecomment-639464652.

Note: some test cases do not actually fail with sniper but yet the normal printer is used because the output code is somewhat wrong or with style problems that we might want to report to the Spoon team anyways.