### PR TITLE
doc: Add throws to findFilesByExtension Javadoc

### DIFF
--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -69,6 +69,7 @@ public class FileUtils {
      * @param directory A directory
      * @param ext A file extension including the leading dot
      * @return All files in the given directory or any subdirectory with a matching extension
+     * @throws IOException If there is an error traversing the directory
      */
     public static List<File> findFilesByExtension(File directory, String ext) throws IOException {
         if (!directory.isDirectory()) {


### PR DESCRIPTION
To silence this annoying warning when compiling:

```
1 warning
[WARNING] Javadoc Warnings
[WARNING] /home/slarse/Documents/github/work/sorald/src/main/java/sorald/FileUtils.java:73: warning: no @throws for java.io.IOException
[WARNING] public static List<File> findFilesByExtension(File directory, String ext) throws IOException {
[WARNING] ^
```