### PR TITLE
test: Convert all JUnit4 tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,6 @@
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -1,15 +1,15 @@
 package sorald;
 
 import java.io.File;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FileOutputStrategyTest {
 
     private String fileOutputStrategyTestWorkspace = "FileOutputStrategyTest";
 
-    @After
+    @AfterEach
     public void tearDown() {
         TestHelper.deleteDirectory(new File(fileOutputStrategyTestWorkspace));
     }
@@ -32,11 +32,11 @@ public class FileOutputStrategyTest {
 
         File spooned =
                 new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);
-        Assert.assertEquals(spooned.list().length, 1);
+        Assertions.assertEquals(spooned.list().length, 1);
 
         File patches =
                 new File(fileOutputStrategyTestWorkspace + File.separator + Constants.PATCHES);
-        Assert.assertEquals(patches.list().length, 1);
+        Assertions.assertEquals(patches.list().length, 1);
     }
 
     @Test
@@ -55,11 +55,11 @@ public class FileOutputStrategyTest {
 
         File spooned =
                 new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);
-        Assert.assertEquals(spooned.list().length, 1);
+        Assertions.assertEquals(spooned.list().length, 1);
 
         File patches =
                 new File(fileOutputStrategyTestWorkspace + File.separator + Constants.PATCHES);
-        Assert.assertNull(patches.list());
+        Assertions.assertNull(patches.list());
     }
 
     @Test
@@ -80,10 +80,10 @@ public class FileOutputStrategyTest {
 
         File spooned =
                 new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);
-        Assert.assertTrue(spooned.list().length > 1);
+        Assertions.assertTrue(spooned.list().length > 1);
 
         File patches =
                 new File(fileOutputStrategyTestWorkspace + File.separator + Constants.PATCHES);
-        Assert.assertNull(patches.list());
+        Assertions.assertNull(patches.list());
     }
 }

--- a/src/test/java/sorald/MaxFixesPerRuleTest.java
+++ b/src/test/java/sorald/MaxFixesPerRuleTest.java
@@ -1,6 +1,6 @@
 package sorald.processor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
 import sorald.Constants;
 import sorald.Main;

--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -1,6 +1,6 @@
 package sorald;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
 import org.sonar.java.checks.CastArithmeticOperandCheck;
 import org.sonar.java.checks.EqualsOnAtomicClassCheck;

--- a/src/test/java/sorald/NoSonarTest.java
+++ b/src/test/java/sorald/NoSonarTest.java
@@ -1,6 +1,6 @@
 package sorald.processor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
 import sorald.Constants;
 import sorald.Main;

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -1,6 +1,8 @@
 package sorald.processor;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
 import sorald.Constants;
 import sorald.Main;
@@ -38,15 +40,13 @@ public class SegmentStrategyTest {
         RuleVerifier.verifyNoIssue(pathToRepairedFile, new ArrayHashCodeAndToStringCheck());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void arrayToStringProcessor_fail_Test() throws Exception {
         String fileName = "ArrayHashCodeAndToString.java";
         String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
-        String pathToRepairedFile =
-                Constants.SORALD_WORKSPACE + "/SEGMENT/" + Constants.SPOONED + "/" + fileName;
 
         RuleVerifier.verifyHasIssue(pathToBuggyFile, new ArrayHashCodeAndToStringCheck());
-        Main.main(
+        String[] args =
                 new String[] {
                     Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
                     "SEGMENT",
@@ -60,8 +60,7 @@ public class SegmentStrategyTest {
                     PrettyPrintingStrategy.NORMAL.name(),
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE + "/SEGMENT/"
-                });
-        TestHelper.removeComplianceComments(pathToRepairedFile);
-        RuleVerifier.verifyNoIssue(pathToRepairedFile, new ArrayHashCodeAndToStringCheck());
+                };
+        assertThrows(RuntimeException.class, () -> Main.main(args));
     }
 }

--- a/src/test/java/sorald/SoraldConfigTest.java
+++ b/src/test/java/sorald/SoraldConfigTest.java
@@ -2,8 +2,8 @@ package sorald;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SoraldConfigTest {
 
@@ -17,6 +17,6 @@ public class SoraldConfigTest {
         ruleKeys.add(2116);
         ruleKeys.add(2184);
         config.addRuleKeys(ruleKeys);
-        Assert.assertEquals(2, config.getRuleKeys().size());
+        Assertions.assertEquals(2, config.getRuleKeys().size());
     }
 }

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -2,7 +2,7 @@ package sorald.miner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,7 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import sorald.Constants;
 
 public class WarningMinerTest {
@@ -40,7 +40,7 @@ public class WarningMinerTest {
         List<String> expectedLines = extractSortedNonZeroChecks(correctResults.toPath());
         List<String> actualLines = extractSortedNonZeroChecks(outputFile.toPath());
 
-        assertFalse("sanity check failure, expected output is empty", expectedLines.isEmpty());
+        assertFalse(expectedLines.isEmpty(), "sanity check failure, expected output is empty");
         assertThat(actualLines, equalTo(expectedLines));
     }
 

--- a/src/test/java/sorald/segment/FirstFitSegmentationAlgorithmTest.java
+++ b/src/test/java/sorald/segment/FirstFitSegmentationAlgorithmTest.java
@@ -7,8 +7,9 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import sorald.Constants;
 
 public class FirstFitSegmentationAlgorithmTest {
@@ -20,8 +21,8 @@ public class FirstFitSegmentationAlgorithmTest {
         filesPath.add(".");
         Node node = new Node(null, filesPath);
         Pair<Node, Node> p = FirstFitSegmentationAlgorithm.splitFileNode(node, 1);
-        Assert.assertEquals(1, p.getFirst().getJavaFiles().size());
-        Assert.assertEquals(1, p.getSecond().getJavaFiles().size());
+        Assertions.assertEquals(1, p.getFirst().getJavaFiles().size());
+        Assertions.assertEquals(1, p.getSecond().getJavaFiles().size());
     }
 
     @Test
@@ -30,30 +31,31 @@ public class FirstFitSegmentationAlgorithmTest {
         Node rootNode = SoraldTreeBuilderAlgorithm.buildTree(folder);
 
         LinkedList<LinkedList<Node>> segments = FirstFitSegmentationAlgorithm.segment(rootNode, 2);
-        Assert.assertEquals(2, segments.size());
+        Assertions.assertEquals(2, segments.size());
 
         LinkedList<Node> segmentOne = segments.get(0);
         Node dirNode = segmentOne.get(0);
         Node fileNodeOne = dirNode.getChildren().get(0);
         File subDirFolder = new File(dirNode.getRootPath());
-        Assert.assertTrue(dirNode.isDirNode());
-        Assert.assertTrue(fileNodeOne.isFileNode());
-        Assert.assertEquals(1, segmentOne.size());
-        Assert.assertEquals(1, dirNode.getChildren().size());
-        Assert.assertEquals(2, fileNodeOne.getJavaFiles().size());
-        Assert.assertEquals("DummySubFolder", subDirFolder.getName());
+        Assertions.assertTrue(dirNode.isDirNode());
+        Assertions.assertTrue(fileNodeOne.isFileNode());
+        Assertions.assertEquals(1, segmentOne.size());
+        Assertions.assertEquals(1, dirNode.getChildren().size());
+        Assertions.assertEquals(2, fileNodeOne.getJavaFiles().size());
+        Assertions.assertEquals("DummySubFolder", subDirFolder.getName());
         List<String> dummyFileNames =
                 fileNodeOne.getJavaFiles().stream()
                         .map(absolutePath -> new File(absolutePath).getName())
                         .collect(Collectors.toList());
-        Assert.assertThat(dummyFileNames, containsInAnyOrder("DummyTwo.java", "DummyThree.java"));
+        MatcherAssert.assertThat(
+                dummyFileNames, containsInAnyOrder("DummyTwo.java", "DummyThree.java"));
 
         LinkedList<Node> segmentTwo = segments.get(1);
         Node fileNodeTwo = segmentTwo.get(0);
         File dummyOne = new File(fileNodeTwo.getJavaFiles().get(0));
-        Assert.assertTrue(fileNodeTwo.isFileNode());
-        Assert.assertEquals(1, segmentTwo.size());
-        Assert.assertEquals(1, fileNodeTwo.getJavaFiles().size());
-        Assert.assertEquals("DummyOne.java", dummyOne.getName());
+        Assertions.assertTrue(fileNodeTwo.isFileNode());
+        Assertions.assertEquals(1, segmentTwo.size());
+        Assertions.assertEquals(1, fileNodeTwo.getJavaFiles().size());
+        Assertions.assertEquals("DummyOne.java", dummyOne.getName());
     }
 }

--- a/src/test/java/sorald/segment/SoraldTreeBuilderAlgorithmTest.java
+++ b/src/test/java/sorald/segment/SoraldTreeBuilderAlgorithmTest.java
@@ -5,8 +5,9 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import sorald.Constants;
 
 public class SoraldTreeBuilderAlgorithmTest {
@@ -16,22 +17,22 @@ public class SoraldTreeBuilderAlgorithmTest {
         String folder = Constants.PATH_TO_RESOURCES_FOLDER + "DummyTreeDir";
         Node rootNode = SoraldTreeBuilderAlgorithm.buildTree(folder);
         File rootFolder = new File(folder);
-        Assert.assertEquals("DummyTreeDir", rootFolder.getName());
-        Assert.assertEquals(3, rootNode.getJavaFilesNbs());
-        Assert.assertEquals(2, rootNode.getChildren().size());
+        Assertions.assertEquals("DummyTreeDir", rootFolder.getName());
+        Assertions.assertEquals(3, rootNode.getJavaFilesNbs());
+        Assertions.assertEquals(2, rootNode.getChildren().size());
 
         Node rootFileNode = rootNode.getChildren().get(1);
-        Assert.assertTrue(rootFileNode.isFileNode());
-        Assert.assertEquals(1, rootFileNode.getJavaFiles().size());
+        Assertions.assertTrue(rootFileNode.isFileNode());
+        Assertions.assertEquals(1, rootFileNode.getJavaFiles().size());
         File file1 = new File(rootFileNode.getJavaFiles().get(0));
-        Assert.assertEquals("DummyOne.java", file1.getName());
+        Assertions.assertEquals("DummyOne.java", file1.getName());
 
         Node subDirNode = rootNode.getChildren().get(0);
         File subDirFolder = new File(subDirNode.getRootPath());
-        Assert.assertTrue(subDirNode.isDirNode());
-        Assert.assertEquals("DummySubFolder", subDirFolder.getName());
-        Assert.assertEquals(2, subDirNode.getJavaFilesNbs());
-        Assert.assertEquals(1, subDirNode.getChildren().size());
+        Assertions.assertTrue(subDirNode.isDirNode());
+        Assertions.assertEquals("DummySubFolder", subDirFolder.getName());
+        Assertions.assertEquals(2, subDirNode.getJavaFilesNbs());
+        Assertions.assertEquals(1, subDirNode.getChildren().size());
 
         Node subDirFileNode = subDirNode.getChildren().get(0);
         File file2 = new File(subDirFileNode.getJavaFiles().get(0));
@@ -40,6 +41,7 @@ public class SoraldTreeBuilderAlgorithmTest {
                 subDirFileNode.getJavaFiles().stream()
                         .map(absolutPath -> new File(absolutPath).getName())
                         .collect(Collectors.toList());
-        Assert.assertThat(dummyFileNames, containsInAnyOrder("DummyTwo.java", "DummyThree.java"));
+        MatcherAssert.assertThat(
+                dummyFileNames, containsInAnyOrder("DummyTwo.java", "DummyThree.java"));
     }
 }


### PR DESCRIPTION
Fix #155 

This PR fully adopts JUnit5 by converting all remaining JUnit4 tests. We no longer need the vintage engine, so that's dropped from the pom. This will make more elaborate test fixtures (e.g. the stuff discussed in #153) easier to manage.

The entire conversion was automatic, with the exception of editing the pom and a single test case that had to be slightly rewritten (see review comment).