### PR TITLE
wip: Add targeted repair

### DIFF
--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -26,6 +26,7 @@ public class Constants {
     public static final String ARG_REPAIR_STRATEGY = "repairStrategy";
     public static final String ARG_MAX_FILES_PER_SEGMENT = "maxFilesPerSegment";
     public static final String ARG_RULE_TYPES = "ruleTypes";
+    public static final String ARG_RULE_VIOLATIONS = "violationIds";
 
     public static final String PROCESSOR_PACKAGE = "sorald.processor";
 

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/sorald/SoraldConfig.java
+++ b/src/main/java/sorald/SoraldConfig.java
@@ -1,12 +1,16 @@
 package sorald;
 
+import sorald.sonar.RuleViolation;
+
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /* All config settings of Sorald should be gathered here */
 public class SoraldConfig {
     private final List<Integer> ruleKeys = new ArrayList<>();
+    private final List<RuleViolation> ruleViolations = new ArrayList<>();
     private PrettyPrintingStrategy prettyPrintingStrategy;
     private FileOutputStrategy fileOutputStrategy;
     private RepairStrategy repairStrategy;
@@ -29,6 +33,14 @@ public class SoraldConfig {
 
     public List<Integer> getRuleKeys() {
         return this.ruleKeys;
+    }
+
+    public void addRuleViolations(List<RuleViolation> ruleViolations) {
+        ruleViolations.stream().distinct().forEach(this.ruleViolations::add);
+    }
+
+    public List<RuleViolation> getRuleViolations() {
+        return Collections.unmodifiableList(ruleViolations);
     }
 
     public void setPrettyPrintingStrategy(PrettyPrintingStrategy prettyPrintingStrategy) {

--- a/src/main/java/sorald/SoraldConfig.java
+++ b/src/main/java/sorald/SoraldConfig.java
@@ -1,11 +1,10 @@
 package sorald;
 
-import sorald.sonar.RuleViolation;
-
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import sorald.sonar.RuleViolation;
 
 /* All config settings of Sorald should be gathered here */
 public class SoraldConfig {

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -1,24 +1,15 @@
 package sorald.processor;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.sonar.plugins.java.api.JavaFileScanner;
-import sorald.Constants;
 import sorald.FileUtils;
 import sorald.UniqueTypesCollector;
 import sorald.annotations.ProcessorAnnotation;
-import sorald.segment.Node;
-import sorald.sonar.Checks;
-import sorald.sonar.RuleVerifier;
 import sorald.sonar.RuleViolation;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtElement;
@@ -31,49 +22,8 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
 
     public SoraldAbstractProcessor() {}
 
-    public SoraldAbstractProcessor initResource(String originalFilesPath, File baseDir) {
-        JavaFileScanner sonarCheck = Checks.getCheckInstance(getRuleKey());
-        try {
-            List<String> filesToScan = new ArrayList<>();
-            File file = new File(originalFilesPath);
-            if (file.isFile()) {
-                filesToScan.add(file.getAbsolutePath());
-            } else {
-                try {
-                    filesToScan =
-                            FileUtils.findFilesByExtension(file, Constants.JAVA_EXT).stream()
-                                    .map(File::getAbsolutePath)
-                                    .collect(Collectors.toList());
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-            ruleViolations = RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return this;
-    }
-
-    public SoraldAbstractProcessor initResource(List<Node> segment, File baseDir) {
-        JavaFileScanner sonarCheck = Checks.getCheckInstance(getRuleKey());
-        List<String> filesToScan = new ArrayList<>();
-        for (Node node : segment) {
-            if (node.isFileNode()) {
-                filesToScan.addAll(node.getJavaFiles());
-            } else {
-                try (Stream<Path> walk = Files.walk(Paths.get(node.getRootPath()))) {
-                    filesToScan.addAll(
-                            walk.map(x -> x.toFile().getAbsolutePath())
-                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
-                                    .collect(Collectors.toList()));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-
-        ruleViolations = RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
+    public SoraldAbstractProcessor<E> setRuleViolations(Set<RuleViolation> ruleViolations) {
+        this.ruleViolations = new HashSet<>(ruleViolations);
         return this;
     }
 

--- a/src/main/java/sorald/sonar/Checks.java
+++ b/src/main/java/sorald/sonar/Checks.java
@@ -40,6 +40,7 @@ import org.sonar.java.checks.synchronization.ValueBasedObjectUsedForLockCheck;
 import org.sonar.java.checks.unused.UnusedReturnedDataCheck;
 import org.sonar.java.checks.unused.UnusedThrowableCheck;
 import org.sonar.java.se.checks.*;
+import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaFileScanner;
 
 /** Class for easily accessing Sonar check classes. */
@@ -114,7 +115,7 @@ public class Checks {
      * @return the numeric identifier of the rule related to the given check class. Non-digits are
      *     stripped, so e.g. S1234 becomes 1234.
      */
-    public static String getRuleKey(Class<? extends JavaFileScanner> checkClass) {
+    public static String getRuleKey(Class<? extends JavaCheck> checkClass) {
         return Arrays.stream(checkClass.getAnnotationsByType(Rule.class))
                 .map(Rule::key)
                 .map(Checks::stripDigits)

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -2,18 +2,13 @@ package sorald.sonar;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.FileUtils;
-import sorald.segment.Node;
 
 /** Helper class that uses Sonar to scan projects for rule violations. */
 public class ProjectScanner {
@@ -39,34 +34,6 @@ public class ProjectScanner {
                                 .collect(Collectors.toList());
             } catch (IOException e) {
                 e.printStackTrace();
-            }
-        }
-        return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
-    }
-
-    /**
-     * Scan a segment of a project for rule violations.
-     *
-     * @param segment A segment.
-     * @param baseDir Base directory of the project.
-     * @param sonarCheck The check to scan with.
-     * @return All violations in the segments.
-     */
-    public static Set<RuleViolation> scanSegment(
-            List<Node> segment, File baseDir, JavaFileScanner sonarCheck) {
-        List<String> filesToScan = new ArrayList<>();
-        for (Node node : segment) {
-            if (node.isFileNode()) {
-                filesToScan.addAll(node.getJavaFiles());
-            } else {
-                try (Stream<Path> walk = Files.walk(Paths.get(node.getRootPath()))) {
-                    filesToScan.addAll(
-                            walk.map(x -> x.toFile().getAbsolutePath())
-                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
-                                    .collect(Collectors.toList()));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
             }
         }
         return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -1,0 +1,74 @@
+package sorald.sonar;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import sorald.Constants;
+import sorald.FileUtils;
+import sorald.segment.Node;
+
+/** Helper class that uses Sonar to scan projects for rule violations. */
+public class ProjectScanner {
+
+    /**
+     * Scan a project for rule violations.
+     *
+     * @param target Targeted file or directory of the project.
+     * @param baseDir Base directory of the project.
+     * @param sonarCheck The check to scan with.
+     * @return All violations in the target.
+     */
+    public static Set<RuleViolation> scanProject(
+            File target, File baseDir, JavaFileScanner sonarCheck) {
+        List<String> filesToScan = new ArrayList<>();
+        if (target.isFile()) {
+            filesToScan.add(target.getAbsolutePath());
+        } else {
+            try {
+                filesToScan =
+                        FileUtils.findFilesByExtension(target, Constants.JAVA_EXT).stream()
+                                .map(File::getAbsolutePath)
+                                .collect(Collectors.toList());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
+    }
+
+    /**
+     * Scan a segment of a project for rule violations.
+     *
+     * @param segment A segment.
+     * @param baseDir Base directory of the project.
+     * @param sonarCheck The check to scan with.
+     * @return All violations in the segments.
+     */
+    public static Set<RuleViolation> scanSegment(
+            List<Node> segment, File baseDir, JavaFileScanner sonarCheck) {
+        List<String> filesToScan = new ArrayList<>();
+        for (Node node : segment) {
+            if (node.isFileNode()) {
+                filesToScan.addAll(node.getJavaFiles());
+            } else {
+                try (Stream<Path> walk = Files.walk(Paths.get(node.getRootPath()))) {
+                    filesToScan.addAll(
+                            walk.map(x -> x.toFile().getAbsolutePath())
+                                    .filter(f -> f.endsWith(Constants.JAVA_EXT))
+                                    .collect(Collectors.toList()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return RuleVerifier.analyze(filesToScan, baseDir, sonarCheck);
+    }
+}

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -86,7 +86,7 @@ public class RuleVerifier {
         scanner.scan(inputFiles);
 
         return sonarComponents.getMessages().stream()
-                .map(RuleViolation::new)
+                .map(ScannedViolation::new)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -14,6 +14,9 @@ public abstract class RuleViolation {
     /** @return The name of the check class that generated this warning. */
     public abstract String getCheckName();
 
+    /** @return The key of the rule that is violated. */
+    public abstract String getRuleKey();
+
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof RuleViolation)) {

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -1,14 +1,32 @@
 package sorald.sonar;
 
+import java.util.Objects;
+
 /** Representation of a violation of some Sonar rule */
-public interface RuleViolation {
+public abstract class RuleViolation {
 
     /** @return The line number related to the rule violation. */
-    int getLineNumber();
+    public abstract int getLineNumber();
 
     /** @return The name of the file that was analyzed. */
-    String getFileName();
+    public abstract String getFileName();
 
     /** @return The name of the check class that generated this warning. */
-    String getCheckName();
+    public abstract String getCheckName();
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RuleViolation)) {
+            return false;
+        }
+        var other = (RuleViolation) obj;
+        return getLineNumber() == other.getLineNumber()
+                && getFileName().equals(other.getFileName())
+                && getCheckName().equals(other.getCheckName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLineNumber(), getFileName(), getCheckName());
+    }
 }

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -1,28 +1,14 @@
 package sorald.sonar;
 
-import java.util.Objects;
-import org.sonar.java.AnalyzerMessage;
-
-/** Facade around {@link org.sonar.java.AnalyzerMessage} */
-public class RuleViolation {
-    private final AnalyzerMessage message;
-
-    RuleViolation(AnalyzerMessage message) {
-        this.message = message;
-    }
+/** Representation of a violation of some Sonar rule */
+public interface RuleViolation {
 
     /** @return The line number related to the rule violation. */
-    public int getLineNumber() {
-        return Objects.requireNonNull(message.getLine());
-    }
+    int getLineNumber();
 
     /** @return The name of the file that was analyzed. */
-    public String getFileName() {
-        return message.getInputComponent().key().replace(":", "");
-    }
+    String getFileName();
 
     /** @return The name of the check class that generated this warning. */
-    public String getCheckName() {
-        return message.getCheck().getClass().getSimpleName();
-    }
+    String getCheckName();
 }

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -26,4 +26,9 @@ public class ScannedViolation extends RuleViolation {
     public String getCheckName() {
         return message.getCheck().getClass().getSimpleName();
     }
+
+    /** @return The key of the rule that is violated. */
+    public String getRuleKey() {
+        return Checks.getRuleKey(message.getCheck().getClass());
+    }
 }

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -5,7 +5,7 @@ import org.sonar.java.AnalyzerMessage;
 import java.util.Objects;
 
 /** Facade around {@link org.sonar.java.AnalyzerMessage} */
-public class ScannedViolation implements RuleViolation {
+public class ScannedViolation extends RuleViolation {
     private final AnalyzerMessage message;
 
     ScannedViolation(AnalyzerMessage message) {

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -1,0 +1,29 @@
+package sorald.sonar;
+
+import org.sonar.java.AnalyzerMessage;
+
+import java.util.Objects;
+
+/** Facade around {@link org.sonar.java.AnalyzerMessage} */
+public class ScannedViolation implements RuleViolation {
+    private final AnalyzerMessage message;
+
+    ScannedViolation(AnalyzerMessage message) {
+        this.message = message;
+    }
+
+    /** @return The line number related to the rule violation. */
+    public int getLineNumber() {
+        return Objects.requireNonNull(message.getLine());
+    }
+
+    /** @return The name of the file that was analyzed. */
+    public String getFileName() {
+        return message.getInputComponent().key().replace(":", "");
+    }
+
+    /** @return The name of the check class that generated this warning. */
+    public String getCheckName() {
+        return message.getCheck().getClass().getSimpleName();
+    }
+}

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -1,8 +1,7 @@
 package sorald.sonar;
 
-import org.sonar.java.AnalyzerMessage;
-
 import java.util.Objects;
+import org.sonar.java.AnalyzerMessage;
 
 /** Facade around {@link org.sonar.java.AnalyzerMessage} */
 public class ScannedViolation extends RuleViolation {

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -1,0 +1,75 @@
+package sorald;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import sorald.sonar.Checks;
+import sorald.sonar.ProjectScanner;
+import sorald.sonar.RuleViolation;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/** Tests for the targeted repair functionality of Sorald. */
+public class TargetedRepairTest {
+
+    @Test
+    void targetedRepair_correctlyRepairsSingleViolation(@TempDir File workdir) throws Exception {
+        // arrange
+        org.apache.commons.io.FileUtils.copyDirectory(
+                new File(Constants.PATH_TO_RESOURCES_FOLDER), workdir);
+
+        String ruleKey = "2111";
+        JavaFileScanner check = Checks.getCheckInstance(ruleKey);
+        File targetFile =
+                workdir.toPath()
+                        .resolve("processor_test_files")
+                        .resolve("2111_BigDecimalDoubleConstructor")
+                        .resolve("BigDecimalDoubleConstructor.java")
+                        .toFile();
+
+        Set<RuleViolation> violationsBefore =
+                ProjectScanner.scanProject(targetFile, workdir, check);
+        assertThat(
+                "there must be more than 1 violation in the test file for an adequate test",
+                violationsBefore.size(),
+                greaterThan(1));
+        RuleViolation targetViolation =
+                violationsBefore.stream()
+                        .sorted(Comparator.comparing(RuleViolation::getLineNumber))
+                        .findFirst()
+                        .get();
+
+        // act
+        Main.main(
+                new String[] {
+                    Constants.REPAIR_COMMAND_NAME,
+                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    workdir.getAbsolutePath(),
+                    Constants.ARG_SYMBOL + Constants.ARG_RULE_VIOLATIONS,
+                    String.format(
+                            "%s:%s:%s",
+                            ruleKey, targetViolation.getFileName(), targetViolation.getLineNumber())
+                });
+
+        // assert
+        File soraldWorkspace = new File(Constants.SORALD_WORKSPACE);
+        List<File> repairedFiles =
+                FileUtils.findFilesByExtension(soraldWorkspace, Constants.JAVA_EXT);
+        Set<RuleViolation> violationsAfter =
+                ProjectScanner.scanProject(soraldWorkspace, soraldWorkspace, check);
+
+        assertThat(violationsAfter.size(), equalTo(violationsBefore.size() - 1));
+        assertFalse(violationsAfter.contains(targetViolation));
+        assertThat(repairedFiles.size(), equalTo(1));
+        assertThat(repairedFiles.get(0).getName(), equalTo(targetFile.getName()));
+    }
+}

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -1,22 +1,20 @@
 package sorald;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.sonar.Checks;
 import sorald.sonar.ProjectScanner;
 import sorald.sonar.RuleViolation;
-
-import java.io.File;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /** Tests for the targeted repair functionality of Sorald. */
 public class TargetedRepairTest {


### PR DESCRIPTION
Repair part of #225 

Depends on #240 (which must be merged first). @khaes-kth I've implemented this to use violation IDs on the form `<rule-key>:<filepath>:<line-nr>`. All of that information is available to the miner, so that's the minimum we need to implement targeted repair. The miner is however missing a convenience method in `RuleViolation`, see the code comments.

We can discuss this further at the meeting.