### PR TITLE
refactor: Remove Constants.ARG_SYMBOL

### DIFF
--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -11,21 +11,20 @@ public class Constants {
     public static final String REPAIR_COMMAND_NAME = "repair";
     public static final String MINE_COMMAND_NAME = "mine";
 
-    public static final String ARG_SYMBOL = "--";
-    public static final String ARG_RULE_KEYS = "ruleKeys";
-    public static final String ARG_ORIGINAL_FILES_PATH = "originalFilesPath";
-    public static final String ARG_STATS_ON_GIT_REPOS = "statsOnGitRepos";
-    public static final String ARG_STATS_OUTPUT_FILE = "statsOutputFile";
-    public static final String ARG_GIT_REPOS_LIST = "gitReposList";
-    public static final String ARG_TEMP_DIR = "tempDir";
-    public static final String ARG_WORKSPACE = "workspace";
-    public static final String ARG_GIT_REPO_PATH = "gitRepoPath";
-    public static final String ARG_PRETTY_PRINTING_STRATEGY = "prettyPrintingStrategy";
-    public static final String ARG_FILE_OUTPUT_STRATEGY = "fileOutputStrategy";
-    public static final String ARG_MAX_FIXES_PER_RULE = "maxFixesPerRule";
-    public static final String ARG_REPAIR_STRATEGY = "repairStrategy";
-    public static final String ARG_MAX_FILES_PER_SEGMENT = "maxFilesPerSegment";
-    public static final String ARG_RULE_TYPES = "ruleTypes";
+    public static final String ARG_RULE_KEYS = "--ruleKeys";
+    public static final String ARG_ORIGINAL_FILES_PATH = "--originalFilesPath";
+    public static final String ARG_STATS_ON_GIT_REPOS = "--statsOnGitRepos";
+    public static final String ARG_STATS_OUTPUT_FILE = "--statsOutputFile";
+    public static final String ARG_GIT_REPOS_LIST = "--gitReposList";
+    public static final String ARG_TEMP_DIR = "--tempDir";
+    public static final String ARG_WORKSPACE = "--workspace";
+    public static final String ARG_GIT_REPO_PATH = "--gitRepoPath";
+    public static final String ARG_PRETTY_PRINTING_STRATEGY = "--prettyPrintingStrategy";
+    public static final String ARG_FILE_OUTPUT_STRATEGY = "--fileOutputStrategy";
+    public static final String ARG_MAX_FIXES_PER_RULE = "--maxFixesPerRule";
+    public static final String ARG_REPAIR_STRATEGY = "--repairStrategy";
+    public static final String ARG_MAX_FILES_PER_SEGMENT = "--maxFilesPerSegment";
+    public static final String ARG_RULE_TYPES = "--ruleTypes";
 
     public static final String PROCESSOR_PACKAGE = "sorald.processor";
 

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -57,14 +57,14 @@ public class Cli {
         @CommandLine.Spec CommandLine.Model.CommandSpec spec;
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH},
+                names = {Constants.ARG_ORIGINAL_FILES_PATH},
                 description =
                         "The path to the file or folder to be analyzed and possibly repaired.",
                 required = true)
         File originalFilesPath;
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS},
+                names = {Constants.ARG_RULE_KEYS},
                 description =
                         "Choose one or more of the following rule keys "
                                 + "(use ',' to separate multiple keys):\n"
@@ -85,48 +85,48 @@ public class Cli {
         }
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE},
+                names = {Constants.ARG_WORKSPACE},
                 description =
                         "The path to a folder that will be used as workspace by Sorald, i.e. the path for the output.",
                 defaultValue = Constants.SORALD_WORKSPACE)
         File soraldWorkspace;
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_GIT_REPO_PATH},
+                names = {Constants.ARG_GIT_REPO_PATH},
                 description = "The path to a git repository directory.")
         File gitRepoPath;
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY},
+                names = {Constants.ARG_PRETTY_PRINTING_STRATEGY},
                 description =
                         "Mode for pretty printing the source code: 'NORMAL', which means that all source code will be printed and its formatting might change (such as indentation), and 'SNIPER', which means that only statements changed towards the repair of Sonar rule violations will be printed.")
         PrettyPrintingStrategy prettyPrintingStrategy = PrettyPrintingStrategy.SNIPER;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
+                names = Constants.ARG_FILE_OUTPUT_STRATEGY,
                 description =
                         "Mode for outputting files: 'CHANGED_ONLY', which means that only changed files will be created in the workspace. 'ALL', which means that all files, including the unchanged ones, will be created in the workspace. 'IN_PLACE', which means that results are written directly to source files.")
         FileOutputStrategy fileOutputStrategy = FileOutputStrategy.CHANGED_ONLY;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_MAX_FIXES_PER_RULE,
+                names = Constants.ARG_MAX_FIXES_PER_RULE,
                 description = "Max number of fixes per rule.")
         int maxFixesPerRule = Integer.MAX_VALUE;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                names = Constants.ARG_REPAIR_STRATEGY,
                 description =
                         "Type of repair strategy. DEFAULT - load everything without splitting up the folder in segments, SEGMENT - splitting the folder into smaller segments and repair one segment at a time (need to specify --maxFilesPerSegment if not default)")
         RepairStrategy repairStrategy = RepairStrategy.DEFAULT;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_MAX_FILES_PER_SEGMENT,
+                names = Constants.ARG_MAX_FILES_PER_SEGMENT,
                 description =
                         "Max number of files per loaded segment for segmented repair. It should be >= 3000 files per segment.")
         int maxFilesPerSegment = 6500;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
+                names = Constants.ARG_STATS_OUTPUT_FILE,
                 description =
                         "Path to a file to store execution statistics in (in JSON format). If left unspecified, Sorald does not gather statistics.")
         File statsOutputFile;
@@ -154,9 +154,7 @@ public class Cli {
             if (maxFilesPerSegment <= 0) {
                 throw new CommandLine.ParameterException(
                         spec.commandLine(),
-                        Constants.ARG_SYMBOL
-                                + Constants.ARG_MAX_FILES_PER_SEGMENT
-                                + " must be greater than 0");
+                        Constants.ARG_MAX_FILES_PER_SEGMENT + " must be greater than 0");
             }
 
             if (statsOutputFile != null && repairStrategy == RepairStrategy.SEGMENT) {
@@ -194,33 +192,33 @@ public class Cli {
         @CommandLine.Spec CommandLine.Model.CommandSpec spec;
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH},
+                names = {Constants.ARG_ORIGINAL_FILES_PATH},
                 description =
                         "The path to the file or folder to be analyzed and possibly repaired.")
         File originalFilesPath;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_STATS_ON_GIT_REPOS,
+                names = Constants.ARG_STATS_ON_GIT_REPOS,
                 description = "If the stats should be computed on git repos.")
         boolean statsOnGitRepos;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
+                names = Constants.ARG_STATS_OUTPUT_FILE,
                 description = "The path to the output file.")
         File statsOutputFile;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_GIT_REPOS_LIST,
+                names = Constants.ARG_GIT_REPOS_LIST,
                 description = "The path to the repos list.")
         File reposList;
 
         @CommandLine.Option(
-                names = Constants.ARG_SYMBOL + Constants.ARG_TEMP_DIR,
+                names = Constants.ARG_TEMP_DIR,
                 description = "The path to the temp directory.")
         File tempDir;
 
         @CommandLine.Option(
-                names = {Constants.ARG_SYMBOL + Constants.ARG_RULE_TYPES},
+                names = {Constants.ARG_RULE_TYPES},
                 description =
                         "One or more types of rules to check for (use ',' to separate multiple types). Choices: ${COMPLETION-CANDIDATES}",
                 split = ",")

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -17,15 +17,15 @@ public class FileOutputStrategyTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     Constants.PATH_TO_RESOURCES_FOLDER,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "4973",
-                    Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
+                    Constants.ARG_FILE_OUTPUT_STRATEGY,
                     FileOutputStrategy.CHANGED_ONLY.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
-                    Constants.ARG_SYMBOL + Constants.ARG_GIT_REPO_PATH,
+                    Constants.ARG_GIT_REPO_PATH,
                     "."
                 });
 
@@ -41,13 +41,13 @@ public class FileOutputStrategyTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     Constants.PATH_TO_RESOURCES_FOLDER,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "4973",
-                    Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
+                    Constants.ARG_FILE_OUTPUT_STRATEGY,
                     FileOutputStrategy.CHANGED_ONLY.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE
                 });
 
@@ -63,15 +63,15 @@ public class FileOutputStrategyTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     Constants.PATH_TO_RESOURCES_FOLDER,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "4973",
-                    Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
+                    Constants.ARG_FILE_OUTPUT_STRATEGY,
                     FileOutputStrategy.ALL.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY,
+                    Constants.ARG_PRETTY_PRINTING_STRATEGY,
                     PrettyPrintingStrategy.NORMAL.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE
                 });
 
@@ -91,9 +91,7 @@ public class FileOutputStrategyTest {
 
         // act
         ProcessorTestHelper.runSorald(
-                testCase,
-                Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
-                FileOutputStrategy.IN_PLACE.name());
+                testCase, Constants.ARG_FILE_OUTPUT_STRATEGY, FileOutputStrategy.IN_PLACE.name());
 
         // assert
         RuleVerifier.verifyNoIssue(
@@ -115,7 +113,7 @@ public class FileOutputStrategyTest {
                 () ->
                         ProcessorTestHelper.runSorald(
                                 testCase,
-                                Constants.ARG_SYMBOL + Constants.ARG_FILE_OUTPUT_STRATEGY,
+                                Constants.ARG_FILE_OUTPUT_STRATEGY,
                                 FileOutputStrategy.IN_PLACE.name()));
     }
 

--- a/src/test/java/sorald/GatherStatsTest.java
+++ b/src/test/java/sorald/GatherStatsTest.java
@@ -22,11 +22,11 @@ public class GatherStatsTest {
         List<String> cliArgs =
                 List.of(
                         Constants.REPAIR_COMMAND_NAME,
-                        Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                        Constants.ARG_ORIGINAL_FILES_PATH,
                         ProcessorTestHelper.TEST_FILES_ROOT.toString(),
-                        Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                        Constants.ARG_RULE_KEYS,
                         "2755",
-                        Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
+                        Constants.ARG_STATS_OUTPUT_FILE,
                         statsFile.getAbsolutePath());
         Main.main(cliArgs.toArray(String[]::new));
 
@@ -46,9 +46,7 @@ public class GatherStatsTest {
         File statsFile = tempDir.toPath().resolve("stats.json").toFile();
 
         ProcessorTestHelper.runSorald(
-                testCase,
-                Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
-                statsFile.getAbsolutePath());
+                testCase, Constants.ARG_STATS_OUTPUT_FILE, statsFile.getAbsolutePath());
 
         JSONObject jo = FileUtils.readJSON(statsFile.toPath());
         JSONArray repairs = jo.getJSONArray(StatsMetadataKeys.REPAIRS);
@@ -74,13 +72,13 @@ public class GatherStatsTest {
         String[] cliArgs =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     ProcessorTestHelper.TEST_FILES_ROOT.toString(),
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "2755",
-                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    Constants.ARG_REPAIR_STRATEGY,
                     RepairStrategy.SEGMENT.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
+                    Constants.ARG_STATS_OUTPUT_FILE,
                     statsFile.getAbsolutePath()
                 };
 

--- a/src/test/java/sorald/MaxFixesPerRuleTest.java
+++ b/src/test/java/sorald/MaxFixesPerRuleTest.java
@@ -19,13 +19,13 @@ public class MaxFixesPerRuleTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     pathToBuggyFile,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "2116",
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
-                    Constants.ARG_SYMBOL + Constants.ARG_MAX_FIXES_PER_RULE,
+                    Constants.ARG_MAX_FIXES_PER_RULE,
                     "3"
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);

--- a/src/test/java/sorald/MultipleProcessorsTest.java
+++ b/src/test/java/sorald/MultipleProcessorsTest.java
@@ -21,13 +21,13 @@ public class MultipleProcessorsTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     pathToBuggyFile,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "2111,2184,2204",
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
-                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    Constants.ARG_REPAIR_STRATEGY,
                     repairStrategy.name()
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);

--- a/src/test/java/sorald/NoSonarTest.java
+++ b/src/test/java/sorald/NoSonarTest.java
@@ -19,13 +19,13 @@ public class NoSonarTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     pathToBuggyFile,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "2116",
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
-                    Constants.ARG_SYMBOL + Constants.ARG_MAX_FIXES_PER_RULE,
+                    Constants.ARG_MAX_FIXES_PER_RULE,
                     "3"
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -22,19 +22,19 @@ public class SegmentStrategyTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    Constants.ARG_REPAIR_STRATEGY,
                     "SEGMENT",
                     // FIXME MAX_FILES_PER_SEGMENT is set to 1 as a temporary fix to
                     // https://github.com/SpoonLabs/sorald/issues/154
-                    Constants.ARG_SYMBOL + Constants.ARG_MAX_FILES_PER_SEGMENT,
+                    Constants.ARG_MAX_FILES_PER_SEGMENT,
                     "1",
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     Constants.PATH_TO_RESOURCES_FOLDER,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "2116",
-                    Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY,
+                    Constants.ARG_PRETTY_PRINTING_STRATEGY,
                     PrettyPrintingStrategy.NORMAL.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE + "/SEGMENT/"
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);
@@ -50,17 +50,17 @@ public class SegmentStrategyTest {
         String[] args =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_REPAIR_STRATEGY,
+                    Constants.ARG_REPAIR_STRATEGY,
                     "SEGMENT",
-                    Constants.ARG_SYMBOL + Constants.ARG_MAX_FILES_PER_SEGMENT,
+                    Constants.ARG_MAX_FILES_PER_SEGMENT,
                     "0",
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     Constants.PATH_TO_RESOURCES_FOLDER,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     "2116",
-                    Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY,
+                    Constants.ARG_PRETTY_PRINTING_STRATEGY,
                     PrettyPrintingStrategy.NORMAL.name(),
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE + "/SEGMENT/"
                 };
         assertThrows(RuntimeException.class, () -> Main.main(args));

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -64,7 +64,7 @@ public class WarningMinerTest {
                 pathToRepos,
                 outputFile.getPath(),
                 temp.getPath(),
-                Constants.ARG_SYMBOL + Constants.ARG_RULE_TYPES,
+                Constants.ARG_RULE_TYPES,
                 checkTypes.stream().map(Checks.CheckType::name).collect(Collectors.joining(",")));
 
         List<String> expectedChecks =
@@ -98,7 +98,7 @@ public class WarningMinerTest {
         Main.main(
                 new String[] {
                     Constants.MINE_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     workdir.toString()
                 });
 
@@ -150,12 +150,12 @@ public class WarningMinerTest {
         String[] baseArgs =
                 new String[] {
                     Constants.MINE_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_STATS_ON_GIT_REPOS,
-                    Constants.ARG_SYMBOL + Constants.ARG_GIT_REPOS_LIST,
+                    Constants.ARG_STATS_ON_GIT_REPOS,
+                    Constants.ARG_GIT_REPOS_LIST,
                     pathToRepos,
-                    Constants.ARG_SYMBOL + Constants.ARG_STATS_OUTPUT_FILE,
+                    Constants.ARG_STATS_OUTPUT_FILE,
                     pathToOutput,
-                    Constants.ARG_SYMBOL + Constants.ARG_TEMP_DIR,
+                    Constants.ARG_TEMP_DIR,
                     pathToTempDir
                 };
         String[] fullArgs =

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -128,13 +128,13 @@ public class ProcessorTestHelper {
         var coreArgs =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_SYMBOL + Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_ORIGINAL_FILES_PATH,
                     originalFileAbspath,
-                    Constants.ARG_SYMBOL + Constants.ARG_RULE_KEYS,
+                    Constants.ARG_RULE_KEYS,
                     Checks.getRuleKey(checkClass),
-                    Constants.ARG_SYMBOL + Constants.ARG_WORKSPACE,
+                    Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE,
-                    Constants.ARG_SYMBOL + Constants.ARG_PRETTY_PRINTING_STRATEGY,
+                    Constants.ARG_PRETTY_PRINTING_STRATEGY,
                     brokenWithSniper
                             ? PrettyPrintingStrategy.NORMAL.name()
                             : PrettyPrintingStrategy.SNIPER.name()


### PR DESCRIPTION
Fix #242 

This is a simple refactor that removes the `Constants.ARG_SYMBOL` constant and puts `--` directly in each argument name. The split was necessary when using the old CLI library, as it required the argument names _without_ the `--` prefix to extract options. picocli doesn't, and so the split is purely an annoyance when writing tests.