### PR TITLE
StringIndexOutOfBoundsException exception fixed

### DIFF
--- a/src/main/java/sorald/UniqueTypesCollector.java
+++ b/src/main/java/sorald/UniqueTypesCollector.java
@@ -54,6 +54,8 @@ public class UniqueTypesCollector {
 		Object topLevelTypeToBeRemoved = null;
 		for (Map.Entry topLevelType : this.topLevelTypes4Output.entrySet()) {
 			int index = filePath.indexOf(Constants.SPOONED_INTERMEDIATE);
+			if(index < 0)
+				continue;
 			filePath = ".*" + filePath.substring(index + Constants.SPOONED_INTERMEDIATE.length(), filePath.length());
 			if (topLevelType.getKey().toString().matches(filePath)) {
 				topLevelTypeToBeRemoved = topLevelType.getKey();


### PR DESCRIPTION
Hello @fermadeiral 

I'm not sure about the reason/semantics. But it seems that we should consider the cases where "index < 0" to avoid StringIndexOutOfBoundsException that we talked about tody.