### PR TITLE
fix: Avoid processing directories with .java extension as files

### DIFF
--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -1,8 +1,12 @@
 package sorald;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class FileUtils {
 
@@ -51,5 +55,34 @@ public class FileUtils {
             }
         }
         return directoryToBeDeleted.delete();
+    }
+
+    /**
+     * Search for files with the given file extension in the given directory, as well as recursively
+     * in subdirectories.
+     *
+     * @param directory A directory
+     * @param ext A file extension including the leading dot
+     * @return All files in the given directory or any subdirectory with a matching extension
+     */
+    public static List<File> findFilesByExtension(File directory, String ext) throws IOException {
+        if (!directory.isDirectory()) {
+            throw new IllegalArgumentException(directory.toString() + " is not a directory");
+        }
+        return Files.walk(directory.toPath())
+                .map(Path::toFile)
+                .filter(File::isFile)
+                .filter(f -> getExtension(f).equals(ext))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @param file A file
+     * @return The file extension of the given file including the dot, or the empty string if it
+     *     has no extension
+     */
+    public static String getExtension(File file) {
+        String[] parts = file.getName().split("\\.");
+        return parts.length <= 1 ? "" : parts[parts.length - 1];
     }
 }

--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -83,6 +83,6 @@ public class FileUtils {
      */
     public static String getExtension(File file) {
         String[] parts = file.getName().split("\\.");
-        return parts.length <= 1 ? "" : parts[parts.length - 1];
+        return parts.length <= 1 ? "" : "." + parts[parts.length - 1];
     }
 }

--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class FileUtils {
 
@@ -69,17 +70,18 @@ public class FileUtils {
         if (!directory.isDirectory()) {
             throw new IllegalArgumentException(directory.toString() + " is not a directory");
         }
-        return Files.walk(directory.toPath())
-                .map(Path::toFile)
-                .filter(File::isFile)
-                .filter(f -> getExtension(f).equals(ext))
-                .collect(Collectors.toList());
+        try (Stream<Path> files = Files.walk(directory.toPath())) {
+            return files.map(Path::toFile)
+                    .filter(File::isFile)
+                    .filter(f -> getExtension(f).equals(ext))
+                    .collect(Collectors.toList());
+        }
     }
 
     /**
      * @param file A file
-     * @return The file extension of the given file including the dot, or the empty string if it
-     *     has no extension
+     * @return The file extension of the given file including the dot, or the empty string if it has
+     *     no extension
      */
     public static String getExtension(File file) {
         String[] parts = file.getName().split("\\.");

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -39,10 +39,10 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
             if (file.isFile()) {
                 filesToScan.add(file.getAbsolutePath());
             } else {
-                try (Stream<Path> walk = Files.walk(Paths.get(file.getAbsolutePath()))) {
+                try {
                     filesToScan =
-                            walk.map(x -> x.toFile().getAbsolutePath())
-                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
+                            FileUtils.findFilesByExtension(file, Constants.JAVA_EXT).stream()
+                                    .map(File::getAbsolutePath)
                                     .collect(Collectors.toList());
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/src/test/java/sorald/FileUtilsTest.java
+++ b/src/test/java/sorald/FileUtilsTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -21,11 +23,18 @@ public class FileUtilsTest {
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
                 new File(Constants.PATH_TO_RESOURCES_FOLDER), workdir);
+        Path javaExtDirpath = workdir.toPath().resolve("randomdir.java");
+        Path javaFileInJavaExtDirpath = javaExtDirpath.resolve("SomeClass.java");
+        Files.createDirectory(workdir.toPath().resolve("randomdir.java"));
+        Files.createFile(javaFileInJavaExtDirpath);
+
 
         // act
         List<File> files = FileUtils.findFilesByExtension(workdir, Constants.JAVA_EXT);
 
         // assert
+        assertTrue(files.stream().anyMatch(f -> f.toPath().equals(javaFileInJavaExtDirpath)));
+        assertFalse(files.stream().anyMatch(f -> f.toPath().equals(javaExtDirpath)));
         assertFalse(files.stream().anyMatch(f -> !f.isFile()));
     }
 

--- a/src/test/java/sorald/FileUtilsTest.java
+++ b/src/test/java/sorald/FileUtilsTest.java
@@ -1,0 +1,59 @@
+package sorald;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class FileUtilsTest {
+
+    @Test
+    public void findFilesByExtension_onlyReturnsFiles_whenDirectoriesHaveMatchingExtensions(
+            @TempDir File workdir) throws Exception {
+        // arrange
+        org.apache.commons.io.FileUtils.copyDirectory(
+                new File(Constants.PATH_TO_RESOURCES_FOLDER), workdir);
+
+        // act
+        List<File> files = FileUtils.findFilesByExtension(workdir, Constants.JAVA_EXT);
+
+        // assert
+        assertFalse(files.stream().anyMatch(f -> !f.isFile()));
+    }
+
+    @Test
+    public void findFilesByExtension_onlyReturnsFilesWithMatchingExtension() throws IOException {
+        // act
+        List<File> files =
+                FileUtils.findFilesByExtension(
+                        new File(Constants.PATH_TO_RESOURCES_FOLDER), Constants.JAVA_EXT);
+
+        // assert
+        Predicate<File> isJavaFile =
+                f -> f.isFile() && FileUtils.getExtension(f).equals(Constants.JAVA_EXT);
+        assertTrue(files.stream().allMatch(isJavaFile));
+    }
+
+    @Test
+    public void findFilesByExtension_throws_whenDirectoryIsNotADirectory() {
+        File notADirectory = new File("definitely/not/a/directory.nope");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FileUtils.findFilesByExtension(notADirectory, ""),
+                notADirectory.toString() + " is not a directory");
+    }
+
+    @Test
+    public void getExtension_returnsEmptyString_whenFileLacksExtension() {
+        File fileWithoutExtension = new File("path/to/some/file");
+        assertEquals("", FileUtils.getExtension(fileWithoutExtension));
+    }
+}

--- a/src/test/java/sorald/FileUtilsTest.java
+++ b/src/test/java/sorald/FileUtilsTest.java
@@ -1,8 +1,5 @@
 package sorald;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class FileUtilsTest {
 
@@ -27,7 +26,6 @@ public class FileUtilsTest {
         Path javaFileInJavaExtDirpath = javaExtDirpath.resolve("SomeClass.java");
         Files.createDirectory(workdir.toPath().resolve("randomdir.java"));
         Files.createFile(javaFileInJavaExtDirpath);
-
 
         // act
         List<File> files = FileUtils.findFilesByExtension(workdir, Constants.JAVA_EXT);

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -104,16 +104,23 @@ public class ProcessorTestHelper {
 
     /** Run sorald on the given test case. */
     static void runSorald(ProcessorTestCase<?> testCase) throws Exception {
-        String originalFileAbspath = testCase.nonCompliantFile.toPath().toAbsolutePath().toString();
-        RuleVerifier.verifyHasIssue(originalFileAbspath, testCase.createCheckInstance());
+        RuleVerifier.verifyHasIssue(
+                testCase.nonCompliantFile.getAbsolutePath(), testCase.createCheckInstance());
+        runSorald(testCase.nonCompliantFile, testCase.checkClass);
+    }
 
-        boolean brokenWithSniper = BROKEN_WITH_SNIPER.contains(testCase.checkClass);
+    /** Run sorald on the given file with the given checkClass * */
+    static void runSorald(File originaFilesPath, Class<? extends JavaFileScanner> checkClass)
+            throws Exception {
+        String originalFileAbspath = originaFilesPath.getAbsolutePath();
+
+        boolean brokenWithSniper = BROKEN_WITH_SNIPER.contains(checkClass);
         Main.main(
                 new String[] {
                     Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
                     originalFileAbspath,
                     Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
-                    testCase.ruleKey,
+                    Checks.getRuleKey(checkClass),
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
                     Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY,


### PR DESCRIPTION
Fix #204 

This fixes a crash that occurs when you apply Sorald to a project that has a directory ending in `.java`.

This also applies to the miner, but I'll fix that separately.