### PR TITLE
test: Add test case for segment repair of multiple rules

### DIFF
--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -1,6 +1,7 @@
 package sorald;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
 import org.sonar.java.checks.CastArithmeticOperandCheck;
 import org.sonar.java.checks.EqualsOnAtomicClassCheck;
@@ -8,8 +9,9 @@ import sorald.sonar.RuleVerifier;
 
 public class MultipleProcessorsTest {
 
-    @Test
-    public void test_threeExistingRules() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"DEFAULT", "SEGMENT"})
+    public void test_threeExistingRules(String repairStrategy) throws Exception {
         String fileName = "MultipleProcessors.java";
         String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
         String pathToRepairedFile =
@@ -22,7 +24,9 @@ public class MultipleProcessorsTest {
                     Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
                     "2111,2184,2204",
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE
+                    Constants.SORALD_WORKSPACE,
+                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    repairStrategy
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);
         RuleVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
+import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
+import org.sonar.java.checks.CastArithmeticOperandCheck;
+import org.sonar.java.checks.EqualsOnAtomicClassCheck;
 import sorald.Constants;
 import sorald.Main;
 import sorald.PrettyPrintingStrategy;
@@ -62,5 +65,30 @@ public class SegmentStrategyTest {
                     Constants.SORALD_WORKSPACE + "/SEGMENT/"
                 };
         assertThrows(RuntimeException.class, () -> Main.main(args));
+    }
+
+    @Test
+    public void segmentStrategy_repairsAllIssues_whenMultipleRulesAreViolated() throws Exception {
+        String fileName = "MultipleProcessors.java";
+        String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
+        String pathToRepairedFile =
+                Constants.SORALD_WORKSPACE + "/" + Constants.SPOONED + "/" + fileName;
+
+        Main.main(
+                new String[] {
+                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    "SEGMENT",
+                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    pathToBuggyFile,
+                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    "2111,2184,2204",
+                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.SORALD_WORKSPACE
+                });
+
+        TestHelper.removeComplianceComments(pathToRepairedFile);
+        RuleVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());
+        RuleVerifier.verifyNoIssue(pathToRepairedFile, new CastArithmeticOperandCheck());
+        RuleVerifier.verifyNoIssue(pathToRepairedFile, new EqualsOnAtomicClassCheck());
     }
 }

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
-import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
-import org.sonar.java.checks.CastArithmeticOperandCheck;
-import org.sonar.java.checks.EqualsOnAtomicClassCheck;
 import sorald.Constants;
 import sorald.Main;
 import sorald.PrettyPrintingStrategy;
@@ -65,32 +62,5 @@ public class SegmentStrategyTest {
                     Constants.SORALD_WORKSPACE + "/SEGMENT/"
                 };
         assertThrows(RuntimeException.class, () -> Main.main(args));
-    }
-
-    @Test
-    public void segmentStrategy_repairsAllIssues_whenMultipleRulesAreViolated() throws Exception {
-        String fileName = "MultipleProcessors.java";
-        String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
-        String pathToRepairedFile =
-                Constants.SORALD_WORKSPACE + "/" + Constants.SPOONED + "/" + fileName;
-
-        Main.main(
-                new String[] {
-                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
-                    "SEGMENT",
-                    Constants.ARG_SYMBOL + Constants.ARG_MAX_FILES_PER_SEGMENT,
-                    "1",
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
-                    pathToBuggyFile,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
-                    "2111,2184,2204",
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE
-                });
-
-        TestHelper.removeComplianceComments(pathToRepairedFile);
-        RuleVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());
-        RuleVerifier.verifyNoIssue(pathToRepairedFile, new CastArithmeticOperandCheck());
-        RuleVerifier.verifyNoIssue(pathToRepairedFile, new EqualsOnAtomicClassCheck());
     }
 }

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -78,6 +78,8 @@ public class SegmentStrategyTest {
                 new String[] {
                     Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
                     "SEGMENT",
+                    Constants.ARG_SYMBOL + Constants.ARG_MAX_FILES_PER_SEGMENT,
+                    "1",
                     Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
                     pathToBuggyFile,
                     Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,


### PR DESCRIPTION
Related to #170 

This shows that the segment strategy currently only fixes one rule. Not intended to be merged, just for documentation at this point.