### PR TITLE
fix: Use Spoon snapshot to fix incorrect indentation style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,14 @@
         </license>
     </licenses>
 
+    <repositories>
+        <repository>
+            <id>ow2.org-snapshot</id>
+            <name>Maven Repository for Spoon Snapshots</name>
+            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>info.picocli</groupId>
@@ -60,7 +68,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>8.4.0-beta-5</version>
+            <version>8.4.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <!-- must be excluded as it is signed, which causes problems with unsigned version from sonar -->

--- a/src/test/java/sorald/processor/ProcessorTest.java
+++ b/src/test/java/sorald/processor/ProcessorTest.java
@@ -1,5 +1,8 @@
 package sorald.processor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -7,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -135,6 +139,29 @@ public class ProcessorTest {
 
         // assert
         assertTrue(new File(Constants.SORALD_WORKSPACE).exists());
+    }
+
+    @Test
+    public void sorald_doesNotIndentNewElementsWithTabs_whenSourceCodeUsesSpaces()
+            throws Exception {
+        // arrange
+        // rule 2755 always adds new elements, among other things a method
+        ProcessorTestHelper.ProcessorTestCase<?> testCase =
+                ProcessorTestHelper.getTestCaseStream()
+                        .filter(tc -> tc.ruleKey.equals("2755"))
+                        .findFirst()
+                        .get();
+
+        // act
+        ProcessorTestHelper.runSorald(testCase);
+
+        // assert
+        String output =
+                Files.readString(
+                        Paths.get(Constants.SORALD_WORKSPACE)
+                                .resolve(Constants.SPOONED)
+                                .resolve(testCase.outfileRelpath));
+        assertThat(output, not(containsString("\t")));
     }
 
     /**


### PR DESCRIPTION
Fix #256 

The latest snapshot build of Spoon works for resolving the problem with incorrect indentation. I suggest we simply use the snapshot build of Spoon (except for when we make a release), as I'm fairly often contributing to Spoon to fix issues in Sorald.