### PR TITLE
Add academic bibliographic references in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ $ java -jar target/sorald-1.1-SNAPSHOT-jar-with-dependencies.jar --originalFiles
 
 To run Sorald on projects towards proposing fixes in the form of PRs, look at [this Git repository](https://github.com/HarisAdzemovic/SQ-Repair-CI-Integration) for an example. In it, Sorald is ran on the three Apache projects defined in the *projects_for_model_1.txt* file.
  
+## Academic bibliographic references
+
+"[A template-based approach to automatic program repair of Sonarqube static warnings](http://kth.diva-portal.org/smash/get/diva2:1433710/FULLTEXT01.pdf)", by Haris Adzemovic, Master's thesis, KTH, School of Electrical Engineering and Computer Science (EECS), 2020. 
+
+```
+@mastersthesis{Adzemovic2020,
+    title = {A template-based approach to automatic program repair of Sonarqube static warnings},
+    author = {Adzemovic, Haris},
+    year = {2020},
+    school = {KTH, School of Electrical Engineering and Computer Science (EECS)},    
+    url = {kth.diva-portal.org/smash/get/diva2:1433710/FULLTEXT01.pdf}
+}
+```
+ 
 ## Contributing
 
 Contributions are welcome! Feel free to open issues on this GitHub repository, and also to open pull requests for making this project nicer (see instructions [here](/docs/CONTRIBUTING.md)).

--- a/README.md
+++ b/README.md
@@ -99,17 +99,7 @@ To run Sorald on projects towards proposing fixes in the form of PRs, look at [t
  
 ## Academic bibliographic references
 
-"[A template-based approach to automatic program repair of Sonarqube static warnings](http://kth.diva-portal.org/smash/get/diva2:1433710/FULLTEXT01.pdf)", by Haris Adzemovic, Master's thesis, KTH, School of Electrical Engineering and Computer Science (EECS), 2020. 
-
-```
-@mastersthesis{Adzemovic2020,
-    title = {A template-based approach to automatic program repair of Sonarqube static warnings},
-    author = {Adzemovic, Haris},
-    year = {2020},
-    school = {KTH, School of Electrical Engineering and Computer Science (EECS)},    
-    url = {kth.diva-portal.org/smash/get/diva2:1433710/FULLTEXT01.pdf}
-}
-```
+"[A template-based approach to automatic program repair of Sonarqube static warnings](http://kth.diva-portal.org/smash/get/diva2:1433710/FULLTEXT01.pdf)", by Haris Adzemovic, Master's thesis, KTH, School of Electrical Engineering and Computer Science (EECS), 2020. [(bibtex)](http://www.diva-portal.org/smash/references?referenceFormat=BIBTEX&pids=[diva2:1433710]&fileName=export.txt)
  
 ## Contributing
 


### PR DESCRIPTION
This PR adds academic bibliographic references in the README. I realized that this information was missing in our repository because of @slarse's comment [here](https://github.com/SpoonLabs/sorald/issues/82#issuecomment-709903413).

Currently, there is only @HarisAdzemovic's thesis, but soon we will have @henry-lp's thesis and other related scientific works.

@monperrus, WDYT?