### PR TITLE
chore: Switch to Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It can currently repair violations of [15+ rules](/docs/HANDLED_RULES.md).
 
 ### Prerequisites 
 
-A JDK (java 1.8)
+A JDK (Java 11+)
 
 ### Usage
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,9 +76,6 @@ We have an automatically enforced code style in sorald, and your code will not
 pass CI if it does not adhere to it. To ensure that your code does adhere to it,
 run `mvn spotless:apply`, and then commit any changes the formatter makes.
 
-> **Note:** This step requires you to have the Maven build system installed, as
-> well as JDK11+.
-
 5) Update documentation
 
 Your processor is done, it's passing the minimum tests, so now you can update the documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         </dependency>
     </dependencies>
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>


### PR DESCRIPTION
Fix #211 

We're dropping support for Java 8 and now only support Java 11+. This PR updates the pom and related documentation.