### PR TITLE
refactor: Extract discovery of rule violations from SoraldAbstractRepair

### DIFF
--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -1,24 +1,15 @@
 package sorald.processor;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.sonar.plugins.java.api.JavaFileScanner;
-import sorald.Constants;
 import sorald.FileUtils;
 import sorald.UniqueTypesCollector;
 import sorald.annotations.ProcessorAnnotation;
-import sorald.segment.Node;
-import sorald.sonar.Checks;
-import sorald.sonar.RuleVerifier;
 import sorald.sonar.RuleViolation;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtElement;
@@ -31,49 +22,8 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
 
     public SoraldAbstractProcessor() {}
 
-    public SoraldAbstractProcessor initResource(String originalFilesPath, File baseDir) {
-        JavaFileScanner sonarCheck = Checks.getCheckInstance(getRuleKey());
-        try {
-            List<String> filesToScan = new ArrayList<>();
-            File file = new File(originalFilesPath);
-            if (file.isFile()) {
-                filesToScan.add(file.getAbsolutePath());
-            } else {
-                try {
-                    filesToScan =
-                            FileUtils.findFilesByExtension(file, Constants.JAVA_EXT).stream()
-                                    .map(File::getAbsolutePath)
-                                    .collect(Collectors.toList());
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-            ruleViolations = RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return this;
-    }
-
-    public SoraldAbstractProcessor initResource(List<Node> segment, File baseDir) {
-        JavaFileScanner sonarCheck = Checks.getCheckInstance(getRuleKey());
-        List<String> filesToScan = new ArrayList<>();
-        for (Node node : segment) {
-            if (node.isFileNode()) {
-                filesToScan.addAll(node.getJavaFiles());
-            } else {
-                try (Stream<Path> walk = Files.walk(Paths.get(node.getRootPath()))) {
-                    filesToScan.addAll(
-                            walk.map(x -> x.toFile().getAbsolutePath())
-                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
-                                    .collect(Collectors.toList()));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-
-        ruleViolations = RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
+    public SoraldAbstractProcessor<E> setRuleViolations(Set<RuleViolation> ruleViolations) {
+        this.ruleViolations = new HashSet<>(ruleViolations);
         return this;
     }
 

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -2,18 +2,13 @@ package sorald.sonar;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.FileUtils;
-import sorald.segment.Node;
 
 /** Helper class that uses Sonar to scan projects for rule violations. */
 public class ProjectScanner {
@@ -39,34 +34,6 @@ public class ProjectScanner {
                                 .collect(Collectors.toList());
             } catch (IOException e) {
                 e.printStackTrace();
-            }
-        }
-        return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
-    }
-
-    /**
-     * Scan a segment of a project for rule violations.
-     *
-     * @param segment A segment.
-     * @param baseDir Base directory of the project.
-     * @param sonarCheck The check to scan with.
-     * @return All violations in the segments.
-     */
-    public static Set<RuleViolation> scanSegment(
-            List<Node> segment, File baseDir, JavaFileScanner sonarCheck) {
-        List<String> filesToScan = new ArrayList<>();
-        for (Node node : segment) {
-            if (node.isFileNode()) {
-                filesToScan.addAll(node.getJavaFiles());
-            } else {
-                try (Stream<Path> walk = Files.walk(Paths.get(node.getRootPath()))) {
-                    filesToScan.addAll(
-                            walk.map(x -> x.toFile().getAbsolutePath())
-                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
-                                    .collect(Collectors.toList()));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
             }
         }
         return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -1,0 +1,74 @@
+package sorald.sonar;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import sorald.Constants;
+import sorald.FileUtils;
+import sorald.segment.Node;
+
+/** Helper class that uses Sonar to scan projects for rule violations. */
+public class ProjectScanner {
+
+    /**
+     * Scan a project for rule violations.
+     *
+     * @param target Targeted file or directory of the project.
+     * @param baseDir Base directory of the project.
+     * @param sonarCheck The check to scan with.
+     * @return All violations in the target.
+     */
+    public static Set<RuleViolation> scanProject(
+            File target, File baseDir, JavaFileScanner sonarCheck) {
+        List<String> filesToScan = new ArrayList<>();
+        if (target.isFile()) {
+            filesToScan.add(target.getAbsolutePath());
+        } else {
+            try {
+                filesToScan =
+                        FileUtils.findFilesByExtension(target, Constants.JAVA_EXT).stream()
+                                .map(File::getAbsolutePath)
+                                .collect(Collectors.toList());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
+    }
+
+    /**
+     * Scan a segment of a project for rule violations.
+     *
+     * @param segment A segment.
+     * @param baseDir Base directory of the project.
+     * @param sonarCheck The check to scan with.
+     * @return All violations in the segments.
+     */
+    public static Set<RuleViolation> scanSegment(
+            List<Node> segment, File baseDir, JavaFileScanner sonarCheck) {
+        List<String> filesToScan = new ArrayList<>();
+        for (Node node : segment) {
+            if (node.isFileNode()) {
+                filesToScan.addAll(node.getJavaFiles());
+            } else {
+                try (Stream<Path> walk = Files.walk(Paths.get(node.getRootPath()))) {
+                    filesToScan.addAll(
+                            walk.map(x -> x.toFile().getAbsolutePath())
+                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
+                                    .collect(Collectors.toList()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
+    }
+}


### PR DESCRIPTION
This is step 1 of the targeted repair implementation (#225).

This refactor extracts the discovery of rule violations from the SoraldAbstractRepair class and pulls it up to an earlier level of the execution. It makes it much easier to replace the rule violations with something constructed from violation IDs for the targeted repair. See further comments in the code.