### PR TITLE
Add InterruptedExceptionProcessor (SonarSource rule 2142)

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -5,6 +5,7 @@ Sorald can currently repair violations of the following rules:
 * [Bug](#bug)
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
     * ["BigDecimal(double)" should not be used](#bigdecimaldouble-should-not-be-used-sonar-rule-2111) ([Sonar Rule 2111](https://rules.sonarsource.com/java/RSPEC-2111))
+    * ["InterruptedException" should not be ignored](#interruptedexception-should-not-be-ignored-sonar-rule-2142) ([Sonar Rule 2142](https://rules.sonarsource.com/java/RSPEC-2142))
     * ["Iterator.next()" methods should throw "NoSuchElementException"](#iteratornext-methods-should-throw-nosuchelementexception-sonar-rule-2272) ([Sonar Rule 2272](https://rules.sonarsource.com/java/RSPEC-2272))
     * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
     * ["getClass" should not be used for synchronization](#getclass-should-not-be-used-for-synchronization-sonar-rule-3067) ([Sonar Rule 3067](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067))
@@ -65,6 +66,27 @@ Example:
 ```
 
 Check out an accepted PR in [Apache PDFBox](https://github.com/apache/pdfbox/pull/76) that repairs one BigDecimalDoubleConstructor violation.
+
+-----
+
+#### "InterruptedException" should not be ignored ([Sonar Rule 2142](https://rules.sonarsource.com/java/RSPEC-2142))
+
+A `catch` block that catches an `InterruptedException`, but neither re-interrupts the method nor rethrows the `InterruptedException`, i.e., ignores the `InterruptedException`, is augmented with `Thread.currentThread().interrupt();`.
+
+Example:
+```diff
+    public void run() {
+        try {
+            while (true) {
+                // do stuff
+            } 
+-       } catch (InterruptedException e) { // Noncompliant; logging is not enough
++       } catch (InterruptedException e) {
+            LOGGER.log(Level.WARN, "Interrupted!", e);
++           Thread.currentThread().interrupt();
+        }
+    }
+```
 
 -----
 

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -1,0 +1,42 @@
+package sorald.processor;
+
+import org.sonar.java.checks.InterruptedExceptionCheck;
+import sorald.ProcessorAnnotation;
+import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+
+@ProcessorAnnotation(key = 2142, description = "\"InterruptedException\" should not be ignored")
+public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCatch> {
+
+	public InterruptedExceptionProcessor(String originalFilesPath) {
+		super(originalFilesPath, new InterruptedExceptionCheck());
+	}
+
+	@Override
+	public boolean isToBeProcessed(CtCatch candidate) {
+		if (!super.isToBeProcessedAccordingToStandards(candidate)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void process(CtCatch element) {
+		super.process(element);
+
+		Factory factory = element.getFactory();
+		CtClass<?> threadClass = factory.Class().get(Thread.class);
+		CtTypeAccess<?> threadClassAccess = factory.createTypeAccess(threadClass.getReference());
+		CtMethod<?> currentThreadMethod = threadClass.getMethodsByName("currentThread").get(0);
+		CtMethod<?> interruptMethod = threadClass.getMethodsByName("interrupt").get(0);
+		CtInvocation firstInvocation = factory.createInvocation(threadClassAccess, currentThreadMethod.getReference());
+		CtInvocation secondInvocation = factory.createInvocation(firstInvocation, interruptMethod.getReference());
+
+		element.getBody().addStatement(element.getBody().getStatements().size(), secondInvocation);
+	}
+
+}

--- a/src/test/java/sorald/processor/InterruptedExceptionProcessorTest.java
+++ b/src/test/java/sorald/processor/InterruptedExceptionProcessorTest.java
@@ -1,0 +1,31 @@
+package sorald.processor;
+
+import org.junit.Test;
+import org.sonar.java.checks.InterruptedExceptionCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import sorald.Constants;
+import sorald.FileOutputStrategy;
+import sorald.Main;
+import sorald.PrettyPrintingStrategy;
+import sorald.TestHelper;
+
+public class InterruptedExceptionProcessorTest {
+
+	@Test
+	public void test() throws Exception {
+		String fileName = "InterruptedExceptionForTesting.java";
+		String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
+		String pathToRepairedFile = Constants.SORALD_WORKSPACE + "/" + Constants.SPOONED +"/" + fileName;
+
+		JavaCheckVerifier.verify(pathToBuggyFile, new InterruptedExceptionCheck());
+		Main.main(new String[]{
+				Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,pathToBuggyFile,
+				Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,"2142",
+				Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY, PrettyPrintingStrategy.NORMAL.name(),
+				Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY, FileOutputStrategy.ALL.name(),
+				Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,Constants.SORALD_WORKSPACE});
+		TestHelper.removeComplianceComments(pathToRepairedFile);
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new InterruptedExceptionCheck());
+	}
+
+}

--- a/src/test/resources/InterruptedExceptionForTesting.java
+++ b/src/test/resources/InterruptedExceptionForTesting.java
@@ -1,0 +1,114 @@
+// Test for rule s2142
+// From https://github.com/SonarSource/sonar-java/blob/971eeaf972d8112aa4b7dd9cbf0ed577b397d6a7/java-checks/src/test/files/checks/InterruptedExceptionCheck.java
+
+enum Level {
+	WARN;
+}
+interface Log {
+	void log(Level level, String s, Exception e);
+}
+
+class InterruptedExceptionForTesting {
+	static final Log LOGGER;
+
+	public void run () {
+		try {
+			while (true) {
+				// do stuff
+			}
+		}catch (InterruptedException e) { // Noncompliant; logging is not enough
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+		}
+	}
+
+	public void runUnknownSymbol () {
+		try {
+			while (true) {
+				// do stuff
+			}
+		}catch (java.io.IOException e) {
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+		}catch (InterruptedException e) { // Noncompliant
+			unknownField.log(Level.WARN, "Interrupted!", e);
+		}
+	}
+
+	public void catchUnionType () {
+		try {
+			while (true) {
+				// do stuff
+			}
+		} catch (InterruptedException | java.io.IOException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			unknownField.log(Level.WARN, "Interrupted!", e);
+		}
+	}
+
+	public void run2 () throws InterruptedException{
+		try {
+			while (true) {
+				// do stuff
+			}
+		} catch (InterruptedException e) {
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			// clean up state...
+			throw e;
+		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			throw new java.io.IOException();
+		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			Exception e1 = new Exception();
+			throw e1;
+		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			throw new IllegalStateException("foo", e);
+		} catch (ThreadDeath threadDeath) {
+			throw threadDeath;
+		} catch (ThreadDeath threadDeath) { // Noncompliant {{Either re-interrupt this method or rethrow the "ThreadDeath".}}
+			throw new java.io.IOException();
+		}
+	}
+
+	public void run3 () {
+		try {
+			while (true) {
+				// do stuff
+			}
+		} catch (InterruptedException e) {
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			// clean up state...
+			Thread.currentThread().interrupt();
+		}
+		try {
+			while (true) {
+				// do stuff
+			}
+		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			// clean up state...
+			new Foo().interrupt();
+		}
+	}
+
+	public Task getNextTask(BlockingQueue<Task> queue) {
+		boolean interrupted = false;
+		try {
+			while (true) {
+				try {
+					return queue.take();
+				} catch (InterruptedException e) {
+					interrupted = true;
+					// fall through and retry
+				}
+			}
+		} finally {
+			if (interrupted)
+				Thread.currentThread().interrupt();
+		}
+	}
+
+}
+
+class Foo {
+	void interrupt();
+}


### PR DESCRIPTION
This PR adds a processor for the rule ["InterruptedException" should not be ignored](https://rules.sonarsource.com/java/RSPEC-2142).

Transformation:

```diff
+import java.io.IOException;
 class InterruptedExceptionForTesting {
     static final Log LOGGER;
 
     public void run() {
         try {
             while (true) {
                 // do stuff
             } 
-		}catch (InterruptedException e) { // Noncompliant; logging is not enough
+        } catch (InterruptedException e) {
+            
             LOGGER.log(Level.WARN, "Interrupted!", e);
+            Thread.currentThread().interrupt();
         }
     }
 
     public void runUnknownSymbol() {
         try {
             while (true) {
                 // do stuff
             } 
-		}catch (java.io.IOException e) {
+        } catch (IOException e) {
             LOGGER.log(Level.WARN, "Interrupted!", e);
-		}catch (InterruptedException e) { // Noncompliant
+        } catch (InterruptedException e) {
+            
             unknownField.log(Level.WARN, "Interrupted!", e);
+            Thread.currentThread().interrupt();
         }
     }
 
     public void catchUnionType() {
         try {
             while (true) {
                 // do stuff
             } 
-		} catch (InterruptedException | java.io.IOException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+        } catch (InterruptedException | IOException e) {
+            
             unknownField.log(Level.WARN, "Interrupted!", e);
+            Thread.currentThread().interrupt();
         }
     }
 
     public void run2() throws InterruptedException {
         try {
             while (true) {
                 // do stuff
             } 
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARN, "Interrupted!", e);
             // clean up state...
             throw e;
-		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+        } catch (InterruptedException e) {
+            
             LOGGER.log(Level.WARN, "Interrupted!", e);
-			throw new java.io.IOException();
-		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+            throw new IOException();
+            Thread.currentThread().interrupt();
+        } catch (InterruptedException e) {
+            
             LOGGER.log(Level.WARN, "Interrupted!", e);
             Exception e1 = new Exception();
             throw e1;
-		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+            Thread.currentThread().interrupt();
+        } catch (InterruptedException e) {
+            
             LOGGER.log(Level.WARN, "Interrupted!", e);
             throw new IllegalStateException("foo", e);
+            Thread.currentThread().interrupt();
         } catch (ThreadDeath threadDeath) {
             throw threadDeath;
-		} catch (ThreadDeath threadDeath) { // Noncompliant {{Either re-interrupt this method or rethrow the "ThreadDeath".}}
-			throw new java.io.IOException();
+        } catch (ThreadDeath threadDeath) {
+            
+            throw new IOException();
+            Thread.currentThread().interrupt();
         }
     }
 
     public void run3() {
         try {
             while (true) {
                 // do stuff
             } 
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARN, "Interrupted!", e);
             // clean up state...
             Thread.currentThread().interrupt();
         }
         try {
             while (true) {
                 // do stuff
             } 
-		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+        } catch (InterruptedException e) {
+            
             LOGGER.log(Level.WARN, "Interrupted!", e);
             // clean up state...
             new Foo().interrupt();
+            Thread.currentThread().interrupt();
         }
     }
 
     public Task getNextTask(BlockingQueue<Task> queue) {
         boolean interrupted = false;
         try {
             while (true) {
                 try {
                     return queue.take();
                 } catch (InterruptedException e) {
                     interrupted = true;
                     // fall through and retry
                 }
             } 
         } finally {
             if (interrupted)
                 Thread.currentThread().interrupt();
         }
     }
 }
```

Note: The diff is a little messy because of the default printer (the sniper doesn't work), but the transformations are in principle correct.

Note 2: This rule was chosen to be handled in a discussion with @khaes-kth.