### PR TITLE
feat: Add support for XMLInputFactory in XxeProcessingProcessor

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -410,6 +410,7 @@ Currently, we target the following types:
 
 * `DocumentBuilderFactory`
 * `TransformerFactory`
+* `XMLInputFactory`
 
 The transformation is highly similar regardless of type, and consists of replacing
 factory creation with a call to a helper method that creates a "safe" factory. For
@@ -436,7 +437,8 @@ factory creation with a call to a helper method that creates a "safe" factory. F
 
 The precise attributes set in `createTYPEFACTORY` depends on the particular
 factory used. For example, with `TransformerFactory`, `ACCESS_EXTERNAL_SCHEMA`
-is replaced with `ACCESS_EXTERNAL_STYLESHEET`.
+is replaced with `ACCESS_EXTERNAL_STYLESHEET`. The method name to set attributes
+also varies, but is typically either `setAttribute` or `setProperty`.
 
 This is just a small part of rule 2755, and we are working on adding support
 for other cases. The repair currently cannot handle builders and factories in

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -35,6 +35,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
 
     private static final String DOCUMENT_BUILDER_FACTORY = "DocumentBuilderFactory";
     private static final String TRANSFORMER_FACTORY = "TransformerFactory";
+    private static final String XML_INPUT_FACTORY = "XMLInputFactory";
 
     @Override
     public boolean isToBeProcessed(CtInvocation<?> candidate) {
@@ -43,7 +44,8 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
 
     /** Check if the target of the invocation is of a type currently supported by this processor */
     private static boolean isSupported(CtInvocation<?> candidate) {
-        List<String> supportedNames = Arrays.asList(DOCUMENT_BUILDER_FACTORY, TRANSFORMER_FACTORY);
+        List<String> supportedNames =
+                Arrays.asList(DOCUMENT_BUILDER_FACTORY, TRANSFORMER_FACTORY, XML_INPUT_FACTORY);
         return supportedNames.contains(candidate.getType().getSimpleName());
     }
 
@@ -89,10 +91,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
 
         List<CtStatement> statements = new ArrayList<>();
         statements.add(builderFactoryVariable);
-        statements.addAll(
-                setXMLConstantsAttributesToEmptyString(
-                        builderFactoryVariable,
-                        getXMLConstantNamesFor(newInstanceInvocation.getType())));
+        statements.addAll(setXMLConstantsAttributesToEmptyString(builderFactoryVariable));
 
         return createPrivateStaticMethod(
                 "create" + newInstanceInvocation.getType().getSimpleName(),
@@ -108,12 +107,12 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
      * </code>
      */
     private List<? extends CtInvocation<?>> setXMLConstantsAttributesToEmptyString(
-            CtLocalVariable<?> localVar, List<String> xmlConstantsAttrs) {
+            CtLocalVariable<?> localVar) {
         CtLiteral<Object> emptyString = getFactory().createLiteral("");
         Function<CtFieldRead<String>, ? extends CtInvocation<?>> setAttrToEmptyString =
                 (xmlAttrRead) ->
                         createSetAttributeInvocation(read(localVar), xmlAttrRead, emptyString);
-        return xmlConstantsAttrs.stream()
+        return getXMLConstantNamesFor(localVar.getType()).stream()
                 .map(this::readXmlConstant)
                 .map(setAttrToEmptyString)
                 .collect(Collectors.toList());
@@ -190,13 +189,17 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
         return fieldRead;
     }
 
-    /** @return An invocation target.setAttribute(key, value). */
+    /**
+     * @return An invocation target.SET_ATTRIBUTE(key, value), where the exact name of SET_ATTRIBUTE
+     *     depends on the target type.
+     */
     private <T> CtInvocation<T> createSetAttributeInvocation(
             CtExpression<T> target, CtExpression<String> key, CtExpression<Object> value) {
         CtType<T> builderFactory = target.getType().getTypeDeclaration();
+        String setAttrMethodName = getAttributeSetterMethodName(target.getType());
         CtMethod<T> setAttribute =
                 builderFactory.getMethod(
-                        "setAttribute", getFactory().Type().STRING, getFactory().Type().OBJECT);
+                        setAttrMethodName, getFactory().Type().STRING, getFactory().Type().OBJECT);
         return getFactory().createInvocation(target, setAttribute.getReference(), key, value);
     }
 
@@ -221,5 +224,18 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
         return type.getSimpleName().equals(TRANSFORMER_FACTORY)
                 ? Arrays.asList(ACCESS_EXTERNAL_DTD, ACCESS_EXTERNAL_STYLESHEET)
                 : Arrays.asList(ACCESS_EXTERNAL_DTD, ACCESS_EXTERNAL_SCHEMA);
+    }
+
+    private static String getAttributeSetterMethodName(CtTypeReference<?> type) {
+        switch (type.getSimpleName()) {
+            case DOCUMENT_BUILDER_FACTORY:
+            case TRANSFORMER_FACTORY:
+                return "setAttribute";
+            case XML_INPUT_FACTORY:
+                return "setProperty";
+            default:
+                throw new IllegalArgumentException(
+                        "Missing method name for " + type.getSimpleName());
+        }
     }
 }

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureXMLInputFactoryUsage.java
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureXMLInputFactoryUsage.java
@@ -1,0 +1,17 @@
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+
+public class InsecureXMLInputFactoryUsage {
+    public static String parse(String xmlFile) throws FileNotFoundException, XMLStreamException {
+        XMLInputFactory factory = XMLInputFactory.newInstance();  // Noncompliant
+        XMLEventReader eventReader = factory.createXMLEventReader(new FileReader(xmlFile));
+        return eventReader.getElementText();
+    }
+
+    public static String parseChained(String xmlFile) throws FileNotFoundException, XMLStreamException {
+        return XMLInputFactory.newInstance().createXMLEventReader(new FileReader(xmlFile)).getElementText(); // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureXMLInputFactoryUsage.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureXMLInputFactoryUsage.java.expected
@@ -1,0 +1,25 @@
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+
+public class InsecureXMLInputFactoryUsage {
+    public static String parse(String xmlFile) throws FileNotFoundException, XMLStreamException {
+        XMLInputFactory factory = createXMLInputFactory();
+        XMLEventReader eventReader = factory.createXMLEventReader(new FileReader(xmlFile));
+        return eventReader.getElementText();
+    }
+
+    public static String parseChained(String xmlFile) throws FileNotFoundException, XMLStreamException {
+        return createXMLInputFactory().createXMLEventReader(new FileReader(xmlFile)).getElementText();
+    }
+
+    private static XMLInputFactory createXMLInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        return factory;
+    }
+}


### PR DESCRIPTION
Working toward #194 

This PR adds support for the `XMLInputFactory` in the `XxeProcessingProcessor` which handles the rule [XML parsers should not be vulnerable to XXE attacks](https://rules.sonarsource.com/java/type/Vulnerability/RSPEC-2755).

The transformation is identical to the one in #201, with the one exception that the setter method is called `setProperty` instead of `setAttribute`.