### PR TITLE
feat: Add PublicStaticFieldShouldBeFinalProcessor (SonarSource rule 1444)

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -386,11 +386,11 @@ The repair consists of making public static fields final.
 
 Example:
 ```diff
-public class NonFinalPublicStaticField {
--   public static Integer meaningOfLife = 42;
-+   public static final Integer meaningOfLife = 42;
-    private static Integer CATCH = 22; // Compliant
-    protected static Integer order = 66; // Compliant
-    static Integer roadToHill = 30; // Compliant
-}
+ public class NonFinalPublicStaticField {
+-    public static Integer meaningOfLife = 42;
++    public static final Integer meaningOfLife = 42;
+     private static Integer CATCH = 22; // Compliant
+     protected static Integer order = 66; // Compliant
+     static Integer roadToHill = 30; // Compliant
+ }
 ```

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -21,6 +21,7 @@ Sorald can currently repair violations of the following rules:
 * [Code Smell](#code-smell)
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
+    * ["public static" fields should be constant](#public-static-fields-should-be-constant-sonar-rule-1444) ([Sonar Rule 1444](https://rules.sonarsource.com/java/RSPEC-1444))
 
 ### *Bug*
 
@@ -378,3 +379,18 @@ Example:
 ```
 
 Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/2265) that repairs one DeadStore violation.
+
+#### "public static" fields should be constant ([Sonar Rule 1444](https://rules.sonarsource.com/java/RSPEC-1444))
+
+The repair consists of making public static fields final.
+
+Example:
+```diff
+public class NonFinalPublicStaticField {
+-   public static Integer meaningOfLife = 42;
++   public static final Integer meaningOfLife = 42;
+    private static Integer CATCH = 22; // Compliant
+    protected static Integer order = 66; // Compliant
+    static Integer roadToHill = 30; // Compliant
+}
+```

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -1,6 +1,5 @@
 package sorald.processor;
 
-import java.util.Set;
 import org.sonar.java.checks.PublicStaticFieldShouldBeFinalCheck;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
@@ -16,11 +15,7 @@ public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProce
 
     @Override
     public boolean isToBeProcessed(CtField<?> candidate) {
-        if (!super.isToBeProcessedAccordingToStandards(candidate)) {
-            return false;
-        }
-        Set<ModifierKind> modifiers = candidate.getModifiers();
-        return modifiers.contains(ModifierKind.PUBLIC) && !modifiers.contains(ModifierKind.FINAL);
+        return super.isToBeProcessedAccordingToStandards(candidate);
     }
 
     @Override

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -1,0 +1,31 @@
+package sorald.processor;
+
+import java.util.Set;
+import org.sonar.java.checks.PublicStaticFieldShouldBeFinalCheck;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import sorald.ProcessorAnnotation;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.ModifierKind;
+
+@ProcessorAnnotation(key = 1444, description = "\"public static\" fields should be constant")
+public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProcessor<CtField<?>> {
+    @Override
+    public JavaFileScanner getSonarCheck() {
+        return new PublicStaticFieldShouldBeFinalCheck();
+    }
+
+    @Override
+    public boolean isToBeProcessed(CtField<?> candidate) {
+        if (!super.isToBeProcessedAccordingToStandards(candidate)) {
+            return false;
+        }
+        Set<ModifierKind> modifiers = candidate.getModifiers();
+        return modifiers.contains(ModifierKind.PUBLIC) && !modifiers.contains(ModifierKind.FINAL);
+    }
+
+    @Override
+    public void process(CtField<?> element) {
+        super.process(element);
+        element.addModifier(ModifierKind.FINAL);
+    }
+}

--- a/src/main/java/sorald/sonar/Checks.java
+++ b/src/main/java/sorald/sonar/Checks.java
@@ -250,7 +250,9 @@ public class Checks {
         typeToChecks.put(
                 CheckType.CODE_SMELL,
                 createKeyToCheckMap(
-                        DeadStoreCheck.class, SerializableFieldInSerializableClassCheck.class));
+                        DeadStoreCheck.class,
+                        SerializableFieldInSerializableClassCheck.class,
+                        PublicStaticFieldShouldBeFinalCheck.class));
 
         TYPE_TO_CHECKS = Collections.unmodifiableMap(typeToChecks);
 

--- a/src/test/resources/processor_test_files/1444_PublicStaticFieldShouldBeFinal/NonFinalPublicStaticField.java
+++ b/src/test/resources/processor_test_files/1444_PublicStaticFieldShouldBeFinal/NonFinalPublicStaticField.java
@@ -1,0 +1,6 @@
+public class NonFinalPublicStaticField {
+    public static Integer meaningOfLife = 42; // Noncompliant
+    private static Integer CATCH = 22; // Compliant
+    protected static Integer order = 66; // Compliant
+    static Integer roadToHill = 30; // Compliant
+}

--- a/src/test/resources/processor_test_files/1444_PublicStaticFieldShouldBeFinal/NonFinalPublicStaticField.java.expected
+++ b/src/test/resources/processor_test_files/1444_PublicStaticFieldShouldBeFinal/NonFinalPublicStaticField.java.expected
@@ -1,0 +1,6 @@
+public class NonFinalPublicStaticField {
+    public static final Integer meaningOfLife = 42;
+    private static Integer CATCH = 22; // Compliant
+    protected static Integer order = 66; // Compliant
+    static Integer roadToHill = 30; // Compliant
+}


### PR DESCRIPTION
This PR adds a processor for the rule ["public static" fields should be constant](https://rules.sonarsource.com/java/RSPEC-1444).

Transformation:

```diff
 public class NonFinalPublicStaticField {
-    public static Integer meaningOfLife = 42;
+    public static final Integer meaningOfLife = 42;
     private static Integer CATCH = 22; // Compliant
     protected static Integer order = 66; // Compliant
     static Integer roadToHill = 30; // Compliant
 }
```

I did this mostly to test our contributing guidelines, and found some flaws as documented in #178.

There are two things to note about rule 1444 and this new processor.

1. It's categorized as a code smell, but also appears as a vulnerability and so aligns with our prioritization in #51 
    - [Example in Spoon](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&open=AXSzsF_p0NCgCl1d2odL&resolved=false&rules=squid%3AS1444&types=VULNERABILITY)
    - [CWE entry](https://cwe.mitre.org/data/definitions/500.html)
2. The processor may introduce a code smell, as it does not attempt to change the variable name from e.g. camel case to capitalized snake case
    - To fully comply, `meaningOfLife` should be changed to `MEANING_OF_LIFE`
    - The reason the processor doesn't do this is that we don't have the testing capabilities to verify the correctness of such a modification yet: all accesses to the variable must also be rewritten.