### PR TITLE
fix: Fix handling of crashing checks

### DIFF
--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -15,6 +15,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.java.AnalyzerMessage;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.ast.JavaAstScanner;
@@ -137,6 +138,7 @@ public class RuleVerifier {
         // FIXME The SensorContextTester is an internal and unstable component in sonar,
         //       we should implement our own SensorContext
         SensorContextTester context = SensorContextTester.create(baseDir);
+        context.setSettings(new MapSettings().setProperty(SonarComponents.FAIL_ON_EXCEPTION_KEY, true));
         SoraldSonarComponents sonarComponents = new SoraldSonarComponents(context.fileSystem());
         sonarComponents.setSensorContext(context);
         return sonarComponents;

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -128,7 +128,8 @@ public class RuleVerifier {
                         sonarComponents,
                         SymbolicExecutionMode.getMode(checks.toArray(new JavaFileScanner[0])));
         // TODO set the version number to something appropriate for the current context
-        //      setting it too high may yield false positives (fixes that aren't applicable to lower versions)
+        //      setting it too high may yield false positives (fixes that aren't applicable to lower
+        // versions)
         //      setting it too low may yield false negatives and parsing issues
         visitorsBridge.setJavaVersion(new JavaVersionImpl(14));
         scanner.setVisitorBridge(visitorsBridge);
@@ -139,7 +140,8 @@ public class RuleVerifier {
         // FIXME The SensorContextTester is an internal and unstable component in sonar,
         //       we should implement our own SensorContext
         SensorContextTester context = SensorContextTester.create(baseDir);
-        context.setSettings(new MapSettings().setProperty(SonarComponents.FAIL_ON_EXCEPTION_KEY, true));
+        context.setSettings(
+                new MapSettings().setProperty(SonarComponents.FAIL_ON_EXCEPTION_KEY, true));
         SoraldSonarComponents sonarComponents = new SoraldSonarComponents(context.fileSystem());
         sonarComponents.setSensorContext(context);
         return sonarComponents;

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -20,6 +20,7 @@ import org.sonar.java.AnalyzerMessage;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import org.sonar.java.model.JavaVersionImpl;
 import org.sonar.java.model.VisitorsBridge;
 import org.sonar.java.se.SymbolicExecutionMode;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -126,10 +127,10 @@ public class RuleVerifier {
                         Collections.emptyList(),
                         sonarComponents,
                         SymbolicExecutionMode.getMode(checks.toArray(new JavaFileScanner[0])));
-        // TODO we may want to set the version of the visitors bridge, as without setting it the
-        //      implementation defaults to the highest version supported by the parser (currently
-        //      Java 14)
-        //      visitorsBridge.setJavaVersion(new JavaVersionImpl(8));
+        // TODO set the version number to something appropriate for the current context
+        //      setting it too high may yield false positives (fixes that aren't applicable to lower versions)
+        //      setting it too low may yield false negatives and parsing issues
+        visitorsBridge.setJavaVersion(new JavaVersionImpl(14));
         scanner.setVisitorBridge(visitorsBridge);
         return scanner;
     }

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -8,11 +8,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.sonar.java.AnalysisException;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
 import sorald.Constants;
 import sorald.sonar.Checks;
 
@@ -62,6 +66,21 @@ public class WarningMinerTest {
                         .collect(Collectors.toList());
 
         assertThat(actualChecks, equalTo(expectedChecks));
+    }
+
+    @Test
+    @SuppressWarnings("UnstableApiUsage")
+    public void extractWarnings_throwsException_whenCheckCrashes() {
+        JavaFileScanner crashyCheck =
+                context -> {
+                    throw new IllegalStateException();
+                };
+
+        assertThrows(
+                AnalysisException.class,
+                () ->
+                        MineSonarWarnings.extractWarnings(
+                                Constants.PATH_TO_RESOURCES_FOLDER, Arrays.asList(crashyCheck)));
     }
 
     private static void runMiner(String pathToRepos, String pathToOutput, String pathToTempDir)

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.AnalysisException;
 import org.sonar.plugins.java.api.JavaFileScanner;
-import org.sonar.plugins.java.api.JavaFileScannerContext;
 import sorald.Constants;
 import sorald.sonar.Checks;
 


### PR DESCRIPTION
Fix #183 
Fix #184 

This PR does two things.

1. Expose check crashes by not catching all exceptions in the warnings miner
    - If there is a crash, we want to know about it, especially when the crash is our fault
2. Fix such a crash in WeakSSLContextCheck by setting the Java version number in the VisitorsBridge to 14

Setting the Java version to 14 is an imperfect fix. It could theoretically cause false positives if a project uses a lesser version of Java by suggesting fixes that aren't applicable to it. Most of these seem related to `< java 8`, though. But setting it too low might cause parsing issues as the parser expects a certain compliance level. As such, I think setting the version a bit too high is preferable to a bit too low at the moment.