### PR TITLE
fix(rule 2755): Remove handling of setting of FEATURE_SECURE_PROCESSING

### DIFF
--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -14,13 +13,11 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import sorald.annotations.IncompleteProcessor;
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.*;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.Filter;
 
 @IncompleteProcessor(
         description =

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -30,7 +30,6 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
     private static final String ACCESS_EXTERNAL_DTD = "ACCESS_EXTERNAL_DTD";
     private static final String ACCESS_EXTERNAL_SCHEMA = "ACCESS_EXTERNAL_SCHEMA";
     private static final String ACCESS_EXTERNAL_STYLESHEET = "ACCESS_EXTERNAL_STYLESHEET";
-    private static final String FEATURE_SECURE_PROCESSING = "FEATURE_SECURE_PROCESSING";
 
     private static final String DOCUMENT_BUILDER_FACTORY = "DocumentBuilderFactory";
     private static final String TRANSFORMER_FACTORY = "TransformerFactory";

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java
@@ -1,9 +1,4 @@
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -20,12 +15,5 @@ public class SetFeatureSecureProcessing {
         StringWriter writer = new StringWriter();
         transformer.transform(new StreamSource(xml), new StreamResult(writer));
         return writer.toString();
-    }
-
-    public static Document parse(String xmlFile) throws Exception {
-        DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();  // Noncompliant
-        df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        DocumentBuilder builder = df.newDocumentBuilder();
-        return builder.parse(new InputSource(xmlFile));
     }
 }

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java
@@ -1,4 +1,9 @@
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
 import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -15,5 +20,12 @@ public class SetFeatureSecureProcessing {
         StringWriter writer = new StringWriter();
         transformer.transform(new StreamSource(xml), new StreamResult(writer));
         return writer.toString();
+    }
+
+    public static Document parse(String xmlFile) throws Exception {
+        DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();  // Noncompliant
+        df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        DocumentBuilder builder = df.newDocumentBuilder();
+        return builder.parse(new InputSource(xmlFile));
     }
 }

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
@@ -4,9 +4,7 @@ import org.xml.sax.InputSource;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -16,6 +14,7 @@ import java.io.StringWriter;
 public class SetFeatureSecureProcessing {
     public static String transform(String xslt, String xml) throws TransformerException {
         TransformerFactory transformerFactory = createTransformerFactory();
+        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
 
         StringWriter writer = new StringWriter();
@@ -25,21 +24,20 @@ public class SetFeatureSecureProcessing {
 
     public static Document parse(String xmlFile) throws Exception {
         DocumentBuilderFactory df = createDocumentBuilderFactory();  // Noncompliant
+        df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder builder = df.newDocumentBuilder();
         return builder.parse(new InputSource(xmlFile));
     }
 
-    private static TransformerFactory createTransformerFactory() throws TransformerConfigurationException {
+    private static TransformerFactory createTransformerFactory() {
         TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         return factory;
     }
 
-    private static DocumentBuilderFactory createDocumentBuilderFactory() throws ParserConfigurationException {
+    private static DocumentBuilderFactory createDocumentBuilderFactory() {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         return factory;

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
@@ -9,6 +9,7 @@ import java.io.StringWriter;
 public class SetFeatureSecureProcessing {
     public static String transform(String xslt, String xml) throws TransformerException {
         TransformerFactory transformerFactory = createTransformerFactory();
+        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
 
         StringWriter writer = new StringWriter();
@@ -18,7 +19,6 @@ public class SetFeatureSecureProcessing {
 
     private static TransformerFactory createTransformerFactory() {
         TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         return factory;

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
@@ -1,12 +1,5 @@
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -23,25 +16,11 @@ public class SetFeatureSecureProcessing {
         return writer.toString();
     }
 
-    public static Document parse(String xmlFile) throws Exception {
-        DocumentBuilderFactory df = createDocumentBuilderFactory();  // Noncompliant
-        DocumentBuilder builder = df.newDocumentBuilder();
-        return builder.parse(new InputSource(xmlFile));
-    }
-
-    private static TransformerFactory createTransformerFactory() throws TransformerConfigurationException {
+    private static TransformerFactory createTransformerFactory() {
         TransformerFactory factory = TransformerFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-        return factory;
-    }
-
-    private static DocumentBuilderFactory createDocumentBuilderFactory() throws ParserConfigurationException {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         return factory;
     }
 }

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
@@ -1,5 +1,12 @@
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
 import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -16,11 +23,25 @@ public class SetFeatureSecureProcessing {
         return writer.toString();
     }
 
-    private static TransformerFactory createTransformerFactory() {
+    public static Document parse(String xmlFile) throws Exception {
+        DocumentBuilderFactory df = createDocumentBuilderFactory();  // Noncompliant
+        DocumentBuilder builder = df.newDocumentBuilder();
+        return builder.parse(new InputSource(xmlFile));
+    }
+
+    private static TransformerFactory createTransformerFactory() throws TransformerConfigurationException {
         TransformerFactory factory = TransformerFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        return factory;
+    }
+
+    private static DocumentBuilderFactory createDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         return factory;
     }
 }

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/SetFeatureSecureProcessing.java.expected
@@ -4,7 +4,9 @@ import org.xml.sax.InputSource;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -14,7 +16,6 @@ import java.io.StringWriter;
 public class SetFeatureSecureProcessing {
     public static String transform(String xslt, String xml) throws TransformerException {
         TransformerFactory transformerFactory = createTransformerFactory();
-        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
 
         StringWriter writer = new StringWriter();
@@ -24,20 +25,21 @@ public class SetFeatureSecureProcessing {
 
     public static Document parse(String xmlFile) throws Exception {
         DocumentBuilderFactory df = createDocumentBuilderFactory();  // Noncompliant
-        df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder builder = df.newDocumentBuilder();
         return builder.parse(new InputSource(xmlFile));
     }
 
-    private static TransformerFactory createTransformerFactory() {
+    private static TransformerFactory createTransformerFactory() throws TransformerConfigurationException {
         TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         return factory;
     }
 
-    private static DocumentBuilderFactory createDocumentBuilderFactory() {
+    private static DocumentBuilderFactory createDocumentBuilderFactory() throws ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         return factory;


### PR DESCRIPTION
Fix #234 

This PR removes the feature introduced by #219, which was found to be entirely broken (see #234). Unfortunately, #219 wasn't squashed, so simply reverting it was inconvenient.

We will probably want to revisit the topic of checked exceptions later, but I don't think it's a priority until we find the need to work with checked exceptions in multiple processors.