### PR TITLE
Test: Replace JUnit4 with JUnit5 Jupiter + vintage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,18 @@
             <artifactId>json</artifactId>
             <version>20190722</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->


### PR DESCRIPTION
In preparation for #141, we need JUnit5 for the more powerful parameterized tests. This PR replaces JUnit4 with JUnit5 Jupiter (which is the new engine) and JUnit5 vintage (which allows for running JUnit4 and 3 tests).