### PR TITLE
chore: Bump Spoon version to 8.4.0-beta-5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>8.3.0</version>
+            <version>8.4.0-beta-5</version>
             <exclusions>
                 <exclusion>
                     <!-- must be excluded as it is signed, which causes problems with unsigned version from sonar -->


### PR DESCRIPTION
We need a fix I introduced in beta-5 (inria/spoon#3702) to do the PR for RSP server (see #226)