### PR TITLE
refactor: Extract list of sonar check classes to Constants

### DIFF
--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -194,9 +194,9 @@ public class Constants {
 		sonarChecks.add(NonNullSetToNullCheck.class);
 		sonarChecks.add(CustomUnclosedResourcesCheck.class);
 
-//        TEMP_SONAR_CHECKS.add(new DefaultMessageListenerContainerCheck());
-//        TEMP_SONAR_CHECKS.add(new SingleConnectionFactoryCheck());
-//        TEMP_SONAR_CHECKS.add(new DependencyWithSystemScopeCheck());
+//        sonarsChecks.add(DefaultMessageListenerContainerCheck.class);
+//        sonarsChecks.add(SingleConnectionFactoryCheck.class);
+//        sonarsChecks.add(DependencyWithSystemScopeCheck.class);
 		SONAR_CHECK_CLASSES = Collections.unmodifiableList(sonarChecks);
 	}
 

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -68,7 +68,7 @@ public class Constants {
 
 	public static final String PATH_TO_STATS_OUTPUT = "experimentation/stats/warnings";
 
-	public static final List<Class<? extends JavaFileScanner>> SONAR_CHECKS;
+	public static final List<Class<? extends JavaFileScanner>> SONAR_CHECK_CLASSES;
 
 	static {
 		List<Class<? extends JavaFileScanner>> sonarChecks = new ArrayList<>();
@@ -197,7 +197,7 @@ public class Constants {
 //        TEMP_SONAR_CHECKS.add(new DefaultMessageListenerContainerCheck());
 //        TEMP_SONAR_CHECKS.add(new SingleConnectionFactoryCheck());
 //        TEMP_SONAR_CHECKS.add(new DependencyWithSystemScopeCheck());
-		SONAR_CHECKS = Collections.unmodifiableList(sonarChecks);
+		SONAR_CHECK_CLASSES = Collections.unmodifiableList(sonarChecks);
 	}
 
 }

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -1,6 +1,29 @@
 package sorald;
 
+import org.sonar.java.checks.*;
+import org.sonar.java.checks.naming.MethodNamedEqualsCheck;
+import org.sonar.java.checks.naming.MethodNamedHashcodeOrEqualCheck;
+import org.sonar.java.checks.serialization.CustomSerializationMethodCheck;
+import org.sonar.java.checks.serialization.ExternalizableClassConstructorCheck;
+import org.sonar.java.checks.serialization.SerializableObjectInSessionCheck;
+import org.sonar.java.checks.serialization.SerializableSuperConstructorCheck;
+import org.sonar.java.checks.spring.ControllerWithSessionAttributesCheck;
+import org.sonar.java.checks.spring.SpringComponentWithWrongScopeCheck;
+import org.sonar.java.checks.spring.SpringIncompatibleTransactionalCheck;
+import org.sonar.java.checks.spring.SpringScanDefaultPackageCheck;
+import org.sonar.java.checks.synchronization.DoubleCheckedLockingCheck;
+import org.sonar.java.checks.synchronization.SynchronizationOnGetClassCheck;
+import org.sonar.java.checks.synchronization.TwoLocksWaitCheck;
+import org.sonar.java.checks.synchronization.ValueBasedObjectUsedForLockCheck;
+import org.sonar.java.checks.unused.UnusedReturnedDataCheck;
+import org.sonar.java.checks.unused.UnusedThrowableCheck;
+import org.sonar.java.se.checks.*;
+import org.sonar.plugins.java.api.JavaFileScanner;
+
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class Constants {
 
@@ -44,5 +67,137 @@ public class Constants {
 	public static final String HASHCODE_METHOD_NAME = "hashCode";
 
 	public static final String PATH_TO_STATS_OUTPUT = "experimentation/stats/warnings";
+
+	public static final List<Class<? extends JavaFileScanner>> SONAR_CHECKS;
+
+	static {
+		List<Class<? extends JavaFileScanner>> sonarChecks = new ArrayList<>();
+		sonarChecks.add(ControllerWithSessionAttributesCheck.class);
+		sonarChecks.add(SpringScanDefaultPackageCheck.class);
+		sonarChecks.add(TwoLocksWaitCheck.class);
+		sonarChecks.add(PreparedStatementAndResultSetCheck.class);
+		sonarChecks.add(ThreadSleepCheck.class);
+		sonarChecks.add(PrintfFailCheck.class);
+		sonarChecks.add(ThreadWaitCallCheck.class);
+		sonarChecks.add(SpringIncompatibleTransactionalCheck.class);
+		sonarChecks.add(DoubleCheckedLockingCheck.class);
+		sonarChecks.add(GettersSettersOnRightFieldCheck.class);
+		sonarChecks.add(RunFinalizersCheck.class);
+		sonarChecks.add(ScheduledThreadPoolExecutorZeroCheck.class);
+		sonarChecks.add(ReuseRandomCheck.class);
+		sonarChecks.add(ObjectFinalizeOverloadedCheck.class);
+		sonarChecks.add(ReturnInFinallyCheck.class);
+		sonarChecks.add(ThreadLocalCleanupCheck.class);
+		sonarChecks.add(CompareStringsBoxedTypesWithEqualsCheck.class);
+		sonarChecks.add(InputStreamReadCheck.class);
+		sonarChecks.add(CompareToNotOverloadedCheck.class);
+		sonarChecks.add(IterableIteratorCheck.class);
+		sonarChecks.add(OverwrittenKeyCheck.class);
+		sonarChecks.add(DateFormatWeekYearCheck.class);
+		sonarChecks.add(UnusedThrowableCheck.class);
+		sonarChecks.add(CollectionSizeAndArrayLengthCheck.class);
+		sonarChecks.add(AllBranchesAreIdenticalCheck.class);
+		sonarChecks.add(SynchronizedOverrideCheck.class);
+		sonarChecks.add(ValueBasedObjectUsedForLockCheck.class);
+		sonarChecks.add(AssertOnBooleanVariableCheck.class);
+		sonarChecks.add(VolatileVariablesOperationsCheck.class);
+		sonarChecks.add(SynchronizationOnGetClassCheck.class);
+		sonarChecks.add(DoubleCheckedLockingAssignmentCheck.class);
+		sonarChecks.add(StringCallsBeyondBoundsCheck.class);
+		sonarChecks.add(RawByteBitwiseOperationsCheck.class);
+		sonarChecks.add(SyncGetterAndSetterCheck.class);
+		sonarChecks.add(StaticMultithreadedUnsafeFieldsCheck.class);
+		sonarChecks.add(NullShouldNotBeUsedWithOptionalCheck.class);
+		sonarChecks.add(DoublePrefixOperatorCheck.class);
+		sonarChecks.add(WrongAssignmentOperatorCheck.class);
+		sonarChecks.add(UnusedReturnedDataCheck.class);
+		sonarChecks.add(InappropriateRegexpCheck.class);
+		sonarChecks.add(NotifyCheck.class);
+		sonarChecks.add(SynchronizedFieldAssignmentCheck.class);
+		sonarChecks.add(SerializableObjectInSessionCheck.class);
+		sonarChecks.add(WaitInSynchronizeCheck.class);
+		sonarChecks.add(ForLoopFalseConditionCheck.class);
+		sonarChecks.add(ForLoopIncrementSignCheck.class);
+		sonarChecks.add(TransactionalMethodVisibilityCheck.class);
+		sonarChecks.add(ServletInstanceFieldCheck.class);
+		sonarChecks.add(ToStringReturningNullCheck.class);
+		sonarChecks.add(EqualsOnAtomicClassCheck.class);
+		sonarChecks.add(IgnoredReturnValueCheck.class);
+		sonarChecks.add(ConfusingOverloadCheck.class);
+		sonarChecks.add(CollectionInappropriateCallsCheck.class);
+		sonarChecks.add(SillyEqualsCheck.class);
+		sonarChecks.add(PrimitiveWrappersInTernaryOperatorCheck.class);
+		sonarChecks.add(InterruptedExceptionCheck.class);
+		sonarChecks.add(ThreadOverridesRunCheck.class);
+		sonarChecks.add(LongBitsToDoubleOnIntCheck.class);
+		sonarChecks.add(UselessIncrementCheck.class);
+		sonarChecks.add(SillyStringOperationsCheck.class);
+		sonarChecks.add(NonSerializableWriteCheck.class);
+		sonarChecks.add(ArrayHashCodeAndToStringCheck.class);
+		sonarChecks.add(CollectionCallingItselfCheck.class);
+		sonarChecks.add(BigDecimalDoubleConstructorCheck.class);
+		sonarChecks.add(InvalidDateValuesCheck.class);
+		sonarChecks.add(ReflectionOnNonRuntimeAnnotationCheck.class);
+		sonarChecks.add(CustomSerializationMethodCheck.class);
+		sonarChecks.add(ExternalizableClassConstructorCheck.class);
+		sonarChecks.add(ClassComparedByNameCheck.class);
+		sonarChecks.add(DuplicateConditionIfElseIfCheck.class);
+		sonarChecks.add(SynchronizationOnStringOrBoxedCheck.class);
+		sonarChecks.add(HasNextCallingNextCheck.class);
+		sonarChecks.add(IdenticalOperandOnBinaryExpressionCheck.class);
+		sonarChecks.add(LoopExecutingAtMostOnceCheck.class);
+		sonarChecks.add(SelfAssignementCheck.class);
+		sonarChecks.add(StringBufferAndBuilderWithCharCheck.class);
+		sonarChecks.add(MethodNamedHashcodeOrEqualCheck.class);
+		sonarChecks.add(ThreadRunCheck.class);
+		sonarChecks.add(MethodNamedEqualsCheck.class);
+		sonarChecks.add(DoubleBraceInitializationCheck.class);
+		sonarChecks.add(VolatileNonPrimitiveFieldCheck.class);
+		sonarChecks.add(ToArrayCheck.class);
+		sonarChecks.add(AbsOnNegativeCheck.class);
+		sonarChecks.add(IgnoredStreamReturnValueCheck.class);
+		sonarChecks.add(IteratorNextExceptionCheck.class);
+		sonarChecks.add(CompareToResultTestCheck.class);
+		sonarChecks.add(CastArithmeticOperandCheck.class);
+		sonarChecks.add(ShiftOnIntOrLongCheck.class);
+		sonarChecks.add(CompareToReturnValueCheck.class);
+		sonarChecks.add(ImmediateReverseBoxingCheck.class);
+		sonarChecks.add(EqualsArgumentTypeCheck.class);
+		sonarChecks.add(InnerClassOfNonSerializableCheck.class);
+		sonarChecks.add(SerializableSuperConstructorCheck.class);
+		sonarChecks.add(ParameterReassignedToCheck.class);
+		sonarChecks.add(EqualsOverridenWithHashCodeCheck.class);
+		sonarChecks.add(ObjectFinalizeOverridenCallsSuperFinalizeCheck.class);
+		sonarChecks.add(SpringComponentWithWrongScopeCheck.class);
+		sonarChecks.add(ConstructorInjectionCheck.class);
+		sonarChecks.add(ClassWithoutHashCodeInHashStructureCheck.class);
+		sonarChecks.add(InstanceOfAlwaysTrueCheck.class);
+		sonarChecks.add(NullDereferenceInConditionalCheck.class);
+		sonarChecks.add(FloatEqualityCheck.class);
+		sonarChecks.add(IfConditionAlwaysTrueOrFalseCheck.class);
+		sonarChecks.add(ObjectFinalizeCheck.class);
+		sonarChecks.add(GetClassLoaderCheck.class);
+		sonarChecks.add(MathOnFloatCheck.class);
+		sonarChecks.add(SymmetricEqualsCheck.class);
+
+		sonarChecks.add(ObjectOutputStreamCheck.class);
+		sonarChecks.add(NoWayOutLoopCheck.class);
+		sonarChecks.add(UnclosedResourcesCheck.class);
+		sonarChecks.add(DivisionByZeroCheck.class);
+		sonarChecks.add(LocksNotUnlockedCheck.class);
+		sonarChecks.add(StreamConsumedCheck.class);
+		sonarChecks.add(StreamNotConsumedCheck.class);
+		sonarChecks.add(OptionalGetBeforeIsPresentCheck.class);
+		sonarChecks.add(MinMaxRangeCheck.class);
+		sonarChecks.add(ConditionalUnreachableCodeCheck.class);
+		sonarChecks.add(NullDereferenceCheck.class);
+		sonarChecks.add(NonNullSetToNullCheck.class);
+		sonarChecks.add(CustomUnclosedResourcesCheck.class);
+
+//        TEMP_SONAR_CHECKS.add(new DefaultMessageListenerContainerCheck());
+//        TEMP_SONAR_CHECKS.add(new SingleConnectionFactoryCheck());
+//        TEMP_SONAR_CHECKS.add(new DependencyWithSystemScopeCheck());
+		SONAR_CHECKS = Collections.unmodifiableList(sonarChecks);
+	}
 
 }

--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -30,7 +30,7 @@ public class MineSonarWarnings {
 
 
     private static List init() {
-        return Constants.SONAR_CHECKS.stream().map(cls -> {
+        return Constants.SONAR_CHECK_CLASSES.stream().map(cls -> {
             try {
                 return cls.getConstructor().newInstance();
             } catch (Exception e) {

--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -20,161 +20,23 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.sonar.java.AnalyzerMessage;
-import org.sonar.java.checks.*;
-import org.sonar.java.checks.naming.MethodNamedEqualsCheck;
-import org.sonar.java.checks.naming.MethodNamedHashcodeOrEqualCheck;
-import org.sonar.java.checks.serialization.CustomSerializationMethodCheck;
-import org.sonar.java.checks.serialization.ExternalizableClassConstructorCheck;
-import org.sonar.java.checks.serialization.SerializableObjectInSessionCheck;
-import org.sonar.java.checks.serialization.SerializableSuperConstructorCheck;
-import org.sonar.java.checks.spring.ControllerWithSessionAttributesCheck;
-import org.sonar.java.checks.spring.SpringComponentWithWrongScopeCheck;
-import org.sonar.java.checks.spring.SpringIncompatibleTransactionalCheck;
-import org.sonar.java.checks.spring.SpringScanDefaultPackageCheck;
-import org.sonar.java.checks.synchronization.DoubleCheckedLockingCheck;
-import org.sonar.java.checks.synchronization.SynchronizationOnGetClassCheck;
-import org.sonar.java.checks.synchronization.TwoLocksWaitCheck;
-import org.sonar.java.checks.synchronization.ValueBasedObjectUsedForLockCheck;
-import org.sonar.java.checks.unused.UnusedReturnedDataCheck;
-import org.sonar.java.checks.unused.UnusedThrowableCheck;
 import org.sonar.java.checks.verifier.MultipleFilesJavaCheckVerifier;
-import org.sonar.java.se.checks.*;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 
 public class MineSonarWarnings {
 
-    private static final List<JavaFileScanner> SONAR_CHECKS = init();
+    private static final List<JavaFileScanner> SONAR_CHECK_INSTANCES = init();
+
 
     private static List init() {
-        List<JavaFileScanner> TEMP_SONAR_CHECKS = new ArrayList<>();
-        TEMP_SONAR_CHECKS.add(new ControllerWithSessionAttributesCheck());
-        TEMP_SONAR_CHECKS.add(new SpringScanDefaultPackageCheck());
-        TEMP_SONAR_CHECKS.add(new TwoLocksWaitCheck());
-        TEMP_SONAR_CHECKS.add(new PreparedStatementAndResultSetCheck());
-        TEMP_SONAR_CHECKS.add(new ThreadSleepCheck());
-        TEMP_SONAR_CHECKS.add(new PrintfFailCheck());
-        TEMP_SONAR_CHECKS.add(new ThreadWaitCallCheck());
-        TEMP_SONAR_CHECKS.add(new SpringIncompatibleTransactionalCheck());
-        TEMP_SONAR_CHECKS.add(new DoubleCheckedLockingCheck());
-        TEMP_SONAR_CHECKS.add(new GettersSettersOnRightFieldCheck());
-        TEMP_SONAR_CHECKS.add(new RunFinalizersCheck());
-        TEMP_SONAR_CHECKS.add(new ScheduledThreadPoolExecutorZeroCheck());
-        TEMP_SONAR_CHECKS.add(new ReuseRandomCheck());
-        TEMP_SONAR_CHECKS.add(new ObjectFinalizeOverloadedCheck());
-        TEMP_SONAR_CHECKS.add(new ReturnInFinallyCheck());
-        TEMP_SONAR_CHECKS.add(new ThreadLocalCleanupCheck());
-        TEMP_SONAR_CHECKS.add(new CompareStringsBoxedTypesWithEqualsCheck());
-        TEMP_SONAR_CHECKS.add(new InputStreamReadCheck());
-        TEMP_SONAR_CHECKS.add(new CompareToNotOverloadedCheck());
-        TEMP_SONAR_CHECKS.add(new IterableIteratorCheck());
-        TEMP_SONAR_CHECKS.add(new OverwrittenKeyCheck());
-        TEMP_SONAR_CHECKS.add(new DateFormatWeekYearCheck());
-        TEMP_SONAR_CHECKS.add(new UnusedThrowableCheck());
-        TEMP_SONAR_CHECKS.add(new CollectionSizeAndArrayLengthCheck());
-        TEMP_SONAR_CHECKS.add(new AllBranchesAreIdenticalCheck());
-        TEMP_SONAR_CHECKS.add(new SynchronizedOverrideCheck());
-        TEMP_SONAR_CHECKS.add(new ValueBasedObjectUsedForLockCheck());
-        TEMP_SONAR_CHECKS.add(new AssertOnBooleanVariableCheck());
-        TEMP_SONAR_CHECKS.add(new VolatileVariablesOperationsCheck());
-        TEMP_SONAR_CHECKS.add(new SynchronizationOnGetClassCheck());
-        TEMP_SONAR_CHECKS.add(new DoubleCheckedLockingAssignmentCheck());
-        TEMP_SONAR_CHECKS.add(new StringCallsBeyondBoundsCheck());
-        TEMP_SONAR_CHECKS.add(new RawByteBitwiseOperationsCheck());
-        TEMP_SONAR_CHECKS.add(new SyncGetterAndSetterCheck());
-        TEMP_SONAR_CHECKS.add(new StaticMultithreadedUnsafeFieldsCheck());
-        TEMP_SONAR_CHECKS.add(new NullShouldNotBeUsedWithOptionalCheck());
-        TEMP_SONAR_CHECKS.add(new DoublePrefixOperatorCheck());
-        TEMP_SONAR_CHECKS.add(new WrongAssignmentOperatorCheck());
-        TEMP_SONAR_CHECKS.add(new UnusedReturnedDataCheck());
-        TEMP_SONAR_CHECKS.add(new InappropriateRegexpCheck());
-        TEMP_SONAR_CHECKS.add(new NotifyCheck());
-        TEMP_SONAR_CHECKS.add(new SynchronizedFieldAssignmentCheck());
-        TEMP_SONAR_CHECKS.add(new SerializableObjectInSessionCheck());
-        TEMP_SONAR_CHECKS.add(new WaitInSynchronizeCheck());
-        TEMP_SONAR_CHECKS.add(new ForLoopFalseConditionCheck());
-        TEMP_SONAR_CHECKS.add(new ForLoopIncrementSignCheck());
-        TEMP_SONAR_CHECKS.add(new TransactionalMethodVisibilityCheck());
-        TEMP_SONAR_CHECKS.add(new ServletInstanceFieldCheck());
-        TEMP_SONAR_CHECKS.add(new ToStringReturningNullCheck());
-        TEMP_SONAR_CHECKS.add(new EqualsOnAtomicClassCheck());
-        TEMP_SONAR_CHECKS.add(new IgnoredReturnValueCheck());
-        TEMP_SONAR_CHECKS.add(new ConfusingOverloadCheck());
-        TEMP_SONAR_CHECKS.add(new CollectionInappropriateCallsCheck());
-        TEMP_SONAR_CHECKS.add(new SillyEqualsCheck());
-        TEMP_SONAR_CHECKS.add(new PrimitiveWrappersInTernaryOperatorCheck());
-        TEMP_SONAR_CHECKS.add(new InterruptedExceptionCheck());
-        TEMP_SONAR_CHECKS.add(new ThreadOverridesRunCheck());
-        TEMP_SONAR_CHECKS.add(new LongBitsToDoubleOnIntCheck());
-        TEMP_SONAR_CHECKS.add(new UselessIncrementCheck());
-        TEMP_SONAR_CHECKS.add(new SillyStringOperationsCheck());
-        TEMP_SONAR_CHECKS.add(new NonSerializableWriteCheck());
-        TEMP_SONAR_CHECKS.add(new ArrayHashCodeAndToStringCheck());
-        TEMP_SONAR_CHECKS.add(new CollectionCallingItselfCheck());
-        TEMP_SONAR_CHECKS.add(new BigDecimalDoubleConstructorCheck());
-        TEMP_SONAR_CHECKS.add(new InvalidDateValuesCheck());
-        TEMP_SONAR_CHECKS.add(new ReflectionOnNonRuntimeAnnotationCheck());
-        TEMP_SONAR_CHECKS.add(new CustomSerializationMethodCheck());
-        TEMP_SONAR_CHECKS.add(new ExternalizableClassConstructorCheck());
-        TEMP_SONAR_CHECKS.add(new ClassComparedByNameCheck());
-        TEMP_SONAR_CHECKS.add(new DuplicateConditionIfElseIfCheck());
-        TEMP_SONAR_CHECKS.add(new SynchronizationOnStringOrBoxedCheck());
-        TEMP_SONAR_CHECKS.add(new HasNextCallingNextCheck());
-        TEMP_SONAR_CHECKS.add(new IdenticalOperandOnBinaryExpressionCheck());
-        TEMP_SONAR_CHECKS.add(new LoopExecutingAtMostOnceCheck());
-        TEMP_SONAR_CHECKS.add(new SelfAssignementCheck());
-        TEMP_SONAR_CHECKS.add(new StringBufferAndBuilderWithCharCheck());
-        TEMP_SONAR_CHECKS.add(new MethodNamedHashcodeOrEqualCheck());
-        TEMP_SONAR_CHECKS.add(new ThreadRunCheck());
-        TEMP_SONAR_CHECKS.add(new MethodNamedEqualsCheck());
-        TEMP_SONAR_CHECKS.add(new DoubleBraceInitializationCheck());
-        TEMP_SONAR_CHECKS.add(new VolatileNonPrimitiveFieldCheck());
-        TEMP_SONAR_CHECKS.add(new ToArrayCheck());
-        TEMP_SONAR_CHECKS.add(new AbsOnNegativeCheck());
-        TEMP_SONAR_CHECKS.add(new IgnoredStreamReturnValueCheck());
-        TEMP_SONAR_CHECKS.add(new IteratorNextExceptionCheck());
-        TEMP_SONAR_CHECKS.add(new CompareToResultTestCheck());
-        TEMP_SONAR_CHECKS.add(new CastArithmeticOperandCheck());
-        TEMP_SONAR_CHECKS.add(new ShiftOnIntOrLongCheck());
-        TEMP_SONAR_CHECKS.add(new CompareToReturnValueCheck());
-        TEMP_SONAR_CHECKS.add(new ImmediateReverseBoxingCheck());
-        TEMP_SONAR_CHECKS.add(new EqualsArgumentTypeCheck());
-        TEMP_SONAR_CHECKS.add(new InnerClassOfNonSerializableCheck());
-        TEMP_SONAR_CHECKS.add(new SerializableSuperConstructorCheck());
-        TEMP_SONAR_CHECKS.add(new ParameterReassignedToCheck());
-        TEMP_SONAR_CHECKS.add(new EqualsOverridenWithHashCodeCheck());
-        TEMP_SONAR_CHECKS.add(new ObjectFinalizeOverridenCallsSuperFinalizeCheck());
-        TEMP_SONAR_CHECKS.add(new SpringComponentWithWrongScopeCheck());
-        TEMP_SONAR_CHECKS.add(new ConstructorInjectionCheck());
-        TEMP_SONAR_CHECKS.add(new ClassWithoutHashCodeInHashStructureCheck());
-        TEMP_SONAR_CHECKS.add(new InstanceOfAlwaysTrueCheck());
-        TEMP_SONAR_CHECKS.add(new NullDereferenceInConditionalCheck());
-        TEMP_SONAR_CHECKS.add(new FloatEqualityCheck());
-        TEMP_SONAR_CHECKS.add(new IfConditionAlwaysTrueOrFalseCheck());
-        TEMP_SONAR_CHECKS.add(new ObjectFinalizeCheck());
-        TEMP_SONAR_CHECKS.add(new GetClassLoaderCheck());
-        TEMP_SONAR_CHECKS.add(new MathOnFloatCheck());
-        TEMP_SONAR_CHECKS.add(new SymmetricEqualsCheck());
-
-        TEMP_SONAR_CHECKS.add(new ObjectOutputStreamCheck());
-        TEMP_SONAR_CHECKS.add(new NoWayOutLoopCheck());
-        TEMP_SONAR_CHECKS.add(new UnclosedResourcesCheck());
-        TEMP_SONAR_CHECKS.add(new DivisionByZeroCheck());
-        TEMP_SONAR_CHECKS.add(new LocksNotUnlockedCheck());
-        TEMP_SONAR_CHECKS.add(new StreamConsumedCheck());
-        TEMP_SONAR_CHECKS.add(new StreamNotConsumedCheck());
-        TEMP_SONAR_CHECKS.add(new OptionalGetBeforeIsPresentCheck());
-        TEMP_SONAR_CHECKS.add(new MinMaxRangeCheck());
-        TEMP_SONAR_CHECKS.add(new ConditionalUnreachableCodeCheck());
-        TEMP_SONAR_CHECKS.add(new NullDereferenceCheck());
-        TEMP_SONAR_CHECKS.add(new NonNullSetToNullCheck());
-        TEMP_SONAR_CHECKS.add(new CustomUnclosedResourcesCheck());
-
-//        TEMP_SONAR_CHECKS.add(new DefaultMessageListenerContainerCheck());
-//        TEMP_SONAR_CHECKS.add(new SingleConnectionFactoryCheck());
-//        TEMP_SONAR_CHECKS.add(new DependencyWithSystemScopeCheck());
-
-        return TEMP_SONAR_CHECKS;
+        return Constants.SONAR_CHECKS.stream().map(cls -> {
+            try {
+                return cls.getConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException("could not instantiate class " + cls.getName());
+            }
+        }).collect(Collectors.toList());
     }
 
     public static JSAP defineArgs() throws JSAPException {
@@ -337,7 +199,7 @@ public class MineSonarWarnings {
                     e.printStackTrace();
                 }
             }
-            for (JavaFileScanner javaFileScanner : SONAR_CHECKS) {
+            for (JavaFileScanner javaFileScanner : SONAR_CHECK_INSTANCES) {
                 Set<AnalyzerMessage> issues = MultipleFilesJavaCheckVerifier.verify(filesToScan, javaFileScanner, false);
                 warnings.putIfAbsent(javaFileScanner.getClass().getSimpleName(), issues.size());
             }


### PR DESCRIPTION
#141 

As mentioned in #144, I need a more secure way to load the check classes in the parameterized test. As there already is a large list of checks in `MineSonarWarnings`, I figured I can just extract that and build a lookup table from it. It's not an exhaustive list, but adding a new check to it when we need to is trivial. **This PR just extracts the list of checks to `Constants.java`**, and changes it to contain the classes themselves rather than instances.

I created this separate PR as #144 is becoming so large.

On a side note, the `WarningMinerTest` is dependent on the order of the checks in the list, which tripped me up a bit.