### PR TITLE
test: Automatically clean default workspace before each test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -1,18 +1,10 @@
 package sorald;
 
 import java.io.File;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class FileOutputStrategyTest {
-
-    private String fileOutputStrategyTestWorkspace = "FileOutputStrategyTest";
-
-    @AfterEach
-    public void tearDown() {
-        TestHelper.deleteDirectory(new File(fileOutputStrategyTestWorkspace));
-    }
 
     @Test
     public void test_onlyChangedFilesAndPatchOutput() throws Exception {
@@ -25,17 +17,15 @@ public class FileOutputStrategyTest {
                     Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
                     FileOutputStrategy.CHANGED_ONLY.name(),
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
-                    fileOutputStrategyTestWorkspace,
+                    Constants.SORALD_WORKSPACE,
                     Constants.ARG_SYMBOL + Constants.ARG_GIT_REPO_PATH,
                     "."
                 });
 
-        File spooned =
-                new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);
+        File spooned = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.SPOONED);
         Assertions.assertEquals(spooned.list().length, 1);
 
-        File patches =
-                new File(fileOutputStrategyTestWorkspace + File.separator + Constants.PATCHES);
+        File patches = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.PATCHES);
         Assertions.assertEquals(patches.list().length, 1);
     }
 
@@ -50,15 +40,13 @@ public class FileOutputStrategyTest {
                     Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
                     FileOutputStrategy.CHANGED_ONLY.name(),
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
-                    fileOutputStrategyTestWorkspace
+                    Constants.SORALD_WORKSPACE
                 });
 
-        File spooned =
-                new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);
+        File spooned = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.SPOONED);
         Assertions.assertEquals(spooned.list().length, 1);
 
-        File patches =
-                new File(fileOutputStrategyTestWorkspace + File.separator + Constants.PATCHES);
+        File patches = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.PATCHES);
         Assertions.assertNull(patches.list());
     }
 
@@ -75,15 +63,13 @@ public class FileOutputStrategyTest {
                     Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY,
                     PrettyPrintingStrategy.NORMAL.name(),
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
-                    fileOutputStrategyTestWorkspace
+                    Constants.SORALD_WORKSPACE
                 });
 
-        File spooned =
-                new File(fileOutputStrategyTestWorkspace + File.separator + Constants.SPOONED);
+        File spooned = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.SPOONED);
         Assertions.assertTrue(spooned.list().length > 1);
 
-        File patches =
-                new File(fileOutputStrategyTestWorkspace + File.separator + Constants.PATCHES);
+        File patches = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.PATCHES);
         Assertions.assertNull(patches.list());
     }
 }

--- a/src/test/java/sorald/WorkspaceCleaner.java
+++ b/src/test/java/sorald/WorkspaceCleaner.java
@@ -1,0 +1,22 @@
+package sorald;
+
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+/**
+ * Helper class the cleans up the default sorald workspace, if it exists, before each test executes.
+ * This is to prevent tests using the default workspace from interfering with each other.
+ */
+public class WorkspaceCleaner implements TestExecutionListener {
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        File workspace = Paths.get(Constants.SORALD_WORKSPACE).toAbsolutePath().normalize().toFile();
+        if (workspace.exists()) {
+            TestHelper.deleteDirectory(workspace);
+        }
+    }
+}

--- a/src/test/java/sorald/WorkspaceCleaner.java
+++ b/src/test/java/sorald/WorkspaceCleaner.java
@@ -1,10 +1,9 @@
 package sorald;
 
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-
 import java.io.File;
 import java.nio.file.Paths;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
 
 /**
  * Helper class the cleans up the default sorald workspace, if it exists, before each test executes.
@@ -14,7 +13,8 @@ public class WorkspaceCleaner implements TestExecutionListener {
 
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
-        File workspace = Paths.get(Constants.SORALD_WORKSPACE).toAbsolutePath().normalize().toFile();
+        File workspace =
+                Paths.get(Constants.SORALD_WORKSPACE).toAbsolutePath().normalize().toFile();
         if (workspace.exists()) {
             TestHelper.deleteDirectory(workspace);
         }

--- a/src/test/java/sorald/processor/ProcessorTest.java
+++ b/src/test/java/sorald/processor/ProcessorTest.java
@@ -1,5 +1,7 @@
 package sorald.processor;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -43,6 +45,9 @@ public class ProcessorTest {
     public void testProcessSingleFile(
             ProcessorTestHelper.ProcessorTestCase<? extends JavaFileScanner> testCase)
             throws Exception {
+        assertFalse(
+                new File(Constants.SORALD_WORKSPACE).exists(),
+                "workspace should must be clean before test");
         String pathToRepairedFile =
                 Paths.get(Constants.SORALD_WORKSPACE)
                         .resolve(Constants.SPOONED)

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+sorald.WorkspaceCleaner


### PR DESCRIPTION
Fix #153 

This PR introduces a test listener that automatically cleans up the default workspace _before_ each test. It is therefore now safe to use the default workspace for all tests, and all tests that previously interfered with each other now don't.

The listener in question is located in `src/test/sorald/WorkspaceCleaner.java`, and is registered as a test service in `src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener`.