### PR TITLE
test: Parameterize multi-rule test case for all repair strategies

### DIFF
--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -1,6 +1,7 @@
 package sorald;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
 import org.sonar.java.checks.CastArithmeticOperandCheck;
 import org.sonar.java.checks.EqualsOnAtomicClassCheck;
@@ -8,8 +9,9 @@ import sorald.sonar.RuleVerifier;
 
 public class MultipleProcessorsTest {
 
-    @Test
-    public void test_threeExistingRules() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"DEFAULT", "SEGMENT"})
+    public void test_threeExistingRules(String repairStrategy) throws Exception {
         String fileName = "MultipleProcessors.java";
         String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
         String pathToRepairedFile =
@@ -22,7 +24,9 @@ public class MultipleProcessorsTest {
                     Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
                     "2111,2184,2204",
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE
+                    Constants.SORALD_WORKSPACE,
+                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    repairStrategy
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);
         RuleVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());

--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -11,7 +11,8 @@ public class MultipleProcessorsTest {
 
     @ParameterizedTest
     @EnumSource(RepairStrategy.class)
-    public void allStrategies_canApplyMultipleProcessors(RepairStrategy repairStrategy) throws Exception {
+    public void allStrategies_canApplyMultipleProcessors(RepairStrategy repairStrategy)
+            throws Exception {
         String fileName = "MultipleProcessors.java";
         String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
         String pathToRepairedFile =

--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -1,7 +1,7 @@
 package sorald;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
 import org.sonar.java.checks.CastArithmeticOperandCheck;
 import org.sonar.java.checks.EqualsOnAtomicClassCheck;
@@ -10,8 +10,8 @@ import sorald.sonar.RuleVerifier;
 public class MultipleProcessorsTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"DEFAULT", "SEGMENT"})
-    public void test_threeExistingRules(String repairStrategy) throws Exception {
+    @EnumSource(RepairStrategy.class)
+    public void allStrategies_canApplyMultipleProcessors(RepairStrategy repairStrategy) throws Exception {
         String fileName = "MultipleProcessors.java";
         String pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER + fileName;
         String pathToRepairedFile =
@@ -26,7 +26,7 @@ public class MultipleProcessorsTest {
                     Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
                     Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
-                    repairStrategy
+                    repairStrategy.name()
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);
         RuleVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());


### PR DESCRIPTION
Fix #170 

Parameterizes the multi-rule test such that it tries to repair multiple rules with both repair strategies. Currently, that means that it tests both the default and the segment strategy, whereas before it only tested the default strategy.

I've tried this test case in relation to the merge of #220 , and it fails before and passes after. So, that redesign fixed the problem.