### PR TITLE
refactor: Run all checks in one pass in warnings miner

### DIFF
--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -202,11 +202,14 @@ public class MineSonarWarnings {
                     e.printStackTrace();
                 }
             }
-            for (JavaFileScanner javaFileScanner : SONAR_CHECK_INSTANCES) {
-                Set<RuleViolation> ruleViolations =
-                        RuleVerifier.analyze(filesToScan, file, javaFileScanner);
-                warnings.putIfAbsent(
-                        javaFileScanner.getClass().getSimpleName(), ruleViolations.size());
+            SONAR_CHECK_INSTANCES.stream()
+                    .map(Object::getClass)
+                    .map(Class::getSimpleName)
+                    .forEach(name -> warnings.put(name, 0));
+            for (RuleViolation violation :
+                    RuleVerifier.analyze(filesToScan, file, SONAR_CHECK_INSTANCES)) {
+                String key = violation.getCheckName();
+                warnings.put(key, warnings.get(key) + 1);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
@@ -185,7 +186,11 @@ public class MineSonarWarnings {
     }
 
     private static Map<String, Integer> extractWarnings(String projectPath) {
-        Map<String, Integer> warnings = new HashMap<>();
+        final Map<String, Integer> warnings = new HashMap<>();
+        SONAR_CHECK_INSTANCES.stream()
+                .map(Object::getClass)
+                .map(Class::getSimpleName)
+                .forEach(checkName -> warnings.put(checkName, 0));
 
         try {
             List<String> filesToScan = new ArrayList<>();
@@ -202,15 +207,11 @@ public class MineSonarWarnings {
                     e.printStackTrace();
                 }
             }
-            SONAR_CHECK_INSTANCES.stream()
-                    .map(Object::getClass)
-                    .map(Class::getSimpleName)
-                    .forEach(name -> warnings.put(name, 0));
-            for (RuleViolation violation :
-                    RuleVerifier.analyze(filesToScan, file, SONAR_CHECK_INSTANCES)) {
-                String key = violation.getCheckName();
-                warnings.put(key, warnings.get(key) + 1);
-            }
+            Consumer<String> incrementWarningCount =
+                    (checkName) -> warnings.put(checkName, warnings.get(checkName) + 1);
+            RuleVerifier.analyze(filesToScan, file, SONAR_CHECK_INSTANCES).stream()
+                    .map(RuleViolation::getCheckName)
+                    .forEach(incrementWarningCount);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -59,6 +59,20 @@ public class RuleVerifier {
     @SuppressWarnings("UnstableApiUsage")
     public static Set<RuleViolation> analyze(
             List<String> filesToScan, File baseDir, JavaFileScanner check) {
+        return analyze(filesToScan, baseDir, Collections.singletonList(check));
+    }
+
+    /**
+     * Analyze the files with respect to check.
+     *
+     * @param filesToScan A list of paths to files.
+     * @param baseDir The base directory of the current project.
+     * @param checks Sonar checks to use.
+     * @return All messages produced by the analyzer, for all files.
+     */
+    @SuppressWarnings("UnstableApiUsage")
+    public static Set<RuleViolation> analyze(
+            List<String> filesToScan, File baseDir, List<JavaFileScanner> checks) {
         List<InputFile> inputFiles =
                 filesToScan.stream()
                         .map(filename -> toInputFile(baseDir, filename))
@@ -66,7 +80,7 @@ public class RuleVerifier {
 
         SoraldSonarComponents sonarComponents = createSonarComponents(baseDir);
         JavaAstScanner scanner =
-                createAstScanner(sonarComponents, Collections.singletonList(check));
+                createAstScanner(sonarComponents, checks);
 
         scanner.scan(inputFiles);
 

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -79,8 +79,7 @@ public class RuleVerifier {
                         .collect(Collectors.toList());
 
         SoraldSonarComponents sonarComponents = createSonarComponents(baseDir);
-        JavaAstScanner scanner =
-                createAstScanner(sonarComponents, checks);
+        JavaAstScanner scanner = createAstScanner(sonarComponents, checks);
 
         scanner.scan(inputFiles);
 

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -63,12 +63,12 @@ public class RuleVerifier {
     }
 
     /**
-     * Analyze the files with respect to check.
+     * Analyze the files with all of the provided checks.
      *
      * @param filesToScan A list of paths to files.
      * @param baseDir The base directory of the current project.
      * @param checks Sonar checks to use.
-     * @return All messages produced by the analyzer, for all files.
+     * @return All messages produced by the analyzer, for all files and all checks.
      */
     @SuppressWarnings("UnstableApiUsage")
     public static Set<RuleViolation> analyze(

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -20,4 +20,9 @@ public class RuleViolation {
     public String getFileName() {
         return message.getInputComponent().key().replace(":", "");
     }
+
+    /** @return The name of the check class that generated this warning. */
+    public String getCheckName() {
+        return message.getCheck().getClass().getSimpleName();
+    }
 }

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import sorald.Constants;
 import sorald.sonar.Checks;

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -9,9 +9,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import sorald.Constants;
+import sorald.sonar.Checks;
 
 public class WarningMinerTest {
 
@@ -25,6 +29,44 @@ public class WarningMinerTest {
         fileName = "warning_miner/test_results.txt";
         File correctResults = new File(Constants.PATH_TO_RESOURCES_FOLDER + fileName);
 
+        runMiner(pathToRepos, outputFile.getPath(), temp.getPath());
+
+        List<String> expectedLines = extractSortedNonZeroChecks(correctResults.toPath());
+        List<String> actualLines = extractSortedNonZeroChecks(outputFile.toPath());
+
+        assertFalse(expectedLines.isEmpty(), "sanity check failure, expected output is empty");
+        assertThat(actualLines, equalTo(expectedLines));
+    }
+
+    /** Test that extracting warnings gives results even for rules that are not violated. */
+    @Test
+    public void extractWarnings_accountsForAllRules_whenManyAreNotViolated() throws Exception {
+        File outputFile = File.createTempFile("warnings", null),
+                temp = Files.createTempDirectory("tempDir").toFile();
+        String fileName = "warning_miner/test_repos.txt";
+        String pathToRepos = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
+
+        runMiner(pathToRepos, outputFile.getPath(), temp.getPath());
+
+        List<String> expectedChecks =
+                Checks.getAllChecks().stream()
+                        .map(Class::getSimpleName)
+                        .sorted()
+                        .collect(Collectors.toList());
+        Pattern checkNamePattern = Pattern.compile("^(.*)=\\d+$");
+        List<String> actualChecks =
+                Files.readAllLines(outputFile.toPath()).stream()
+                        .map(checkNamePattern::matcher)
+                        .filter(Matcher::matches)
+                        .map(m -> m.group(1))
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        assertThat(actualChecks, equalTo(expectedChecks));
+    }
+
+    private static void runMiner(String pathToRepos, String pathToOutput, String pathToTempDir)
+            throws Exception {
         MineSonarWarnings.main(
                 new String[] {
                     Constants.ARG_SYMBOL + Constants.ARG_STATS_ON_GIT_REPOS,
@@ -32,16 +74,10 @@ public class WarningMinerTest {
                     Constants.ARG_SYMBOL + Constants.ARG_GIT_REPOS_LIST,
                     pathToRepos,
                     Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
-                    outputFile.getPath(),
+                    pathToOutput,
                     Constants.ARG_SYMBOL + Constants.ARG_TEMP_DIR,
-                    temp.getPath()
+                    pathToTempDir
                 });
-
-        List<String> expectedLines = extractSortedNonZeroChecks(correctResults.toPath());
-        List<String> actualLines = extractSortedNonZeroChecks(outputFile.toPath());
-
-        assertFalse(expectedLines.isEmpty(), "sanity check failure, expected output is empty");
-        assertThat(actualLines, equalTo(expectedLines));
     }
 
     /**


### PR DESCRIPTION
Fix #168 

This PR will conflict with #156 , that one must be merged first.

Optimizes the warnings miner by running all checks in one pass, instead of running one check at a time. Makes the miner many times faster than it was previously.