### PR TITLE
Update spoon version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>8.2.0-beta-10</version>
+            <version>8.2.0-beta-12</version>
         </dependency>
         <dependency>
             <groupId>org.sonarsource.java</groupId>


### PR DESCRIPTION
The latest Spoon beta version contains multiple fixes in the sniper printer, thus we should use it.