### PR TITLE
feat: Make Sorald resilient to crashes in processor implementations

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,13 +70,14 @@ So the name of your new processor is `CastArithmeticOperandCheck` replacing "Che
 
 2) Create the processor
 
-Once you have the name for the new processor, you can create a class using that name in `src/main/java/sorald/processor`.
-This new class must extend `SoraldAbstractProcessor` and implement the methods `canRepair` and `repair`.
+Once you have the name for the new processor, you can create a class using that
+name in `src/main/java/sorald/processor`.  This new class must extend
+`SoraldAbstractProcessor` and implement the abstract methods.
 
-> See the documentation for the `canRepair` and `repair` methods in
+> See the documentation for the abstract methods in
 > [SoraldAbstractProcessor](src/main/java/sorald/processor/SoraldAbstractProcessor.java),
-> and check out [the existing implementations here](/src/main/java/sorald/processor)
-> for guidance.
+> and check out [the existing implementations
+> here](/src/main/java/sorald/processor) for guidance.
 
 When you have created your processor, you must also add the check class to one
 of the four categories of check classes in the static code block in

--- a/src/main/java/sorald/event/EventType.java
+++ b/src/main/java/sorald/event/EventType.java
@@ -8,5 +8,6 @@ public enum EventType {
     REPAIR,
     MINING_START,
     MINING_END,
-    MINED
+    MINED,
+    CRASH
 }

--- a/src/main/java/sorald/event/StatisticsCollector.java
+++ b/src/main/java/sorald/event/StatisticsCollector.java
@@ -11,6 +11,7 @@ public class StatisticsCollector implements SoraldEventHandler {
     private long repairStart = -1;
     private long repairEnd = -1;
     private final List<SoraldEvent> repairs = new ArrayList<>();
+    private final List<SoraldEvent> crashes = new ArrayList<>();
 
     @Override
     public void registerEvent(SoraldEvent event) {
@@ -30,6 +31,9 @@ public class StatisticsCollector implements SoraldEventHandler {
             case REPAIR:
                 repairs.add(event);
                 break;
+            case CRASH:
+                crashes.add(event);
+                break;
         }
     }
 
@@ -46,5 +50,10 @@ public class StatisticsCollector implements SoraldEventHandler {
     /** @return All repair event data */
     public List<SoraldEvent> getRepairs() {
         return Collections.unmodifiableList(repairs);
+    }
+
+    /** @return All crash event data */
+    public List<SoraldEvent> getCrashes() {
+        return Collections.unmodifiableList(crashes);
     }
 }

--- a/src/main/java/sorald/event/models/CrashEvent.java
+++ b/src/main/java/sorald/event/models/CrashEvent.java
@@ -1,0 +1,37 @@
+package sorald.event.models;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import sorald.event.EventType;
+import sorald.event.SoraldEvent;
+
+/** Event recording a crash. */
+public class CrashEvent implements SoraldEvent {
+    private final String description;
+    private final Exception exception;
+
+    public CrashEvent(String description, Exception exception) {
+        this.description = description;
+        this.exception = exception;
+    }
+
+    @Override
+    public EventType type() {
+        return EventType.CRASH;
+    }
+
+    public String getStackTrace() {
+        StringWriter buf = new StringWriter();
+        exception.printStackTrace(new PrintWriter(buf));
+        return buf.toString();
+    }
+
+    public String getMessage() {
+        String excMsg = exception.getMessage();
+        return excMsg.isEmpty() ? "N/A" : excMsg;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/sorald/event/models/CrashEvent.java
+++ b/src/main/java/sorald/event/models/CrashEvent.java
@@ -13,6 +13,7 @@ public class CrashEvent implements SoraldEvent {
     public CrashEvent(String description, Exception exception) {
         this.description = description;
         this.exception = exception;
+        exception.printStackTrace();
     }
 
     @Override

--- a/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
@@ -36,7 +36,7 @@ public class ArrayHashCodeAndToStringProcessor extends SoraldAbstractProcessor<C
     }
 
     @Override
-    public void repair(CtInvocation<?> element) {
+    public void repairInternal(CtInvocation<?> element) {
         CtExpression prevTarget = element.getTarget();
         CtClass arraysClass = getFactory().Class().get(Arrays.class);
         CtTypeAccess<?> newTarget = getFactory().createTypeAccess(arraysClass.getReference());

--- a/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
@@ -16,7 +16,7 @@ import spoon.reflect.reference.CtExecutableReference;
 public class ArrayHashCodeAndToStringProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
 
     @Override
-    public boolean canRepair(CtInvocation<?> candidate) {
+    public boolean canRepairInternal(CtInvocation<?> candidate) {
         if (candidate.getTarget() == null) {
             return false;
         }

--- a/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
+++ b/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
@@ -14,7 +14,7 @@ public class BigDecimalDoubleConstructorProcessor
         extends SoraldAbstractProcessor<CtConstructorCall> {
 
     @Override
-    public boolean canRepair(CtConstructorCall cons) {
+    public boolean canRepairInternal(CtConstructorCall cons) {
         CtTypeReference bigDecimalTypeRef = getFactory().createCtTypeReference(BigDecimal.class);
         CtTypeReference doubleTypeRef = getFactory().createCtTypeReference(double.class);
         CtTypeReference floatTypeRef = getFactory().createCtTypeReference(float.class);

--- a/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
+++ b/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
@@ -31,7 +31,7 @@ public class BigDecimalDoubleConstructorProcessor
     }
 
     @Override
-    public void repair(CtConstructorCall cons) {
+    public void repairInternal(CtConstructorCall cons) {
         if (cons.getArguments().size() == 1) {
             CtType bigDecimalClass = getFactory().Class().get(BigDecimal.class);
             CtCodeSnippetExpression invoker =

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -15,7 +15,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBinaryOperator> {
 
     @Override
-    public boolean canRepair(CtBinaryOperator candidate) {
+    public boolean canRepairInternal(CtBinaryOperator candidate) {
         List<CtBinaryOperator> binaryOperatorChildren =
                 candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
         if (binaryOperatorChildren.size()

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -38,7 +38,7 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
     }
 
     @Override
-    public void repair(CtBinaryOperator element) {
+    public void repairInternal(CtBinaryOperator element) {
         CtTypeReference<?> typeToBeUsedToCast = getExpectedType(element);
         CtCodeSnippetExpression newBinaryOperator =
                 element.getFactory()

--- a/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -48,7 +48,7 @@ public class CompareStringsBoxedTypesWithEqualsProcessor
     }
 
     @Override
-    public void repair(CtBinaryOperator<?> element) {
+    public void repairInternal(CtBinaryOperator<?> element) {
         CtExpression<?> lhs = element.getLeftHandOperand();
         CtExpression<?> rhs = element.getRightHandOperand();
 

--- a/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -17,7 +17,7 @@ public class CompareStringsBoxedTypesWithEqualsProcessor
         extends SoraldAbstractProcessor<CtBinaryOperator<?>> {
 
     @Override
-    public boolean canRepair(CtBinaryOperator<?> candidate) {
+    public boolean canRepairInternal(CtBinaryOperator<?> candidate) {
         BinaryOperatorKind opKind = candidate.getKind();
         if (opKind == BinaryOperatorKind.EQ || opKind == BinaryOperatorKind.NE) {
             CtExpression<?> left = candidate.getLeftHandOperand();

--- a/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
+++ b/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
@@ -24,7 +24,7 @@ public class CompareToReturnValueProcessor extends SoraldAbstractProcessor<CtRet
     }
 
     @Override
-    public void repair(CtReturn<?> ctReturn) {
+    public void repairInternal(CtReturn<?> ctReturn) {
         CtLiteral<?> elem2Replace = ctReturn.getFactory().createLiteral(-1);
         ctReturn.getReturnedExpression().replace(elem2Replace);
     }

--- a/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
+++ b/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
@@ -12,7 +12,7 @@ import spoon.reflect.declaration.CtMethod;
 public class CompareToReturnValueProcessor extends SoraldAbstractProcessor<CtReturn<?>> {
 
     @Override
-    public boolean canRepair(CtReturn<?> ctReturn) {
+    public boolean canRepairInternal(CtReturn<?> ctReturn) {
         CtMethod ctMethod = ctReturn.getParent(CtMethod.class);
         String returnTypeName = ctMethod.getType().getSimpleName();
         if (ctMethod.getSimpleName().equals("compareTo")

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -9,7 +9,7 @@ import spoon.reflect.code.CtStatement;
 public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
 
     @Override
-    public boolean canRepair(CtStatement element) {
+    public boolean canRepairInternal(CtStatement element) {
         if (element instanceof CtLocalVariable || element instanceof CtAssignment) {
             return true;
         }

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -17,7 +17,7 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
     }
 
     @Override
-    public void repair(CtStatement element) {
+    public void repairInternal(CtStatement element) {
         element.delete();
     }
 }

--- a/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
+++ b/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
@@ -27,7 +27,7 @@ public class EqualsOnAtomicClassProcessor extends SoraldAbstractProcessor<CtInvo
     }
 
     @Override
-    public void repair(CtInvocation element) {
+    public void repairInternal(CtInvocation element) {
         CtType atomicClass;
         if (isAtomicInteger(element.getTarget())) {
             atomicClass = getFactory().Class().get(AtomicInteger.class);

--- a/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
+++ b/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
@@ -18,7 +18,7 @@ import spoon.reflect.reference.CtExecutableReference;
 public class EqualsOnAtomicClassProcessor extends SoraldAbstractProcessor<CtInvocation> {
 
     @Override
-    public boolean canRepair(CtInvocation candidate) {
+    public boolean canRepairInternal(CtInvocation candidate) {
         if (candidate.getExecutable().getSignature().equals("equals(java.lang.Object)")
                 && isAtomicClassRef(candidate.getTarget())) {
             return true;

--- a/src/main/java/sorald/processor/GetClassLoaderProcessor.java
+++ b/src/main/java/sorald/processor/GetClassLoaderProcessor.java
@@ -40,7 +40,7 @@ public class GetClassLoaderProcessor extends SoraldAbstractProcessor<CtInvocatio
     }
 
     @Override
-    public void repair(CtInvocation<?> element) {
+    public void repairInternal(CtInvocation<?> element) {
         Factory factory = element.getFactory();
         CtClass<?> c = factory.Class().get(Thread.class);
         CtTypeAccess<?> access = factory.createTypeAccess(c.getReference());

--- a/src/main/java/sorald/processor/GetClassLoaderProcessor.java
+++ b/src/main/java/sorald/processor/GetClassLoaderProcessor.java
@@ -16,7 +16,7 @@ public class GetClassLoaderProcessor extends SoraldAbstractProcessor<CtInvocatio
     private HashMap<Integer, Boolean> hashCodesOfTypesUsingJEE = new HashMap<Integer, Boolean>();
 
     @Override
-    public boolean canRepair(CtInvocation<?> invocation) {
+    public boolean canRepairInternal(CtInvocation<?> invocation) {
         String invocationStr = invocation.toString();
         if (invocationStr.contains("getClass().getClassLoader()")
                 || invocationStr.contains(".class.getClassLoader()")) {

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -17,7 +17,7 @@ public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCat
     }
 
     @Override
-    public void repair(CtCatch element) {
+    public void repairInternal(CtCatch element) {
         Factory factory = element.getFactory();
         CtClass<?> threadClass = factory.Class().get(Thread.class);
         CtTypeAccess<?> threadClassAccess = factory.createTypeAccess(threadClass.getReference());

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -12,7 +12,7 @@ import spoon.reflect.factory.Factory;
 public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCatch> {
 
     @Override
-    public boolean canRepair(CtCatch candidate) {
+    public boolean canRepairInternal(CtCatch candidate) {
         return true;
     }
 

--- a/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
+++ b/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
@@ -25,7 +25,7 @@ public class IteratorNextExceptionProcessor extends SoraldAbstractProcessor<CtMe
      *     already throw the correct error.
      */
     @Override
-    public boolean canRepair(CtMethod candidate) {
+    public boolean canRepairInternal(CtMethod candidate) {
         CtType iteratorInterface = getFactory().Interface().get(Iterator.class);
         CtMethod next = (CtMethod) iteratorInterface.getMethodsByName("next").get(0);
         if (candidate.isOverriding(next)) {

--- a/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
+++ b/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
@@ -52,7 +52,7 @@ public class IteratorNextExceptionProcessor extends SoraldAbstractProcessor<CtMe
     }
 
     @Override
-    public void repair(CtMethod method) {
+    public void repairInternal(CtMethod method) {
         CtIf anIf = getFactory().Core().createIf();
         CtCodeSnippetExpression expr = getFactory().Core().createCodeSnippetExpression();
         expr.setValue("!hasNext()");

--- a/src/main/java/sorald/processor/MathOnFloatProcessor.java
+++ b/src/main/java/sorald/processor/MathOnFloatProcessor.java
@@ -13,7 +13,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class MathOnFloatProcessor extends SoraldAbstractProcessor<CtBinaryOperator> {
 
     @Override
-    public boolean canRepair(CtBinaryOperator candidate) {
+    public boolean canRepairInternal(CtBinaryOperator candidate) {
         List<CtBinaryOperator> binaryOperatorChildren =
                 candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
         if (binaryOperatorChildren.size()

--- a/src/main/java/sorald/processor/MathOnFloatProcessor.java
+++ b/src/main/java/sorald/processor/MathOnFloatProcessor.java
@@ -28,7 +28,7 @@ public class MathOnFloatProcessor extends SoraldAbstractProcessor<CtBinaryOperat
     }
 
     @Override
-    public void repair(CtBinaryOperator element) {
+    public void repairInternal(CtBinaryOperator element) {
         CtCodeSnippetExpression newLeftHandOperand =
                 element.getFactory()
                         .createCodeSnippetExpression("(double) " + element.getLeftHandOperand());

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -9,7 +9,7 @@ import spoon.reflect.declaration.ModifierKind;
 @ProcessorAnnotation(key = 1444, description = "\"public static\" fields should be constant")
 public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProcessor<CtField<?>> {
     @Override
-    public boolean canRepair(CtField<?> candidate) {
+    public boolean canRepairInternal(CtField<?> candidate) {
         return true;
     }
 

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -14,7 +14,7 @@ public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProce
     }
 
     @Override
-    public void repair(CtField<?> element) {
+    public void repairInternal(CtField<?> element) {
         element.addModifier(ModifierKind.FINAL);
     }
 }

--- a/src/main/java/sorald/processor/SelfAssignementProcessor.java
+++ b/src/main/java/sorald/processor/SelfAssignementProcessor.java
@@ -17,7 +17,7 @@ import spoon.reflect.factory.Factory;
 public class SelfAssignementProcessor extends SoraldAbstractProcessor<CtAssignment<?, ?>> {
 
     @Override
-    public boolean canRepair(CtAssignment<?, ?> candidate) {
+    public boolean canRepairInternal(CtAssignment<?, ?> candidate) {
         CtExpression<?> leftExpression = candidate.getAssigned();
         CtExpression<?> rightExpression = candidate.getAssignment();
         if (rightExpression == null || candidate.getParent(CtAssignment.class) != null) {

--- a/src/main/java/sorald/processor/SelfAssignementProcessor.java
+++ b/src/main/java/sorald/processor/SelfAssignementProcessor.java
@@ -33,7 +33,7 @@ public class SelfAssignementProcessor extends SoraldAbstractProcessor<CtAssignme
     }
 
     @Override
-    public void repair(CtAssignment<?, ?> element) {
+    public void repairInternal(CtAssignment<?, ?> element) {
         Factory factory = element.getFactory();
         CtType<?> type = element.getParent(CtType.class);
 

--- a/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
@@ -17,7 +17,7 @@ public class SerializableFieldInSerializableClassProcessor
     }
 
     @Override
-    public void repair(CtField element) {
+    public void repairInternal(CtField element) {
         element.addModifier(ModifierKind.TRANSIENT);
     }
 }

--- a/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
@@ -12,7 +12,7 @@ public class SerializableFieldInSerializableClassProcessor
         extends SoraldAbstractProcessor<CtField> {
 
     @Override
-    public boolean canRepair(CtField element) {
+    public boolean canRepairInternal(CtField element) {
         return true;
     }
 

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -12,6 +12,7 @@ import sorald.event.EventHelper;
 import sorald.event.EventType;
 import sorald.event.SoraldEvent;
 import sorald.event.SoraldEventHandler;
+import sorald.event.models.CrashEvent;
 import sorald.sonar.RuleViolation;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtElement;
@@ -65,7 +66,9 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         try {
             return canRepairInternal(candidate);
         } catch (Exception e) {
-            // TODO make note of crash as event
+            EventHelper.fireEvent(
+                    new CrashEvent("Crash in " + getClass().getCanonicalName() + "::canRepair", e),
+                    eventHandlers);
             return false;
         }
     }

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -137,17 +137,21 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
 
     @Override
     public final void process(E element) {
-        assert !processedViolations.contains(bestFits.get(element));
+        try {
+            assert !processedViolations.contains(bestFits.get(element));
 
-        final String ruleKey = getRuleKey();
-        final String elementPosition = element.getPosition().toString();
+            final String ruleKey = getRuleKey();
+            final String elementPosition = element.getPosition().toString();
 
-        repair(element);
+            repair(element);
 
-        EventHelper.fireEvent(new RepairEvent(ruleKey, elementPosition), eventHandlers);
-        UniqueTypesCollector.getInstance().collect(element);
+            EventHelper.fireEvent(new RepairEvent(ruleKey, elementPosition), eventHandlers);
+            UniqueTypesCollector.getInstance().collect(element);
 
-        processedViolations.add(bestFits.get(element));
+            processedViolations.add(bestFits.get(element));
+        } catch (Exception e) {
+            fireCrashEvent("process", e);
+        }
     }
 
     @Override

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -53,20 +53,41 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
      * example, when repairing something involving a method call, there may be nested calls that are
      * not actually the violating parties, but still appear in the correct vicinity.
      *
-     * <p>Note that a processor gets ONE chance to repair a violation. If it returns true, the
-     * violating element is passed to the {@link SoraldAbstractProcessor#repair(CtElement)} method,
-     * and the violation is consumed.
+     * <p><b>This method does not mutate the state of the processor</b>.
      *
-     * <p><b>This method should not mutate the state of the processor</b>.
+     * <p>This method never crashes, instead returning false if there is a problem in the concrete
+     * processor.
      *
      * @param candidate A candidate element to inspect.
      * @return true if the processor can repair the violation based on this element.
      */
-    public abstract boolean canRepair(E candidate);
+    public final boolean canRepair(E candidate) {
+        try {
+            return canRepairInternal(candidate);
+        } catch (Exception e) {
+            // TODO make note of crash as event
+            return false;
+        }
+    }
+
+    /**
+     * Same as the general description of {@link SoraldAbstractProcessor#canRepair(CtElement)}.
+     *
+     * <p>Note that a processor gets ONE chance to repair a violation. If this method returns true,
+     * the violating element is passed to the {@link SoraldAbstractProcessor#repair(CtElement)}
+     * method, and the violation is consumed.
+     *
+     * <p>It is very important that this method <b>does not mutate the state of the processor.</b>
+     * Doing so may have unexpected side effects.
+     *
+     * @param candidate A candidate element.
+     * @return true if the processor can repair the violation based on this element.
+     */
+    protected abstract boolean canRepairInternal(E candidate);
 
     /**
      * Repair a violating element. An element is only passed to this method after having been
-     * accepted by {@link SoraldAbstractProcessor#canRepair(CtElement)}.
+     * accepted by {@link SoraldAbstractProcessor#canRepairInternal(CtElement)}.
      *
      * @param element An element to repair.
      */

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -81,12 +81,15 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
      * <p>This method never crashes.
      *
      * @param element An element to repair.
+     * @return true if the repair proceeded without crashing, false if errors were encountered.
      */
-    public final void repair(E element) {
+    public final boolean repair(E element) {
         try {
             repairInternal(element);
+            return true;
         } catch (Exception e) {
             fireCrashEvent("repairInternal", e);
+            return false;
         }
     }
 

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -66,9 +66,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         try {
             return canRepairInternal(candidate);
         } catch (Exception e) {
-            EventHelper.fireEvent(
-                    new CrashEvent("Crash in " + getClass().getCanonicalName() + "::canRepair", e),
-                    eventHandlers);
+            fireCrashEvent("canRepairInternal", e);
             return false;
         }
     }
@@ -106,7 +104,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         return this;
     }
 
-    public SoraldAbstractProcessor<?> setEventHandlers(List<SoraldEventHandler> eventHandlers) {
+    public SoraldAbstractProcessor<E> setEventHandlers(List<SoraldEventHandler> eventHandlers) {
         this.eventHandlers = eventHandlers;
         return this;
     }
@@ -179,5 +177,11 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         public String getRuleViolationPosition() {
             return ruleViolationPosition;
         }
+    }
+
+    private void fireCrashEvent(String methodName, Exception e) {
+        EventHelper.fireEvent(
+                new CrashEvent("Crash in " + getClass().getCanonicalName() + "::" + methodName, e),
+                eventHandlers);
     }
 }

--- a/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
@@ -46,7 +46,7 @@ public class SynchronizationOnGetClassProcessor extends SoraldAbstractProcessor<
     }
 
     @Override
-    public void repair(CtSynchronized element) {
+    public void repairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         CtTypeReference<?> typeRef;
         if (expression.toString().equals("getClass()")) {

--- a/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
@@ -17,7 +17,7 @@ import spoon.reflect.reference.CtTypeReference;
 public class SynchronizationOnGetClassProcessor extends SoraldAbstractProcessor<CtSynchronized> {
 
     @Override
-    public boolean canRepair(CtSynchronized element) {
+    public boolean canRepairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         if (expression.toString().endsWith("getClass()")) {
             CtExpression target = ((CtInvocation) expression).getTarget();

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -34,7 +34,7 @@ public class SynchronizationOnStringOrBoxedProcessor
     }
 
     @Override
-    public boolean canRepair(CtSynchronized element) {
+    public boolean canRepairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         if (!expression.getType().toString().equals("String")
                 && !expression.getType().unbox().isPrimitive()) {

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -67,7 +67,7 @@ public class SynchronizationOnStringOrBoxedProcessor
     }
 
     @Override
-    public void repair(CtSynchronized element) {
+    public void repairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         Factory factory = element.getFactory();
         CtFieldRead<?> fieldRead4Update;

--- a/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
@@ -17,7 +17,7 @@ import spoon.reflect.reference.CtVariableReference;
 public class UnclosedResourcesProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
 
     @Override
-    public boolean canRepair(CtConstructorCall element) {
+    public boolean canRepairInternal(CtConstructorCall element) {
         return element.getParent(e -> e instanceof CtConstructorCall) == null;
     }
 

--- a/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
@@ -22,7 +22,7 @@ public class UnclosedResourcesProcessor extends SoraldAbstractProcessor<CtConstr
     }
 
     @Override
-    public void repair(CtConstructorCall element) {
+    public void repairInternal(CtConstructorCall element) {
         CtElement parent =
                 element.getParent(e -> e instanceof CtAssignment || e instanceof CtLocalVariable);
 

--- a/src/main/java/sorald/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sorald/processor/UnusedThrowableProcessor.java
@@ -10,7 +10,7 @@ import spoon.reflect.code.CtThrow;
 public class UnusedThrowableProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
 
     @Override
-    public boolean canRepair(CtConstructorCall element) {
+    public boolean canRepairInternal(CtConstructorCall element) {
         return true;
     }
 

--- a/src/main/java/sorald/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sorald/processor/UnusedThrowableProcessor.java
@@ -15,7 +15,7 @@ public class UnusedThrowableProcessor extends SoraldAbstractProcessor<CtConstruc
     }
 
     @Override
-    public void repair(CtConstructorCall element) {
+    public void repairInternal(CtConstructorCall element) {
         CtThrow ctThrow = getFactory().createCtThrow(element.toString());
         element.replace(ctThrow);
     }

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -49,7 +49,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
     }
 
     @Override
-    public void repair(CtInvocation<?> element) {
+    public void repairInternal(CtInvocation<?> element) {
         CtType<?> declaringType = element.getParent(CtType.class);
 
         CtMethod<?> factoryMethod = createFactoryMethod(element, declaringType);

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -36,7 +36,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
     private static final String XML_INPUT_FACTORY = "XMLInputFactory";
 
     @Override
-    public boolean canRepair(CtInvocation<?> candidate) {
+    public boolean canRepairInternal(CtInvocation<?> candidate) {
         return isSupported(candidate);
     }
 

--- a/src/main/java/sorald/sonar/GreedyBestFitScanner.java
+++ b/src/main/java/sorald/sonar/GreedyBestFitScanner.java
@@ -29,7 +29,7 @@ public class GreedyBestFitScanner<E extends CtElement> extends CtScanner {
      * <p>First it tries to find a Spoon element that intersects the rule violation's position. If
      * that fails, it searches all Spoon elements that start on the same line that the rule
      * violation starts on. Only elements that return true for {@link
-     * SoraldAbstractProcessor#canRepair(CtElement)} are considered as potential best fits.
+     * SoraldAbstractProcessor#canRepairInternal(CtElement)} are considered as potential best fits.
      *
      * <p>The matching is 1:1, but there is no guarantee that all violations appear in the value
      * set.

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -1,0 +1,26 @@
+package sorald.processor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import spoon.reflect.code.CtInvocation;
+
+/** Tests for the concrete methods of {@link sorald.processor.SoraldAbstractProcessor}. */
+public class SoraldAbstractProcessorTest {
+
+    @Test
+    public void canRepair_returnsFalse_whenInternalMethodCrashes() {
+        SoraldAbstractProcessor<?> crashyProcessor =
+                new SoraldAbstractProcessor<CtInvocation<?>>() {
+                    @Override
+                    protected boolean canRepairInternal(CtInvocation<?> candidate) {
+                        throw new RuntimeException("I'm crashy :)");
+                    }
+
+                    @Override
+                    public void repair(CtInvocation<?> element) {}
+                };
+
+        assertFalse(crashyProcessor.canRepair(null));
+    }
+}

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -53,6 +53,17 @@ public class SoraldAbstractProcessorTest {
         assertThat(statsCollector.getCrashes().size(), equalTo(1));
     }
 
+    @Test
+    public void process_recordsCrashEvent() {
+        var statsCollector = new StatisticsCollector();
+        var crashyProcessor = new CrashyProcessor().setEventHandlers(List.of(statsCollector));
+
+        // this will crash as we haven't set the bestFits for the processor
+        crashyProcessor.process(getObjectToString());
+
+        assertThat(statsCollector.getCrashes().size(), equalTo(1));
+    }
+
     /** Processor that always crashes. */
     private static class CrashyProcessor extends SoraldAbstractProcessor<CtMethod<?>> {
         @Override

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import sorald.event.StatisticsCollector;
@@ -24,7 +23,7 @@ public class SoraldAbstractProcessorTest {
     }
 
     @Test
-    public void canRepair_recordsCrashEvent() throws IOException {
+    public void canRepair_recordsCrashEvent() {
         var crashyProcessor = new CrashyProcessor();
         var statsCollector = new StatisticsCollector();
         CtMethod<?> objectToString = getObjectToString();
@@ -32,6 +31,17 @@ public class SoraldAbstractProcessorTest {
         crashyProcessor.setEventHandlers(List.of(statsCollector));
 
         crashyProcessor.canRepair(objectToString);
+
+        assertThat(statsCollector.getCrashes().size(), equalTo(1));
+    }
+
+    @Test
+    public void process_recordsCrashEvent() {
+        var statsCollector = new StatisticsCollector();
+        var crashyProcessor = new CrashyProcessor().setEventHandlers(List.of(statsCollector));
+        CtMethod<?> objectToString = getObjectToString();
+
+        crashyProcessor.repair(objectToString);
 
         assertThat(statsCollector.getCrashes().size(), equalTo(1));
     }
@@ -44,7 +54,9 @@ public class SoraldAbstractProcessorTest {
         }
 
         @Override
-        public void repair(CtMethod<?> element) {}
+        public void repairInternal(CtMethod<?> element) {
+            throw EXCEPTION;
+        }
     }
 
     private static CtMethod<?> getObjectToString() {

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -18,7 +18,9 @@ public class SoraldAbstractProcessorTest {
 
     @Test
     public void canRepair_returnsFalse_whenInternalMethodCrashes() {
-        assertFalse(new CrashyProcessor().canRepair(getObjectToString()));
+        var crashyProcessor =
+                new CrashyProcessor().setEventHandlers(List.of(new StatisticsCollector()));
+        assertFalse(crashyProcessor.canRepair(getObjectToString()));
     }
 
     @Test

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -36,7 +36,14 @@ public class SoraldAbstractProcessorTest {
     }
 
     @Test
-    public void process_recordsCrashEvent() {
+    public void repair_returnsFalse_whenInternalMethodCrashes() {
+        var crashyProcessor =
+                new CrashyProcessor().setEventHandlers(List.of(new StatisticsCollector()));
+        assertFalse(crashyProcessor.repair(getObjectToString()));
+    }
+
+    @Test
+    public void repair_recordsCrashEvent() {
         var statsCollector = new StatisticsCollector();
         var crashyProcessor = new CrashyProcessor().setEventHandlers(List.of(statsCollector));
         CtMethod<?> objectToString = getObjectToString();

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -1,26 +1,53 @@
 package sorald.processor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.Test;
-import spoon.reflect.code.CtInvocation;
+import sorald.event.StatisticsCollector;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
 
 /** Tests for the concrete methods of {@link sorald.processor.SoraldAbstractProcessor}. */
 public class SoraldAbstractProcessorTest {
+    private static final RuntimeException EXCEPTION = new RuntimeException("I'm a crash :)");
 
     @Test
     public void canRepair_returnsFalse_whenInternalMethodCrashes() {
-        assertFalse(new CrashyProcessor().canRepair(null));
+        assertFalse(new CrashyProcessor().canRepair(getObjectToString()));
+    }
+
+    @Test
+    public void canRepair_recordsCrashEvent() throws IOException {
+        var crashyProcessor = new CrashyProcessor();
+        var statsCollector = new StatisticsCollector();
+        CtMethod<?> objectToString = getObjectToString();
+
+        crashyProcessor.setEventHandlers(List.of(statsCollector));
+
+        crashyProcessor.canRepair(objectToString);
+
+        assertThat(statsCollector.getCrashes().size(), equalTo(1));
     }
 
     /** Processor that always crashes. */
-    private static class CrashyProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
+    private static class CrashyProcessor extends SoraldAbstractProcessor<CtMethod<?>> {
         @Override
-        protected boolean canRepairInternal(CtInvocation<?> candidate) {
-            throw new RuntimeException("I'm crashy :)");
+        protected boolean canRepairInternal(CtMethod<?> candidate) {
+            throw EXCEPTION;
         }
 
         @Override
-        public void repair(CtInvocation<?> element) {}
+        public void repair(CtMethod<?> element) {}
+    }
+
+    private static CtMethod<?> getObjectToString() {
+        Launcher launcher = new Launcher();
+        CtType<?> type = launcher.getFactory().Type().OBJECT.getTypeDeclaration();
+        return type.getMethod("toString");
     }
 }

--- a/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
+++ b/src/test/java/sorald/processor/SoraldAbstractProcessorTest.java
@@ -10,17 +10,17 @@ public class SoraldAbstractProcessorTest {
 
     @Test
     public void canRepair_returnsFalse_whenInternalMethodCrashes() {
-        SoraldAbstractProcessor<?> crashyProcessor =
-                new SoraldAbstractProcessor<CtInvocation<?>>() {
-                    @Override
-                    protected boolean canRepairInternal(CtInvocation<?> candidate) {
-                        throw new RuntimeException("I'm crashy :)");
-                    }
+        assertFalse(new CrashyProcessor().canRepair(null));
+    }
 
-                    @Override
-                    public void repair(CtInvocation<?> element) {}
-                };
+    /** Processor that always crashes. */
+    private static class CrashyProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
+        @Override
+        protected boolean canRepairInternal(CtInvocation<?> candidate) {
+            throw new RuntimeException("I'm crashy :)");
+        }
 
-        assertFalse(crashyProcessor.canRepair(null));
+        @Override
+        public void repair(CtInvocation<?> element) {}
     }
 }


### PR DESCRIPTION
Fix #210 
Fix #278 

This PR makes Sorald more resilient to crashes in processor implementations. It essentially does these three things:

* Rename `canRepair` to `canRepairInternal` and create a new concrete method `canRepair` in `SoraldAbstractProcessor` that just calls the internal method and catches any exceptions.
* Same thing for `SoraldAbstractProcessor::repair`
* Wrap the entirety of `SoraldAbstractProcessor::process` in a try/catch.

All these crashes are recorded as crash events, that when printed in the JSON output look something like this:

```json
    "crashes": [{
        "description": "Crash in sorald.processor.SoraldAbstractProcessorTest.CrashyProcessor::canRepair",
        "stackTrace": "java.lang.RuntimeException: I'm a crash :)\n\tat sorald.processor.SoraldAbstractProcessorTest.<clinit>(SoraldAbstractProcessorTest.java:22)\n\tat java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)\n\tat java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)\n\tat org.junit.platform.commons.util.ReflectionUtils.newInstance(ReflectionUtils.java:513)\n\tat org.junit.jupiter.engine.execution.ConstructorInvocation.proceed(ConstructorInvocation.java:56)\n\tat org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)\n\tat org.junit.jupiter.api.extension.InvocationInterceptor.interceptTestClassConstructor(InvocationInterceptor.java:72)\n\tat org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)\n\tat org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)\n\tat org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)\n\tat org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)\n\tat org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)\n\tat org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)\n\tat org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:77)\n\tat org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeTestClassConstructor(ClassBasedTestDescriptor.java:342)\n\tat org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateTestClass(ClassBasedTestDescriptor.java:289)\n\tat org.junit.jupiter.engine.descriptor.ClassTestDescriptor.instantiateTestClass(ClassTestDescriptor.java:79)\n\tat org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateAndPostProcessTestInstance(ClassBasedTestDescriptor.java:267)\n\tat org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$2(ClassBasedTestDescriptor.java:259)\n\tat java.base/java.util.Optional.orElseGet(Optional.java:369)\n\tat org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$3(ClassBasedTestDescriptor.java:258)\n\tat org.junit.jupiter.engine.execution.TestInstancesProvider.getTestInstances(TestInstancesProvider.java:31)\n\tat org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$prepare$0(TestMethodTestDescriptor.java:101)\n\tat org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)\n\tat org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:100)\n\tat org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:65)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$prepare$1(NodeTestTask.java:111)\n\tat org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.prepare(NodeTestTask.java:111)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:79)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1541)\n\tat org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)\n\tat org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)\n\tat org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)\n\tat org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1541)\n\tat org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)\n\tat org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)\n\tat org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)\n\tat org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)\n\tat org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)\n\tat org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)\n\tat org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)\n\tat org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)\n\tat org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)\n\tat org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)\n\tat org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)\n\tat org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)\n\tat org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)\n\tat org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)\n\tat org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)\n\tat com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:71)\n\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)\n\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)\n\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)\n",
        "message": "I'm a crash :)"
    }],
```

