### PR TITLE
fix: Make main method exit non-zero instead of throwing

### DIFF
--- a/src/main/java/sorald/Main.java
+++ b/src/main/java/sorald/Main.java
@@ -3,13 +3,10 @@ package sorald;
 import sorald.cli.Cli;
 
 public class Main {
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         int exitStatus = Cli.createCli().execute(args);
-
-        // TODO change this behavior to just exit with the status, we don't actually want to throw
-        //  an exception in the CLI
         if (exitStatus != 0) {
-            throw new IllegalStateException("CLI exited non-zero");
+            System.exit(exitStatus);
         }
     }
 }

--- a/src/test/java/sorald/GatherStatsTest.java
+++ b/src/test/java/sorald/GatherStatsTest.java
@@ -82,6 +82,6 @@ public class GatherStatsTest {
                     statsFile.getAbsolutePath()
                 };
 
-        assertThrows(IllegalStateException.class, () -> Main.main(cliArgs));
+        assertThrows(SystemExitHandler.NonZeroExit.class, () -> Main.main(cliArgs));
     }
 }

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -7,6 +7,7 @@ import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
 import sorald.Constants;
 import sorald.Main;
 import sorald.PrettyPrintingStrategy;
+import sorald.SystemExitHandler;
 import sorald.TestHelper;
 import sorald.sonar.RuleVerifier;
 
@@ -63,6 +64,6 @@ public class SegmentStrategyTest {
                     Constants.ARG_WORKSPACE,
                     Constants.SORALD_WORKSPACE + "/SEGMENT/"
                 };
-        assertThrows(RuntimeException.class, () -> Main.main(args));
+        assertThrows(SystemExitHandler.NonZeroExit.class, () -> Main.main(args));
     }
 }

--- a/src/test/java/sorald/SystemExitHandler.java
+++ b/src/test/java/sorald/SystemExitHandler.java
@@ -1,0 +1,36 @@
+package sorald;
+
+import java.security.Permission;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+public class SystemExitHandler implements TestExecutionListener {
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        System.setSecurityManager(
+                new SecurityManager() {
+                    @Override
+                    public void checkPermission(Permission perm) {}
+
+                    @Override
+                    public void checkPermission(Permission perm, Object context) {}
+
+                    @Override
+                    public void checkExit(int status) {
+                        if (status != 0) {
+                            throw new NonZeroExit();
+                        }
+                    }
+                });
+    }
+
+    @Override
+    public void executionFinished(
+            TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        System.setSecurityManager(null);
+    }
+
+    public static class NonZeroExit extends RuntimeException {}
+}

--- a/src/test/java/sorald/SystemExitHandler.java
+++ b/src/test/java/sorald/SystemExitHandler.java
@@ -5,6 +5,10 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 
+/**
+ * Handler for calls to {@link System#exit(int)}. It intercepts any calls and throws a {@link
+ * NonZeroExit} whenever a non-zero exit is encountered.
+ */
 public class SystemExitHandler implements TestExecutionListener {
 
     @Override

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,1 +1,2 @@
 sorald.WorkspaceCleaner
+sorald.SystemExitHandler


### PR DESCRIPTION
The `Main.main` method currently throws an `IllegalStateException` when there's an error in executing a command. That's super strange, and it looks very odd to a user to see `IllegalStateException` written out in red letters when they mistype a CLI option, or something like that.

This PR fixes that by instead simply exiting non-zero. To make this behavior testable, it adds a custom security manager that throws a particular exception on non-zero exits. The security manager is registered before each test is executed, and unregistered after each test.