### PR TITLE
feat: Add in-place repair mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ The full list of options is as follows (and can also be found by running
 ```bash
       --fileOutputStrategy=<fileOutputStrategy>
                   Mode for outputting files: 'CHANGED_ONLY', which means that
-                    only changed files will be created in the workspace, and
-                    'ALL', which means that all files, including the unchanged
-                    ones, will be created in the workspace.
+                    only changed files will be created in the workspace. 'ALL',
+                    which means that all files, including the unchanged ones,
+                    will be created in the workspace. 'IN_PLACE', which means
+                    that results are written directly to source files.
       --gitRepoPath=<gitRepoPath>
                   The path to a git repository directory.
   -h, --help      Show this help message and exit.

--- a/src/main/java/sorald/FileOutputStrategy.java
+++ b/src/main/java/sorald/FileOutputStrategy.java
@@ -2,5 +2,6 @@ package sorald;
 
 public enum FileOutputStrategy {
     ALL,
-    CHANGED_ONLY
+    CHANGED_ONLY,
+    IN_PLACE
 }

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -236,7 +236,7 @@ public class Repair {
         try {
             Files.writeString(filepath, output);
         } catch (IOException e) {
-            // most convert to a runtime exception as this is used in writeModel, which in turn
+            // must convert to a runtime exception as this is used in writeModel, which in turn
             // is used in a stream (that can't have checked exceptions)
             throw new RuntimeException(e);
         }

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -222,17 +222,23 @@ public class Repair {
                                     .getEnvironment()
                                     .createPrettyPrinter()
                                     .printTypes(type);
-                    try {
-                        Files.writeString(Paths.get(patchedFile.getKey()), output);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
+                    writeString(Paths.get(patchedFile.getKey()), output);
                 }
 
                 if (config.getGitRepoPath() != null) {
                     createPatches(patchedFile.getKey(), javaOutputProcessor);
                 }
             }
+        }
+    }
+
+    private static void writeString(Path filepath, String output) {
+        try {
+            Files.writeString(filepath, output);
+        } catch (IOException e) {
+            // most convert to a runtime exception as this is used in writeModel, which in turn
+            // is used in a stream (that can't have checked exceptions)
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -1,8 +1,10 @@
 package sorald;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -135,10 +137,14 @@ public class Repair {
     }
 
     private Pair<Path, Path> computeInOutPaths(boolean isFirstRule, boolean isLastRule) {
-        if (isFirstRule && isLastRule) {
+        final Path originalPath = Paths.get(config.getOriginalFilesPath());
+
+        if (config.getFileOutputStrategy() == FileOutputStrategy.IN_PLACE) {
+            // always write to the input files
+            return Pair.of(originalPath, originalPath);
+        } else if (isFirstRule && isLastRule) {
             // one processor, straightforward repair: we use the given input file dir, run one
-            // processor, directly output files (independently of the FileOutputStrategy) in
-            // the final output dir
+            // processor, directly output files the spooned output dir
             return Pair.of(Paths.get(config.getOriginalFilesPath()), spoonedPath);
         } else {
             // more than one processor, thus we need an intermediate dir, which will always
@@ -147,7 +153,7 @@ public class Repair {
             if (isFirstRule) {
                 // the first processor will run, thus we use the given input file
                 // dir and output *all* files in the intermediate dir
-                return Pair.of(Paths.get(config.getOriginalFilesPath()), intermediateSpoonedPath);
+                return Pair.of(originalPath, intermediateSpoonedPath);
             } else if (isLastRule) {
                 // the last processor will run, thus we use as input files the ones in
                 // the intermediate dir and output files in the final output dir
@@ -196,15 +202,33 @@ public class Repair {
 
         boolean isIntermediateOutputDir =
                 outputDir.toString().contains(intermediateSpoonedPath.toString());
-        if (config.getFileOutputStrategy() == FileOutputStrategy.ALL || isIntermediateOutputDir) {
+        FileOutputStrategy outputStrategy = config.getFileOutputStrategy();
+        if (outputStrategy == FileOutputStrategy.ALL || isIntermediateOutputDir) {
             processingManager.process(model.getUnnamedModule().getFactory().Class().getAll());
         } else {
-            assert (config.getFileOutputStrategy() == FileOutputStrategy.CHANGED_ONLY
-                    && !isIntermediateOutputDir);
+            assert outputStrategy == FileOutputStrategy.CHANGED_ONLY
+                    || outputStrategy == FileOutputStrategy.IN_PLACE;
 
             for (Map.Entry<String, CtType> patchedFile :
                     UniqueTypesCollector.getInstance().getTopLevelTypes4Output().entrySet()) {
-                javaOutputProcessor.process(patchedFile.getValue());
+
+                if (outputStrategy == FileOutputStrategy.CHANGED_ONLY) {
+                    javaOutputProcessor.process(patchedFile.getValue());
+                } else {
+                    assert outputStrategy == FileOutputStrategy.IN_PLACE;
+                    CtType<?> type = patchedFile.getValue();
+                    String output =
+                            type.getFactory()
+                                    .getEnvironment()
+                                    .createPrettyPrinter()
+                                    .printTypes(type);
+                    try {
+                        Files.writeString(Paths.get(patchedFile.getKey()), output);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+
                 if (config.getGitRepoPath() != null) {
                     createPatches(patchedFile.getKey(), javaOutputProcessor);
                 }

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -105,7 +105,7 @@ public class Cli {
         @CommandLine.Option(
                 names = Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
                 description =
-                        "Mode for outputting files: 'CHANGED_ONLY', which means that only changed files will be created in the workspace, and 'ALL', which means that all files, including the unchanged ones, will be created in the workspace. 'IN_PLACE', which means that results are written directly to source files.")
+                        "Mode for outputting files: 'CHANGED_ONLY', which means that only changed files will be created in the workspace. 'ALL', which means that all files, including the unchanged ones, will be created in the workspace. 'IN_PLACE', which means that results are written directly to source files.")
         FileOutputStrategy fileOutputStrategy = FileOutputStrategy.CHANGED_ONLY;
 
         @CommandLine.Option(

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -105,7 +105,7 @@ public class Cli {
         @CommandLine.Option(
                 names = Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
                 description =
-                        "Mode for outputting files: 'CHANGED_ONLY', which means that only changed files will be created in the workspace, and 'ALL', which means that all files, including the unchanged ones, will be created in the workspace.")
+                        "Mode for outputting files: 'CHANGED_ONLY', which means that only changed files will be created in the workspace, and 'ALL', which means that all files, including the unchanged ones, will be created in the workspace. 'IN_PLACE', which means that results are written directly to source files.")
         FileOutputStrategy fileOutputStrategy = FileOutputStrategy.CHANGED_ONLY;
 
         @CommandLine.Option(

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -3,6 +3,10 @@ package sorald;
 import java.io.File;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import sorald.processor.ProcessorTestHelper;
+import sorald.sonar.Checks;
+import sorald.sonar.RuleVerifier;
 
 public class FileOutputStrategyTest {
 
@@ -74,5 +78,32 @@ public class FileOutputStrategyTest {
 
         File patches = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.PATCHES);
         Assertions.assertNull(patches.list());
+    }
+
+    @Test
+    public void inPlaceRepair_repairsInPlace(@TempDir File tempDir) throws Exception {
+        // arrange
+        org.apache.commons.io.FileUtils.copyDirectory(
+                ProcessorTestHelper.TEST_FILES_ROOT.toFile(), tempDir);
+        ProcessorTestHelper.ProcessorTestCase<?> testCase =
+                ProcessorTestHelper.getTestCaseStream(tempDir)
+                        .filter(
+                                tc ->
+                                        tc.nonCompliantFile
+                                                .getName()
+                                                .equals("DocumentBuilderLocalVariable.java"))
+                        .findFirst()
+                        .get();
+
+        // act
+        ProcessorTestHelper.runSorald(
+                testCase,
+                Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
+                FileOutputStrategy.IN_PLACE.name());
+
+        // assert
+        RuleVerifier.verifyNoIssue(
+                testCase.nonCompliantFile.getAbsolutePath(),
+                Checks.getCheckInstance(testCase.ruleKey));
     }
 }

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -89,17 +89,25 @@ public class ProcessorTestHelper {
     }
 
     /**
-     * Return a stream of all valid test cases, based on the tests files in {@link
-     * ProcessorTestHelper#TEST_FILES_ROOT}.
+     * @param testFilesRoot Root of a test files directory.
+     * @return A stream of {@link ProcessorTestCase}
      */
-    public static Stream<ProcessorTestCase<?>> getTestCaseStream() {
-        return Arrays.stream(ProcessorTestHelper.TEST_FILES_ROOT.toFile().listFiles())
+    public static Stream<ProcessorTestCase<?>> getTestCaseStream(File testFilesRoot) {
+        return Arrays.stream(testFilesRoot.listFiles())
                 .filter(File::isDirectory)
                 .map(File::listFiles)
                 .flatMap(Arrays::stream)
                 .filter(file -> file.getName().endsWith(".java"))
                 .filter(file -> !file.getName().startsWith("IGNORE"))
                 .map(ProcessorTestHelper::toProcessorTestCase);
+    }
+
+    /**
+     * Return a stream of all valid test cases, based on the tests files in {@link
+     * ProcessorTestHelper#TEST_FILES_ROOT}.
+     */
+    public static Stream<ProcessorTestCase<?>> getTestCaseStream() {
+        return getTestCaseStream(TEST_FILES_ROOT.toFile());
     }
 
     /** Run sorald on the given test case. */


### PR DESCRIPTION
Fix #190 

This PR adds an in-place repair mode, which writes output directly to the source files. It's literally in-place; if Sorald processes multiple rules the source files will be written to multiple times.

Can be activated by passing `--fileOutputStrategy IN_PLACE` to the `repair` command.