### PR TITLE
experiment: Add GitHub issue search script

### DIFF
--- a/experimentation/tools/issue_finder/README.md
+++ b/experimentation/tools/issue_finder/README.md
@@ -1,0 +1,55 @@
+# GitHub issue search script
+This is a small wrapper script around GitHub's [issue search
+API](https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-issues-and-pull-requests).
+ 
+## Requirements
+Requires Python 3.8+
+
+## Install
+Install the packages listed in `requirements.txt`.
+
+```bash
+$ python3 -m pip install -r requirements.txt
+```
+
+> **Note:** You should do this in a virtual environment to avoid polluting
+> system-wide or user packages.
+
+## Usage
+Run like so.
+
+```bash
+$ python3 main.py --token <YOUR_GITHUB_TOKEN> --query <YOUR_QUERY>
+```
+
+There are a bunch of other options you can set as well, run with the `--help`
+option for complete usage. Here's an example invocation searching for
+the keyword "sonar".
+
+```bash
+$ python3 main.py --token xxxxxxxx --query sonar
+https://github.com/pmd/pmd/issues/2942
+https://github.com/SpoonLabs/sorald/issues/226
+https://github.com/javaparser/javaparser/issues/2937
+https://github.com/springdoc/springdoc-openapi-maven-plugin/issues/19
+https://github.com/pmd/pmd/issues/2928
+https://github.com/cnescatlab/sonar-cnes-report/issues/170
+https://github.com/DPigeon/Money-Tree/issues/147
+https://github.com/Riverside-Software/sonar-openedge/issues/856
+https://github.com/pau101/Fairy-Lights/issues/94
+https://github.com/Tencent/QMUI_Android/issues/1032
+https://github.com/insideapp-oss/sonar-flutter/issues/9
+https://github.com/SonarSource/sonar-css/issues/297
+https://github.com/SonarSource/SonarJS/issues/1918
+https://github.com/sonar-intellij-plugin/sonar-intellij-plugin/issues/83
+https://github.com/find-sec-bugs/find-sec-bugs/issues/617
+https://github.com/Nesreenmoh/sfg-pet-clinic/issues/82
+https://github.com/Nesreenmoh/sfg-pet-clinic/issues/81
+[...]
+```
+
+For more stuff you can do with the query string, see [the GitHub
+docs](https://docs.github.com/en/free-pro-team@latest/github/searching-for-information-on-github/searching-issues-and-pull-requests).
+
+> **Warning:** This script uses up API requests quite rapidly, and you'll hit
+> the rate limit before you know it.

--- a/experimentation/tools/issue_finder/main.py
+++ b/experimentation/tools/issue_finder/main.py
@@ -1,0 +1,90 @@
+"""Script for finding issues by keyword (searching title and body)."""
+import pathlib
+import argparse
+import sys
+import re
+
+from typing import List
+
+import github
+
+# parts to search in
+TITLE = "title"
+BODY = "body"
+ALL = "all"
+
+GITHUB_API_URL = "https://api.github.com"
+
+
+def main():
+    parsed_args = create_parser().parse_args(sys.argv[1:])
+
+    repo_fullnames = [
+        stripped_line
+        for line in parsed_args.repo_list.read_text(
+            encoding=sys.getdefaultencoding()
+        ).split("\n")
+        if (stripped_line := line.strip())
+    ]
+
+    gh = github.Github(login_or_token=parsed_args.token, base_url=GITHUB_API_URL)
+
+    search_in_title = parsed_args.search_in in (TITLE, ALL)
+    search_in_body = parsed_args.search_in in (BODY, ALL)
+
+    for repo_fullname in repo_fullnames:
+        repo = gh.get_repo(repo_fullname)
+        matching_issues = (
+            issue
+            for issue in repo.get_issues(state="open")
+            if issue_is_match(
+                issue, ["eventually realize"], search_in_title, search_in_body
+            )
+        )
+
+        for issue in matching_issues:
+            print(f"Match: {repo_fullname}#{issue.number}")
+
+
+def issue_is_match(
+    issue: github.Issue.Issue,
+    keywords: List[str],
+    search_in_title: bool,
+    search_in_body: bool,
+):
+    assert search_in_title or search_in_body
+
+    text = f'{(issue.title if search_in_title else "")}\n{(issue.body if search_in_body else "")}'
+    regex = "|".join(keywords)
+
+    return re.search(regex, text, re.IGNORECASE)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Tool to search GitHub issues for keywords.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-t", "--token", help="a GitHub personal access token", required=True
+    )
+    parser.add_argument(
+        "-r",
+        "--repo-list",
+        help="a plaintext file with GitHub repositories, one on each line on "
+        "the form <OWNER>/<REPO> (e.g. spoonlabs/sorald)",
+        required=True,
+        type=pathlib.Path,
+    )
+    parser.add_argument(
+        "--search-in",
+        help="which part of the issues to search for the keyword(s) in",
+        choices=[TITLE, BODY, ALL],
+        default=TITLE,
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/experimentation/tools/issue_finder/main.py
+++ b/experimentation/tools/issue_finder/main.py
@@ -1,17 +1,13 @@
-"""Script for finding issues by keyword (searching title and body)."""
+"""Script for searching the GitHub issues API."""
 import pathlib
 import argparse
 import sys
 import re
+import logging
 
 from typing import List
 
 import github
-
-# parts to search in
-TITLE = "title"
-BODY = "body"
-ALL = "all"
 
 GITHUB_API_URL = "https://api.github.com"
 
@@ -19,69 +15,53 @@ GITHUB_API_URL = "https://api.github.com"
 def main():
     parsed_args = create_parser().parse_args(sys.argv[1:])
 
-    repo_fullnames = [
-        stripped_line
-        for line in parsed_args.repo_list.read_text(
-            encoding=sys.getdefaultencoding()
-        ).split("\n")
-        if (stripped_line := line.strip())
-    ]
-
     gh = github.Github(login_or_token=parsed_args.token, base_url=GITHUB_API_URL)
 
-    search_in_title = parsed_args.search_in in (TITLE, ALL)
-    search_in_body = parsed_args.search_in in (BODY, ALL)
+    search = gh.search_issues(
+        parsed_args.query,
+        sort=parsed_args.sort_by,
+        order=parsed_args.order,
+        language=parsed_args.language,
+        state="open",
+        type="issue",
+    )
 
-    for repo_fullname in repo_fullnames:
-        repo = gh.get_repo(repo_fullname)
-        matching_issues = (
-            issue
-            for issue in repo.get_issues(state="open")
-            if issue_is_match(
-                issue, ["eventually realize"], search_in_title, search_in_body
-            )
-        )
-
-        for issue in matching_issues:
-            print(f"Match: {repo_fullname}#{issue.number}")
-
-
-def issue_is_match(
-    issue: github.Issue.Issue,
-    keywords: List[str],
-    search_in_title: bool,
-    search_in_body: bool,
-):
-    assert search_in_title or search_in_body
-
-    text = f'{(issue.title if search_in_title else "")}\n{(issue.body if search_in_body else "")}'
-    regex = "|".join(keywords)
-
-    return re.search(regex, text, re.IGNORECASE)
+    for issue in search:
+        print(issue.html_url)
 
 
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Tool to search GitHub issues for keywords.",
+        description="Tool to search GitHub issues for keywords",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
+    parser.add_argument("-q", "--query", help="a free-form search query", required=True)
     parser.add_argument(
-        "-t", "--token", help="a GitHub personal access token", required=True
-    )
-    parser.add_argument(
-        "-r",
-        "--repo-list",
-        help="a plaintext file with GitHub repositories, one on each line on "
-        "the form <OWNER>/<REPO> (e.g. spoonlabs/sorald)",
+        "-t",
+        "--token",
+        help="a GitHub personal access token (no scopes required)",
         required=True,
-        type=pathlib.Path,
     )
     parser.add_argument(
-        "--search-in",
-        help="which part of the issues to search for the keyword(s) in",
-        choices=[TITLE, BODY, ALL],
-        default=TITLE,
+        "-l",
+        "--language",
+        help="the programming language to search for",
+        default="java",
+    )
+    parser.add_argument(
+        "-s",
+        "--sort-by",
+        help="what attribute to sort issues by",
+        choices="comments created updated".split(),
+        default="updated",
+    )
+    parser.add_argument(
+        "-o",
+        "--order",
+        help="order of the results",
+        choices="asc desc".split(),
+        default="desc",
     )
     return parser
 

--- a/experimentation/tools/issue_finder/requirements.txt
+++ b/experimentation/tools/issue_finder/requirements.txt
@@ -1,0 +1,1 @@
+pygithub


### PR DESCRIPTION
Fix #231 

This PR adds a script that's just a thin wrapper around GitHub's search API. See the added README for usage.