### PR TITLE
feat: Add XxeProcessingProcessor (SonarSource rule 2755)

### DIFF
--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -1,0 +1,17 @@
+package sorald.processor;
+
+import sorald.ProcessorAnnotation;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.ModifierKind;
+
+@ProcessorAnnotation(key = 2755, description = "XML parsers should not be vulnerable to XXE attacks")
+public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtField<?>> {
+    @Override
+    public boolean isToBeProcessed(CtField<?> candidate) {
+        return true;
+    }
+
+    @Override
+    public void process(CtField<?> element) {
+    }
+}

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -1,7 +1,10 @@
 package sorald.processor;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import javax.xml.XMLConstants;
-
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtCompilationUnit;
@@ -12,11 +15,6 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 @ProcessorAnnotation(
         key = 2755,
@@ -37,6 +35,23 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
                         || candidate.getParent().getParent() instanceof CtLocalVariable);
     }
 
+    /**
+     * Processing only for the case where the factory is declared separately from the document
+     * builder. Example: <br>
+     * <code>
+     *     // Input
+     *     DocumentBuilderFactory df = DocumentBuilderFactory.newInstance(); // Noncompliant
+     *     DocumentBuilder = df.newDocumentBuilder();
+     *
+     *     // Transform
+     *     DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
+     *     df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+     *     df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+     *     DocumentBuilder = df.newDocumentBuilder();
+     * </code>
+     *
+     * @param element The variable declaration "DocumentBuilderFactory df;"
+     */
     @Override
     public void process(CtInvocation<?> element) {
         super.process(element);

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -1,5 +1,6 @@
 package sorald.processor;
 
+import javax.xml.XMLConstants;
 import sorald.ProcessorAnnotation;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
@@ -16,8 +17,6 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
-
-import javax.xml.XMLConstants;
 
 @ProcessorAnnotation(
         key = 2755,
@@ -84,9 +83,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
         return fieldRead;
     }
 
-    /**
-     * @return An invocation localVar.setAttribute(key, value).
-     */
+    /** @return An invocation localVar.setAttribute(key, value). */
     private <T> CtInvocation<T> createSetAttributeInvocation(
             CtLocalVariable<T> localVar, CtExpression<String> key, CtExpression<Object> value) {
         CtType<T> builderFactory = localVar.getType().getTypeDeclaration();

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -1,17 +1,17 @@
 package sorald.processor;
 
 import sorald.ProcessorAnnotation;
-import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.code.CtInvocation;
 
 @ProcessorAnnotation(key = 2755, description = "XML parsers should not be vulnerable to XXE attacks")
-public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtField<?>> {
+public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
     @Override
-    public boolean isToBeProcessed(CtField<?> candidate) {
-        return true;
+    public boolean isToBeProcessed(CtInvocation<?> candidate) {
+        return super.isToBeProcessedAccordingToStandards(candidate);
     }
 
     @Override
-    public void process(CtField<?> element) {
+    public void process(CtInvocation<?> element) {
+        super.process(element);
     }
 }

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -25,7 +25,8 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
     @Override
     public boolean isToBeProcessed(CtInvocation<?> candidate) {
         return super.isToBeProcessedAccordingToStandards(candidate)
-                && candidate.getParent().getParent() instanceof CtBlock<?>;
+                && candidate.getType().getSimpleName().equals("DocumentBuilderFactory")
+                && candidate.getParent() instanceof CtLocalVariable<?>;
     }
 
     @Override

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -1,17 +1,109 @@
 package sorald.processor;
 
 import sorald.ProcessorAnnotation;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtImport;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtTypeReference;
 
-@ProcessorAnnotation(key = 2755, description = "XML parsers should not be vulnerable to XXE attacks")
+import javax.xml.XMLConstants;
+
+@ProcessorAnnotation(
+        key = 2755,
+        description = "XML parsers should not be vulnerable to XXE attacks")
 public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
     @Override
     public boolean isToBeProcessed(CtInvocation<?> candidate) {
-        return super.isToBeProcessedAccordingToStandards(candidate);
+        return super.isToBeProcessedAccordingToStandards(candidate)
+                && candidate.getParent().getParent() instanceof CtBlock<?>;
     }
 
     @Override
     public void process(CtInvocation<?> element) {
+        CtLocalVariable<?> builderFactoryVar = (CtLocalVariable<?>) element.getParent();
+        CtBlock<?> block = (CtBlock<?>) builderFactoryVar.getParent();
+
+        CtFieldRead<String> accessExternalDtd = readXmlConstant("ACCESS_EXTERNAL_DTD");
+        CtFieldRead<String> accessExternalSchema = readXmlConstant("ACCESS_EXTERNAL_SCHEMA");
+
+        CtLiteral<Object> emptyString = getFactory().createLiteral("");
+        CtInvocation<?> setExternalDtd =
+                createSetAttributeInvocation(builderFactoryVar, accessExternalDtd, emptyString);
+        CtInvocation<?> setExternalSchema =
+                createSetAttributeInvocation(builderFactoryVar, accessExternalSchema, emptyString);
+
+        int statementIdx = block.getStatements().indexOf(builderFactoryVar);
+        block.addStatement(statementIdx + 1, setExternalSchema);
+        block.addStatement(statementIdx + 1, setExternalDtd);
+
+        ensureTypeImported(element, getFactory().Type().get(XMLConstants.class));
+
         super.process(element);
+    }
+
+    /**
+     * Ensure that the given type is imported in the compilation unit in which element is defined.
+     */
+    private void ensureTypeImported(CtElement element, CtType<?> mustBeImported) {
+        CtType<?> declaringType = element.getParent(CtType::isTopLevel);
+        CtCompilationUnit cu = getFactory().CompilationUnit().getOrCreate(declaringType);
+        CtImport requiredImport = getFactory().createImport(mustBeImported.getReference());
+
+        for (CtImport imp : cu.getImports()) {
+            if (imp.toString().equals(requiredImport.toString())) {
+                return;
+            }
+        }
+
+        cu.getImports().add(requiredImport);
+    }
+
+    /**
+     * @param constantName The name of an XMLConstants static variable
+     * @return A field read of XMLConstants.[constantName]
+     */
+    private CtFieldRead<String> readXmlConstant(String constantName) {
+        CtType<XMLConstants> xmlConstants = getFactory().Type().get(XMLConstants.class);
+        CtTypeAccess<?> xmlConstantsAccess =
+                getFactory().createTypeAccess(getReferenceWithImplicitPackage(xmlConstants));
+        CtFieldRead<String> fieldRead = getFactory().createFieldRead();
+        fieldRead.setTarget(xmlConstantsAccess);
+        CtFieldReference fieldRef = xmlConstants.getDeclaredField(constantName);
+        fieldRead.setVariable(fieldRef);
+        return fieldRead;
+    }
+
+    /**
+     * @return An invocation localVar.setAttribute(key, value).
+     */
+    private <T> CtInvocation<T> createSetAttributeInvocation(
+            CtLocalVariable<T> localVar, CtExpression<String> key, CtExpression<Object> value) {
+        CtType<T> builderFactory = localVar.getType().getTypeDeclaration();
+        CtMethod<T> setAttribute =
+                builderFactory.getMethod(
+                        "setAttribute", getFactory().Type().STRING, getFactory().Type().OBJECT);
+        return getFactory()
+                .createInvocation(read(localVar), setAttribute.getReference(), key, value);
+    }
+
+    private <T> CtVariableAccess<T> read(CtLocalVariable<T> localVar) {
+        return getFactory().createVariableRead(localVar.getReference(), localVar.isStatic());
+    }
+
+    private <T> CtTypeReference<T> getReferenceWithImplicitPackage(CtType<T> type) {
+        CtTypeReference<T> ref = type.getReference();
+        ref.getPackage().setImplicit(true);
+        return ref;
     }
 }

--- a/src/main/java/sorald/sonar/Checks.java
+++ b/src/main/java/sorald/sonar/Checks.java
@@ -280,7 +280,8 @@ public class Checks {
                         SMTPSSLServerIdentityCheck.class,
                         ServletMethodsExceptionsThrownCheck.class,
                         SecureXmlTransformerCheck.class,
-                        MutableMembersUsageCheck.class));
+                        MutableMembersUsageCheck.class,
+                        XxeProcessingCheck.class));
 
         typeToChecks.put(
                 CheckType.SECURITY_HOTSPOT,

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderChainedLocalVariable.java
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderChainedLocalVariable.java
@@ -1,0 +1,12 @@
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class DocumentBuilderChainedLocalVariable {
+    public static Document parse(String xmlFile) throws Exception {
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();  // Noncompliant
+        return builder.parse(new InputSource(xmlFile));
+    }
+}

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderChainedLocalVariable.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderChainedLocalVariable.java.expected
@@ -1,0 +1,20 @@
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class DocumentBuilderChainedLocalVariable {
+    public static Document parse(String xmlFile) throws Exception {
+        DocumentBuilder builder = createDocumentBuilder();
+        return builder.parse(new InputSource(xmlFile));
+    }
+
+    private static DocumentBuilder createDocumentBuilder() {
+        DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        return df.newDocumentBuilder();
+    }
+}

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java
@@ -1,0 +1,13 @@
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class DocumentBuilderNoSecurity {
+    public static Document parse(String xmlFile) throws Exception {
+        DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();  // Noncompliant
+        DocumentBuilder builder = df.newDocumentBuilder();
+        return builder.parse(new InputSource(xmlFile));
+    }
+}

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java.expected
@@ -1,6 +1,7 @@
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java.expected
@@ -1,0 +1,15 @@
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class DocumentBuilderNoSecurity {
+    public static Document parse(String xmlFile) throws Exception {
+        DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+        DocumentBuilder builder = df.newDocumentBuilder();
+        return builder.parse(new InputSource(xmlFile));
+    }
+}

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/DocumentBuilderNoSecurity.java.expected
@@ -8,7 +8,7 @@ public class DocumentBuilderNoSecurity {
     public static Document parse(String xmlFile) throws Exception {
         DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
         df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         DocumentBuilder builder = df.newDocumentBuilder();
         return builder.parse(new InputSource(xmlFile));
     }


### PR DESCRIPTION
This PR adds a processor for the rule [XML parsers should not be vulnerable to XXE attacks](https://rules.sonarsource.com/java/type/Vulnerability/RSPEC-2755).

Example transformation:

```diff
+import javax.xml.XMLConstants;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;

 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

 public class DocumentBuilderNoSecurity {
     public static Document parse(String xmlFile) throws Exception {
         DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         DocumentBuilder builder = df.newDocumentBuilder();
         return builder.parse(new InputSource(xmlFile));
     }
 }
```

See #51 for rationale in choosing this processor.

This is heavily WIP at the moment. The rule is complex and can take on many different shapes. For this initial PR, I focus solely on the `DocumentBuilderFactory` variations. The current variations that I know of are:

1. A local variable of type `DocumentBuilderFactory` is declared and initialized. See example transformation above.
    - It's possible that the declaration and initialization are separated, but I've _never_ seen that happen, and so it doesn't seem worth it to account for. As such, the current implementation deals with this case well enough.
2. A local variable of type `DocumentBuilder` is created by chaining `DocumentBuilderFactory.newInstance().newDocumentBuilder()`.
3. Like 1, but instead a field is used.
    - Here, initialization may very well occur in a constructor, and so to be prudent one should attempt to locate any initialization of the field.
4. Like 2, but instead a field is used.

Currently, I've solved case 1. It's rather simple and requires only the addition of a few statements. Cases 2-4 require rewriting the existing code. I think the simplest way to do this is to replace the statements with a method invocation. For example, for case 2, one could substitute `DocumentBuilderFactory.newInstance().newDocumentBuilder()` for `createDocumentBuilder()`, which is defined like so.

```java
private static DocumentBuilder createDocumentBuilder() {
    DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
    df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
    df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
    return df.newDocumentBuilder();
}
```
The tricky part with cases 3 and 4 is that the initialization of the field may very well be separate from the declaration. As such, all initializations must be located and replaced with an invocation to the replacement method.

Finally, there is one more concern: in cases 1 and 3, it's possible that just one of the required attributes is set. We ideally don't want to duplicate them, and so should look for already existing invocations to `df.setAttribute`. Sometimes, the `XMLConstants.FEATURE_SECURE_PROCESSING` is set to `true`. We want to remove that if we find it, as it either does nothing, or is an obscure way to set the two attributes we actually want to set.