### PR TITLE
refactor: Add facade around AnalyzerMessage

### DIFF
--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -19,8 +19,8 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
-import sorald.sonar.Bug;
 import sorald.sonar.RuleVerifier;
+import sorald.sonar.RuleViolation;
 
 public class MineSonarWarnings {
 
@@ -203,8 +203,10 @@ public class MineSonarWarnings {
                 }
             }
             for (JavaFileScanner javaFileScanner : SONAR_CHECK_INSTANCES) {
-                Set<Bug> bugs = RuleVerifier.analyze(filesToScan, javaFileScanner);
-                warnings.putIfAbsent(javaFileScanner.getClass().getSimpleName(), bugs.size());
+                Set<RuleViolation> ruleViolations =
+                        RuleVerifier.analyze(filesToScan, javaFileScanner);
+                warnings.putIfAbsent(
+                        javaFileScanner.getClass().getSimpleName(), ruleViolations.size());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -17,9 +17,9 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.sonar.java.AnalyzerMessage;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
+import sorald.sonar.Bug;
 import sorald.sonar.RuleVerifier;
 
 public class MineSonarWarnings {
@@ -203,8 +203,8 @@ public class MineSonarWarnings {
                 }
             }
             for (JavaFileScanner javaFileScanner : SONAR_CHECK_INSTANCES) {
-                Set<AnalyzerMessage> issues = RuleVerifier.analyze(filesToScan, javaFileScanner);
-                warnings.putIfAbsent(javaFileScanner.getClass().getSimpleName(), issues.size());
+                Set<Bug> bugs = RuleVerifier.analyze(filesToScan, javaFileScanner);
+                warnings.putIfAbsent(javaFileScanner.getClass().getSimpleName(), bugs.size());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -14,14 +14,14 @@ import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.UniqueTypesCollector;
 import sorald.segment.Node;
-import sorald.sonar.Bug;
 import sorald.sonar.RuleVerifier;
+import sorald.sonar.RuleViolation;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtElement;
 
 /** superclass for all processors */
 public abstract class SoraldAbstractProcessor<E extends CtElement> extends AbstractProcessor<E> {
-    private Set<Bug> bugs;
+    private Set<RuleViolation> ruleViolations;
     private int maxFixes = Integer.MAX_VALUE;
     private int nbFixes = 0;
 
@@ -46,7 +46,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
                     e.printStackTrace();
                 }
             }
-            bugs = RuleVerifier.analyze(filesToScan, sonarCheck);
+            ruleViolations = RuleVerifier.analyze(filesToScan, sonarCheck);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -71,7 +71,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
             }
         }
 
-        bugs = RuleVerifier.analyze(filesToScan, sonarCheck);
+        ruleViolations = RuleVerifier.analyze(filesToScan, sonarCheck);
         return this;
     }
 
@@ -110,8 +110,8 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         } catch (IOException e) {
         }
 
-        for (Bug bug : bugs) {
-            if (bug.getLineNumber() == line && bug.getFileName().equals(file)) {
+        for (RuleViolation ruleViolation : ruleViolations) {
+            if (ruleViolation.getLineNumber() == line && ruleViolation.getFileName().equals(file)) {
                 return true;
             }
         }

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -6,16 +6,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.sonar.java.AnalyzerMessage;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.UniqueTypesCollector;
 import sorald.segment.Node;
+import sorald.sonar.Bug;
 import sorald.sonar.RuleVerifier;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtElement;
@@ -47,12 +46,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
                     e.printStackTrace();
                 }
             }
-            Set<AnalyzerMessage> issues = RuleVerifier.analyze(filesToScan, sonarCheck);
-            bugs = new HashSet<>();
-            for (AnalyzerMessage message : issues) {
-                Bug BugOffline = new Bug(message);
-                bugs.add(BugOffline);
-            }
+            bugs = RuleVerifier.analyze(filesToScan, sonarCheck);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -77,13 +71,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
             }
         }
 
-        Set<AnalyzerMessage> issues = RuleVerifier.analyze(filesToScan, sonarCheck);
-        bugs = new HashSet<>();
-        for (AnalyzerMessage message : issues) {
-            Bug BugOffline = new Bug(message);
-            bugs.add(BugOffline);
-        }
-
+        bugs = RuleVerifier.analyze(filesToScan, sonarCheck);
         return this;
     }
 
@@ -134,23 +122,5 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
     public void process(E element) {
         UniqueTypesCollector.getInstance().collect(element);
         this.nbFixes++;
-    }
-
-    class Bug {
-        private int lineNumber;
-        private String fileName;
-
-        public Bug(AnalyzerMessage message) {
-            this.lineNumber = message.getLine();
-            this.fileName = message.getInputComponent().key().replace(":", "");
-        }
-
-        public int getLineNumber() {
-            return lineNumber;
-        }
-
-        public String getFileName() {
-            return fileName;
-        }
     }
 }

--- a/src/main/java/sorald/sonar/Bug.java
+++ b/src/main/java/sorald/sonar/Bug.java
@@ -2,21 +2,21 @@ package sorald.sonar;
 
 import org.sonar.java.AnalyzerMessage;
 
+import java.util.Objects;
+
 /** Facade around {@link org.sonar.java.AnalyzerMessage} */
 public class Bug {
-    private final int lineNumber;
-    private final String fileName;
+    private final AnalyzerMessage message;
 
     Bug(AnalyzerMessage message) {
-        this.lineNumber = message.getLine();
-        this.fileName = message.getInputComponent().key().replace(":", "");
+        this.message = message;
     }
 
     public int getLineNumber() {
-        return lineNumber;
+        return Objects.requireNonNull(message.getLine());
     }
 
     public String getFileName() {
-        return fileName;
+        return message.getInputComponent().key().replace(":", "");
     }
 }

--- a/src/main/java/sorald/sonar/Bug.java
+++ b/src/main/java/sorald/sonar/Bug.java
@@ -1,0 +1,22 @@
+package sorald.sonar;
+
+import org.sonar.java.AnalyzerMessage;
+
+/** Facade around {@link org.sonar.java.AnalyzerMessage} */
+public class Bug {
+    private final int lineNumber;
+    private final String fileName;
+
+    Bug(AnalyzerMessage message) {
+        this.lineNumber = message.getLine();
+        this.fileName = message.getInputComponent().key().replace(":", "");
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -40,9 +40,9 @@ public class RuleVerifier {
      * @return All messages produced by the analyzer, for all files.
      */
     @SuppressWarnings("UnstableApiUsage")
-    public static Set<Bug> analyze(List<String> filesToScan, JavaFileScanner check) {
+    public static Set<RuleViolation> analyze(List<String> filesToScan, JavaFileScanner check) {
         return MultipleFilesJavaCheckVerifier.verify(filesToScan, check, false).stream()
-                .map(Bug::new)
+                .map(RuleViolation::new)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -3,7 +3,7 @@ package sorald.sonar;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import org.sonar.java.AnalyzerMessage;
+import java.util.stream.Collectors;
 import org.sonar.java.checks.verifier.MultipleFilesJavaCheckVerifier;
 import org.sonar.plugins.java.api.JavaFileScanner;
 
@@ -40,8 +40,10 @@ public class RuleVerifier {
      * @return All messages produced by the analyzer, for all files.
      */
     @SuppressWarnings("UnstableApiUsage")
-    public static Set<AnalyzerMessage> analyze(List<String> filesToScan, JavaFileScanner check) {
-        return MultipleFilesJavaCheckVerifier.verify(filesToScan, check, false);
+    public static Set<Bug> analyze(List<String> filesToScan, JavaFileScanner check) {
+        return MultipleFilesJavaCheckVerifier.verify(filesToScan, check, false).stream()
+                .map(Bug::new)
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -1,21 +1,22 @@
 package sorald.sonar;
 
+import java.util.Objects;
 import org.sonar.java.AnalyzerMessage;
 
-import java.util.Objects;
-
 /** Facade around {@link org.sonar.java.AnalyzerMessage} */
-public class Bug {
+public class RuleViolation {
     private final AnalyzerMessage message;
 
-    Bug(AnalyzerMessage message) {
+    RuleViolation(AnalyzerMessage message) {
         this.message = message;
     }
 
+    /** @return The line number related to the rule violation. */
     public int getLineNumber() {
         return Objects.requireNonNull(message.getLine());
     }
 
+    /** @return The name of the file that was analyzed. */
     public String getFileName() {
         return message.getInputComponent().key().replace(":", "");
     }


### PR DESCRIPTION
This is a follow-up on #162, and depends on it. ~**Don't review this until #162 i smerged,** I will fix the commit history.~

This PR extracts the previously internal `SoraldAbstractProcessor.Bug` class into a separate `sorald.sonar.RuleViolation` class, which is just a thin facade around `org.java.sonar.AnalyzerMessage`. Depending on how we proceed with #156, we may not have access to the actual `AnalyzerMessage` (but some higher-level abstraction instead), and so this PR is a precaution.

Since the facade was essentially already there in form of the Bug class, this change was very little effort, and also coincidentally cleans up some of the code base. With this change, the only sonar internals we touch in sorald are the check classes, but it doesn't seem reasonable at the moment to put adapters around them. I think we'll leave them be.