### PR TITLE
refactor: Generalize the writing of JSON output

### DIFF
--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -7,11 +7,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.json.JSONObject;
-import sorald.event.StatisticsCollector;
-import sorald.event.StatsMetadataKeys;
 
 public class FileUtils {
 
@@ -94,21 +93,21 @@ public class FileUtils {
     }
 
     /**
-     * Write the statistics JSON file.
+     * Write a core object and additional data to a JSON file.
      *
-     * @param statsOutputFile The file to write to.
-     * @param statsCollector A {@link StatisticsCollector} containing stats.
-     * @param originalArgs The original arguments passed to the command line.
+     * @param file The file to write to.
+     * @param coreObj The core object to form the basis of the JSON output. All getter methods are
+     *     recursively traversed to create the JSON output.
+     * @param additionalData Additional key/value pairs to put in the JSON output.
      * @throws IOException If the file can't be written to.
      */
-    public static void writeStatisticsJSON(
-            File statsOutputFile, StatisticsCollector statsCollector, List<String> originalArgs)
+    public static void writeJSON(File file, Object coreObj, Map<String, Object> additionalData)
             throws IOException {
         // JSONObject's constructor recursively uses getter methods to produce a JSON object
-        JSONObject jo = new JSONObject(statsCollector);
-        jo.put(StatsMetadataKeys.ORIGINAL_ARGS, originalArgs);
+        JSONObject jo = new JSONObject(coreObj);
+        additionalData.forEach(jo::put);
         Files.writeString(
-                statsOutputFile.toPath(),
+                file.toPath(),
                 jo.toString(4),
                 StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING);

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -19,6 +20,7 @@ import sorald.Repair;
 import sorald.RepairStrategy;
 import sorald.SoraldConfig;
 import sorald.event.StatisticsCollector;
+import sorald.event.StatsMetadataKeys;
 import sorald.miner.MineSonarWarnings;
 import sorald.sonar.Checks;
 
@@ -141,10 +143,12 @@ public class Cli {
                     .repair();
 
             if (statsOutputFile != null) {
-                FileUtils.writeStatisticsJSON(
+                FileUtils.writeJSON(
                         statsOutputFile,
                         statsCollector,
-                        spec.commandLine().getParseResult().originalArgs());
+                        Map.of(
+                                StatsMetadataKeys.ORIGINAL_ARGS,
+                                spec.commandLine().getParseResult().originalArgs()));
             }
 
             return 0;


### PR DESCRIPTION
Related to the comments in #269 

@khaes-kth what do you think about this `writeJSON` method? It's completely agnostic about the objects that are passed to it, it will simply use the `coreObj` as a basis for the output, and then attach the key/value pairs of `additionalData` to that output.