### PR TITLE
refactor: Replace SoraldAbstractProcessor.getSonarCheck with Checks.getCheckInstance

### DIFF
--- a/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
@@ -1,8 +1,6 @@
 package sorald.processor;
 
 import java.util.Arrays;
-import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtExpression;
@@ -18,11 +16,6 @@ import spoon.reflect.reference.CtExecutableReference;
 public class ArrayHashCodeAndToStringProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
 
     public ArrayHashCodeAndToStringProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new ArrayHashCodeAndToStringCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtInvocation<?> candidate) {

--- a/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
+++ b/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
@@ -2,8 +2,6 @@ package sorald.processor;
 
 import java.math.BigDecimal;
 import java.util.List;
-import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtMethod;
@@ -16,11 +14,6 @@ public class BigDecimalDoubleConstructorProcessor
         extends SoraldAbstractProcessor<CtConstructorCall> {
 
     public BigDecimalDoubleConstructorProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new BigDecimalDoubleConstructorCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtConstructorCall cons) {

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -1,8 +1,6 @@
 package sorald.processor;
 
 import java.util.List;
-import org.sonar.java.checks.CastArithmeticOperandCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.*;
@@ -19,11 +17,6 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
     private CtTypeReference typeToBeUsedToCast;
 
     public CastArithmeticOperandProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new CastArithmeticOperandCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtBinaryOperator candidate) {

--- a/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.CompareStringsBoxedTypesWithEqualsCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
@@ -19,11 +17,6 @@ public class CompareStringsBoxedTypesWithEqualsProcessor
         extends SoraldAbstractProcessor<CtBinaryOperator<?>> {
 
     public CompareStringsBoxedTypesWithEqualsProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new CompareStringsBoxedTypesWithEqualsCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtBinaryOperator<?> candidate) {

--- a/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
+++ b/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.CompareToReturnValueCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtLiteral;
@@ -14,11 +12,6 @@ import spoon.reflect.declaration.CtMethod;
 public class CompareToReturnValueProcessor extends SoraldAbstractProcessor<CtReturn<?>> {
 
     public CompareToReturnValueProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new CompareToReturnValueCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtReturn<?> ctReturn) {

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.DeadStoreCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtLocalVariable;
@@ -11,11 +9,6 @@ import spoon.reflect.code.CtStatement;
 public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
 
     public DeadStoreProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new DeadStoreCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtStatement element) {

--- a/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
+++ b/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
@@ -3,8 +3,6 @@ package sorald.processor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import org.sonar.java.checks.EqualsOnAtomicClassCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
@@ -20,11 +18,6 @@ import spoon.reflect.reference.CtExecutableReference;
 public class EqualsOnAtomicClassProcessor extends SoraldAbstractProcessor<CtInvocation> {
 
     public EqualsOnAtomicClassProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new EqualsOnAtomicClassCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtInvocation candidate) {

--- a/src/main/java/sorald/processor/GetClassLoaderProcessor.java
+++ b/src/main/java/sorald/processor/GetClassLoaderProcessor.java
@@ -1,8 +1,6 @@
 package sorald.processor;
 
 import java.util.HashMap;
-import org.sonar.java.checks.GetClassLoaderCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtTypeAccess;
@@ -18,11 +16,6 @@ public class GetClassLoaderProcessor extends SoraldAbstractProcessor<CtInvocatio
     private HashMap<Integer, Boolean> hashCodesOfTypesUsingJEE = new HashMap<Integer, Boolean>();
 
     public GetClassLoaderProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new GetClassLoaderCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtInvocation<?> invocation) {

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.InterruptedExceptionCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtInvocation;
@@ -14,11 +12,6 @@ import spoon.reflect.factory.Factory;
 public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCatch> {
 
     public InterruptedExceptionProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new InterruptedExceptionCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtCatch candidate) {

--- a/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
+++ b/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
@@ -2,8 +2,6 @@ package sorald.processor;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import org.sonar.java.checks.IteratorNextExceptionCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeSnippetExpression;
@@ -21,11 +19,6 @@ import spoon.reflect.reference.CtTypeReference;
 public class IteratorNextExceptionProcessor extends SoraldAbstractProcessor<CtMethod> {
 
     public IteratorNextExceptionProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new IteratorNextExceptionCheck();
-    }
 
     /**
      * @param candidate - Every method of the scanned file

--- a/src/main/java/sorald/processor/MathOnFloatProcessor.java
+++ b/src/main/java/sorald/processor/MathOnFloatProcessor.java
@@ -1,8 +1,6 @@
 package sorald.processor;
 
 import java.util.List;
-import org.sonar.java.checks.MathOnFloatCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -15,11 +13,6 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class MathOnFloatProcessor extends SoraldAbstractProcessor<CtBinaryOperator> {
 
     public MathOnFloatProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new MathOnFloatCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtBinaryOperator candidate) {

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -1,18 +1,11 @@
 package sorald.processor;
 
-import org.sonar.java.checks.PublicStaticFieldShouldBeFinalCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
 
 @ProcessorAnnotation(key = 1444, description = "\"public static\" fields should be constant")
 public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProcessor<CtField<?>> {
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new PublicStaticFieldShouldBeFinalCheck();
-    }
-
     @Override
     public boolean isToBeProcessed(CtField<?> candidate) {
         return super.isToBeProcessedAccordingToStandards(candidate);

--- a/src/main/java/sorald/processor/SelfAssignementProcessor.java
+++ b/src/main/java/sorald/processor/SelfAssignementProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.SelfAssignementCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtAssignment;
@@ -19,11 +17,6 @@ import spoon.reflect.factory.Factory;
 public class SelfAssignementProcessor extends SoraldAbstractProcessor<CtAssignment<?, ?>> {
 
     public SelfAssignementProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new SelfAssignementCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtAssignment<?, ?> candidate) {

--- a/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.serialization.SerializableFieldInSerializableClassCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
@@ -14,11 +12,6 @@ public class SerializableFieldInSerializableClassProcessor
         extends SoraldAbstractProcessor<CtField> {
 
     public SerializableFieldInSerializableClassProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new SerializableFieldInSerializableClassCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtField element) {

--- a/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
@@ -1,8 +1,6 @@
 package sorald.processor;
 
 import java.util.Set;
-import org.sonar.java.checks.synchronization.SynchronizationOnGetClassCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
@@ -19,11 +17,6 @@ import spoon.reflect.reference.CtTypeReference;
 public class SynchronizationOnGetClassProcessor extends SoraldAbstractProcessor<CtSynchronized> {
 
     public SynchronizationOnGetClassProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new SynchronizationOnGetClassCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtSynchronized element) {

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -2,8 +2,6 @@ package sorald.processor;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.sonar.java.checks.SynchronizationOnStringOrBoxedCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
@@ -32,11 +30,6 @@ public class SynchronizationOnStringOrBoxedProcessor
     public SynchronizationOnStringOrBoxedProcessor() {
         this.old2NewFields = new HashMap<>();
         this.old2NewMethods = new HashMap<>();
-    }
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new SynchronizationOnStringOrBoxedCheck();
     }
 
     @Override

--- a/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.se.checks.UnclosedResourcesCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBlock;
@@ -20,11 +18,6 @@ import spoon.reflect.reference.CtVariableReference;
 public class UnclosedResourcesProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
 
     public UnclosedResourcesProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new UnclosedResourcesCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtConstructorCall element) {

--- a/src/main/java/sorald/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sorald/processor/UnusedThrowableProcessor.java
@@ -1,7 +1,5 @@
 package sorald.processor;
 
-import org.sonar.java.checks.unused.UnusedThrowableCheck;
-import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtThrow;
@@ -12,11 +10,6 @@ import spoon.reflect.code.CtThrow;
 public class UnusedThrowableProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
 
     public UnusedThrowableProcessor() {}
-
-    @Override
-    public JavaFileScanner getSonarCheck() {
-        return new UnusedThrowableCheck();
-    }
 
     @Override
     public boolean isToBeProcessed(CtConstructorCall element) {

--- a/src/main/java/sorald/sonar/Checks.java
+++ b/src/main/java/sorald/sonar/Checks.java
@@ -1,6 +1,5 @@
 package sorald.sonar;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/main/java/sorald/sonar/Checks.java
+++ b/src/main/java/sorald/sonar/Checks.java
@@ -1,5 +1,6 @@
 package sorald.sonar;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,6 +78,22 @@ public class Checks {
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("no rule with key " + strippedKey));
+    }
+
+    /**
+     * Get an instance of the check specified by key.
+     *
+     * @param key The key of the check.
+     * @return An instance of the related check class.
+     */
+    public static JavaFileScanner getCheckInstance(String key) {
+        Class<? extends JavaFileScanner> checkClass = getCheck(key);
+
+        try {
+            return checkClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to instantiate " + checkClass.getName());
+        }
     }
 
     /** @return All Sonar-Java checks that Sorald currently keeps track of. */


### PR DESCRIPTION
Fix #177 

This replaces the abstract method `SoraldAbstractProcessor.getSonarCheck` with the `Checks.getCheckInstance` method. As we have all checks in key-to-check mappings, and each processor has an annotation with the key for the rule, this should be a fully sufficient replacement.

The benefit is that new processors don't have to implement the `getSonarCheck` method and, in fact, don't need to know about sonar at all anymore as the abstract base class handles that.