### PR TITLE
feat: Add IncompleteProcessor annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The arguments are the following:
         2272: "Iterator.next()" methods should throw "NoSuchElementException"
         2116: "hashCode" and "toString" should not be called on array instances
         1860: Synchronization should not be based on Strings or boxed primitives
+        1444: "public static" fields should be constant
+                (incomplete: does not fix variable naming)
         2184: Math operands should be cast before assignment
         4973: Strings and Boxed types should be compared using "equals()"
         2095: Resources should be closed
@@ -44,15 +46,16 @@ The arguments are the following:
         serializable
         2204: ".equals()" should not be used to test the values of "Atomic"
         classes
+        2142: "InterruptedException" should not be ignored
         1854: Unused assignments should be removed
-        2111: "BigDecimal(double)" should not be used (default: 2116)
+        2111: "BigDecimal(double)" should not be used
 
   --originalFilesPath <originalFilesPath>
         The path to the file or folder to be analyzed and possibly repaired.
 
   [--workspace <workspace>]
-        The path to a folder that will be used as workspace by Sorald,
-        i.e. the path for the output. (default: ./sorald-workspace)
+        The path to a folder that will be used as workspace by Sorald, i.e. the
+        path for the output. (default: ./sorald-workspace)
 
   [--gitRepoPath <gitRepoPath>]
         The path to a git repository directory.
@@ -61,7 +64,7 @@ The arguments are the following:
         Mode for pretty printing the source code: 'NORMAL', which means that all
         source code will be printed and its formatting might change (such as
         indentation), and 'SNIPER', which means that only statements changed
-        towards the repair of sonar rule violations will be printed. (default:
+        towards the repair of Sonar rule violations will be printed. (default:
         SNIPER)
 
   [--fileOutputStrategy <fileOutputStrategy>]
@@ -71,8 +74,7 @@ The arguments are the following:
         (default: CHANGED_ONLY)
 
   [--maxFixesPerRule <maxFixesPerRule>]
-        Max number of fixes per rule. Default: Integer.MAX_VALUE (or all)
-        (default: 2147483647)
+        Max number of fixes per rule. (default: 2147483647)
 
   [--repairStrategy <repairStrategy>]
         Type of repair strategy. DEFAULT - load everything without splitting up
@@ -86,6 +88,10 @@ The arguments are the following:
 
   [-h|--help]
 ```
+
+> **Note:** Some rules (e.g. 1444) are marked as "incomplete". This means that
+> Sorald's repair for a violation of said rule is either partial or
+> situational.
 
 Example of a concrete call to Sorald, in which multiple rule keys are given as input:
 

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -41,7 +41,8 @@ public class Processors {
                     processorClass.getAnnotation(ProcessorAnnotation.class);
             descriptions += "\n" + ruleKeyToProcessor.getKey() + ": " + annotation.description();
 
-            IncompleteProcessor incomplete = processorClass.getAnnotation(IncompleteProcessor.class);
+            IncompleteProcessor incomplete =
+                    processorClass.getAnnotation(IncompleteProcessor.class);
             if (incomplete != null) {
                 descriptions += "\n\t(incomplete: " + incomplete.description() + ")";
             }

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -1,6 +1,5 @@
 package sorald;
 
-import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -41,6 +40,11 @@ public class Processors {
             ProcessorAnnotation annotation =
                     processorClass.getAnnotation(ProcessorAnnotation.class);
             descriptions += "\n" + ruleKeyToProcessor.getKey() + ": " + annotation.description();
+
+            IncompleteProcessor incomplete = processorClass.getAnnotation(IncompleteProcessor.class);
+            if (incomplete != null) {
+                descriptions += "\n\t(incomplete: " + incomplete.description() + ")";
+            }
         }
         return descriptions;
     }

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -6,26 +6,22 @@ import java.util.Map;
 import java.util.Set;
 import org.reflections.Reflections;
 import sorald.processor.SoraldAbstractProcessor;
+import sorald.sonar.IncompleteProcessor;
 
 public class Processors {
 
     private static final Map<Integer, Class<? extends SoraldAbstractProcessor>>
             RULE_KEY_TO_PROCESSOR = init();
 
-    private static Map init() {
+    private static Map<Integer, Class<? extends SoraldAbstractProcessor>> init() {
         Map<Integer, Class<? extends SoraldAbstractProcessor>> TEMP_RULE_KEY_TO_PROCESSOR =
                 new HashMap<>();
         Reflections reflections = new Reflections(Constants.PROCESSOR_PACKAGE);
         Set<Class<? extends SoraldAbstractProcessor>> allProcessors =
                 reflections.getSubTypesOf(SoraldAbstractProcessor.class);
         for (Class<? extends SoraldAbstractProcessor> processor : allProcessors) {
-            Annotation[] annotations = processor.getAnnotations();
-            for (Annotation annotation : annotations) {
-                if (annotation instanceof ProcessorAnnotation) {
-                    ProcessorAnnotation myAnnotation = (ProcessorAnnotation) annotation;
-                    TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(myAnnotation.key(), processor);
-                }
-            }
+            ProcessorAnnotation annotation = processor.getAnnotation(ProcessorAnnotation.class);
+            TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(annotation.key(), processor);
         }
         return TEMP_RULE_KEY_TO_PROCESSOR;
     }
@@ -39,16 +35,12 @@ public class Processors {
 
     public static String getRuleDescriptions() {
         String descriptions = "";
-        for (Map.Entry ruleKeyToProcessor : RULE_KEY_TO_PROCESSOR.entrySet()) {
-            Class processorClass = (Class) ruleKeyToProcessor.getValue();
-            Annotation[] annotations = processorClass.getAnnotations();
-            for (Annotation annotation : annotations) {
-                if (annotation instanceof ProcessorAnnotation) {
-                    ProcessorAnnotation myAnnotation = (ProcessorAnnotation) annotation;
-                    descriptions +=
-                            "\n" + ruleKeyToProcessor.getKey() + ": " + myAnnotation.description();
-                }
-            }
+        for (Map.Entry<Integer, Class<? extends SoraldAbstractProcessor>> ruleKeyToProcessor :
+                RULE_KEY_TO_PROCESSOR.entrySet()) {
+            Class<? extends SoraldAbstractProcessor> processorClass = ruleKeyToProcessor.getValue();
+            ProcessorAnnotation annotation =
+                    processorClass.getAnnotation(ProcessorAnnotation.class);
+            descriptions += "\n" + ruleKeyToProcessor.getKey() + ": " + annotation.description();
         }
         return descriptions;
     }

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -1,9 +1,11 @@
 package sorald.processor;
 
 import sorald.ProcessorAnnotation;
+import sorald.sonar.IncompleteProcessor;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
 
+@IncompleteProcessor(description = "does not fix variable naming")
 @ProcessorAnnotation(key = 1444, description = "\"public static\" fields should be constant")
 public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProcessor<CtField<?>> {
     @Override

--- a/src/main/java/sorald/sonar/IncompleteProcessor.java
+++ b/src/main/java/sorald/sonar/IncompleteProcessor.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 /** Annotation to mark that a processor is only a partial fix for its associated rule. */
 public @interface IncompleteProcessor {
     /** @return A description as to why and how the processor is incomplete. */
-    String getDescription();
+    String description();
 }

--- a/src/main/java/sorald/sonar/IncompleteProcessor.java
+++ b/src/main/java/sorald/sonar/IncompleteProcessor.java
@@ -1,0 +1,14 @@
+package sorald.sonar;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+/** Annotation to mark that a processor is only a partial fix for its associated rule. */
+public @interface IncompleteProcessor {
+    /** @return A description as to why and how the processor is incomplete. */
+    String getDescription();
+}


### PR DESCRIPTION
Fix #189 

As explained in #189, many processors will be incomplete fixes for their associated rules. We need to make this known both to ourselves (for further development), and to users (to avoid misunderstandings). This PR adds the `IncompleteProcessor` annotation, which can be applied like so.

```java
@IncompleteProcessor(description = "does not fix variable naming")
@ProcessorAnnotation(key = 1444, description = "\"public static\" fields should be constant")
public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProcessor<CtField<?>> {
```

The description is then added to the `--help` message in the CLI.

```bash
Arguments: 

  [--ruleKeys ruleKeys1,ruleKeys2,...,ruleKeysN ]
        Choose one or more of the following rule keys (use ',' to separate
        multiple keys):
        2272: "Iterator.next()" methods should throw "NoSuchElementException"
        1860: Synchronization should not be based on Strings or boxed primitives
        2116: "hashCode" and "toString" should not be called on array instances
        1444: "public static" fields should be constant
                (incomplete: does not fix variable naming)
        2184: Math operands should be cast before assignment
```

The README has also been updated to reflect his new notion of incomplete processors.