### PR TITLE
Test: Add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ jdk:
 script:
   - java -jar /home/travis/build/SpoonLabs/sorald/target/sorald-1.1-SNAPSHOT-jar-with-dependencies.jar --originalFilesPath /home/travis/build/SpoonLabs/sorald/src/test/resources/ArrayHashCodeAndToString.java --ruleKeys 2184
   - mvn test
+
+after_success: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Sorald [![Travis Build Status](https://travis-ci.com/SpoonLabs/sorald.svg?branch=master)](https://travis-ci.com/SpoonLabs/sorald)
-
+# Sorald [![Travis Build Status](https://travis-ci.com/SpoonLabs/sorald.svg?branch=master)](https://travis-ci.com/SpoonLabs/sorald) [![Code Coverage](https://codecov.io/gh/SpoonLabs/sorald/branch/master/graph/badge.svg)](https://codecov.io/gh/SpoonLabs/sorald)
 Sorald is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
 It can currently repair violations of [15+ rules](/docs/HANDLED_RULES.md).
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,27 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <!-- adapted from https://www.jacoco.org/jacoco/trunk/doc/examples/build/pom.xml -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR adds code coverage with Jacoco and Codecov in preparation for #141. I think it's a good idea to have that seeing as many tests will be migrated to a new format, and it'd be easy to drop one or two by accident.

For everything to work, codecov probably needs to be authorized to the repo. If you'd rather use something else (e.g. coveralls), let me know, I just picked these things because they're what I usually use.