### PR TITLE
feat: Automatically resolve version info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,24 @@
                 </executions>
             </plugin>
             <plugin>
+                <!-- creates the build number (git commit hash) that is later attached to the manifest -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals><goal>create</goal></goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                    <shortRevisionLength>8</shortRevisionLength>
+                    <attach>true</attach>
+                    <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.3.0</version>
@@ -154,6 +172,8 @@
                             <mainClass>sorald.Main</mainClass>
                         </manifest>
                         <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Implementation-SCM-Revision>${buildNumber}</Implementation-SCM-Revision>
                             <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -7,8 +7,6 @@ import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.sonar.Checks;
 
 public class Constants {
-    public static final String SORALD_VERSION = "92d377cc39f63be35f9bee00d372c8f1ca06be5e";
-
     public static final String REPAIR_COMMAND_NAME = "repair";
     public static final String MINE_COMMAND_NAME = "mine";
 

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -43,7 +43,8 @@ public class Cli {
             subcommands = {RepairCommand.class, MineCommand.class},
             description =
                     "The Sorald command line application for automatic repair of Sonar rule violations.",
-            synopsisSubcommandLabel = "<COMMAND>")
+            synopsisSubcommandLabel = "<COMMAND>",
+            versionProvider = SoraldVersionProvider.class)
     static class SoraldCLI implements Callable<Integer> {
 
         @Override

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -337,7 +337,8 @@ public class Cli {
                                 StatsMetadataKeys.EXECUTION_INFO,
                                 new ExecutionInfo(
                                         spec.commandLine().getParseResult().originalArgs(),
-                                        Constants.SORALD_VERSION,
+                                        SoraldVersionProvider.getVersionFromPropertiesResource(
+                                                SoraldVersionProvider.DEFAULT_RESOURCE_NAME),
                                         javaVersion,
                                         target));
 

--- a/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -1,0 +1,39 @@
+package sorald.cli;
+
+import java.util.Properties;
+import picocli.CommandLine;
+
+/** Class for providing the CLI with the current version. */
+public class SoraldVersionProvider implements CommandLine.IVersionProvider {
+    static final String LOCAL_VERSION = "LOCAL";
+
+    static final String VERSION_KEY = "Implementation-Version";
+    static final String COMMIT_KEY = "Implementation-SCM-Revision";
+
+    @Override
+    public String[] getVersion() {
+        return new String[] {getVersionFromPropertiesResource("META-INF/MANIFEST.MF")};
+    }
+
+    public static String getVersionFromPropertiesResource(String resourceName) {
+        Properties props = new Properties();
+        try {
+            props.load(
+                    SoraldVersionProvider.class.getClassLoader().getResourceAsStream(resourceName));
+        } catch (Exception e) {
+            return LOCAL_VERSION;
+        }
+        return getVersionFromProperties(props);
+    }
+
+    public static String getVersionFromProperties(Properties props) {
+        String version = props.getProperty(VERSION_KEY);
+        String commitSha = props.getProperty(COMMIT_KEY);
+
+        if (version == null || commitSha == null) {
+            return LOCAL_VERSION;
+        } else {
+            return version.contains("SNAPSHOT") ? "commit: " + commitSha : version;
+        }
+    }
+}

--- a/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -5,16 +5,25 @@ import picocli.CommandLine;
 
 /** Class for providing the CLI with the current version. */
 public class SoraldVersionProvider implements CommandLine.IVersionProvider {
-    static final String LOCAL_VERSION = "LOCAL";
+    public static final String LOCAL_VERSION = "LOCAL";
 
     static final String VERSION_KEY = "Implementation-Version";
     static final String COMMIT_KEY = "Implementation-SCM-Revision";
 
+    public static final String DEFAULT_RESOURCE_NAME = "META-INF/MANIFEST.MF";
+
     @Override
     public String[] getVersion() {
-        return new String[] {getVersionFromPropertiesResource("META-INF/MANIFEST.MF")};
+        return new String[] {getVersionFromPropertiesResource(DEFAULT_RESOURCE_NAME)};
     }
 
+    /**
+     * Tries to fetch the version from the given resource, that is fetched via the class loader. If
+     * the version is a snapshot version, the commit hash is used instead.
+     *
+     * @param resourceName Name of the resource.
+     * @return The resolved version.
+     */
     public static String getVersionFromPropertiesResource(String resourceName) {
         Properties props = new Properties();
         try {
@@ -26,7 +35,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
         return getVersionFromProperties(props);
     }
 
-    public static String getVersionFromProperties(Properties props) {
+    private static String getVersionFromProperties(Properties props) {
         String version = props.getProperty(VERSION_KEY);
         String commitSha = props.getProperty(COMMIT_KEY);
 

--- a/src/test/java/sorald/cli/CliTest.java
+++ b/src/test/java/sorald/cli/CliTest.java
@@ -1,5 +1,11 @@
 package sorald.cli;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import org.junit.jupiter.api.Test;
 
 /** General tests of the CLI functionality. */
@@ -9,5 +15,16 @@ public class CliTest {
     public void cli_exitsNonZero_whenExecutedWithoutSubcommand() {
         int exitStatus = Cli.createCli().execute();
         assert exitStatus != 0;
+    }
+
+    @Test
+    public void cli_providesLocalVersion_whenNotPackaged() {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        int exitStatus = Cli.createCli().execute("--version");
+
+        assertThat(exitStatus, equalTo(0));
+        assertThat(out.toString(), containsString(SoraldVersionProvider.LOCAL_VERSION));
     }
 }

--- a/src/test/java/sorald/cli/SoraldVersionProviderTest.java
+++ b/src/test/java/sorald/cli/SoraldVersionProviderTest.java
@@ -1,0 +1,47 @@
+package sorald.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+public class SoraldVersionProviderTest {
+    private static final Path BOGUS_MANIFESTS = Paths.get("META-INF").resolve("bogus-manifests");
+
+    private static final String VERSION_IN_MANIFESTS = "1.2.3";
+    private static final String COMMIT_IN_MANIFESTS = "123456";
+
+    @Test
+    public void getVersionFromPropertiesResource_returnsLocalVersion_whenResourceDoesNotExist() {
+        assertThat(
+                SoraldVersionProvider.getVersionFromPropertiesResource("no/such/resource"),
+                equalTo(SoraldVersionProvider.LOCAL_VERSION));
+    }
+
+    @Test
+    public void getVersionFromPropertiesResource_returnsVersion_whenNonSnapshot() {
+        String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-RELEASE-VERSION.MF").toString();
+        assertThat(
+                SoraldVersionProvider.getVersionFromPropertiesResource(resourceName),
+                equalTo(VERSION_IN_MANIFESTS));
+    }
+
+    @Test
+    public void getVersionFromPropertiesResource_returnsCommitSha_whenSnapshot() {
+        String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-SNAPSHOT-VERSION.MF").toString();
+        assertThat(
+                SoraldVersionProvider.getVersionFromPropertiesResource(resourceName),
+                equalTo("commit: " + COMMIT_IN_MANIFESTS));
+    }
+
+    @Test
+    public void
+            getVersionFromPropertiesResource_returnsLocalVersion_whenResourceIsMissingVersion() {
+        String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-WITHOUT-VERSION.MF").toString();
+        assertThat(
+                SoraldVersionProvider.getVersionFromPropertiesResource(resourceName),
+                equalTo(SoraldVersionProvider.LOCAL_VERSION));
+    }
+}

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -26,6 +26,7 @@ import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.FileUtils;
 import sorald.Main;
+import sorald.cli.SoraldVersionProvider;
 import sorald.event.StatsMetadataKeys;
 import sorald.sonar.Checks;
 
@@ -151,7 +152,9 @@ public class WarningMinerTest {
 
         assertThat(
                 executionInfo.get(StatsMetadataKeys.SORALD_VERSION),
-                equalTo(Constants.SORALD_VERSION));
+                equalTo(
+                        SoraldVersionProvider.getVersionFromPropertiesResource(
+                                SoraldVersionProvider.DEFAULT_RESOURCE_NAME)));
         assertThat(
                 executionInfo.get(StatsMetadataKeys.JAVA_VERSION),
                 equalTo(System.getProperty(Constants.JAVA_VERSION_SYSTEM_PROPERTY)));

--- a/src/test/resources/META-INF/bogus-manifests/MANIFEST-RELEASE-VERSION.MF
+++ b/src/test/resources/META-INF/bogus-manifests/MANIFEST-RELEASE-VERSION.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Implementation-Version: 1.2.3
+Implementation-SCM-Revision: 123456

--- a/src/test/resources/META-INF/bogus-manifests/MANIFEST-SNAPSHOT-VERSION.MF
+++ b/src/test/resources/META-INF/bogus-manifests/MANIFEST-SNAPSHOT-VERSION.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Implementation-Version: 1.2.3-SNAPSHOT
+Implementation-SCM-Revision: 123456

--- a/src/test/resources/META-INF/bogus-manifests/MANIFEST-WITHOUT-VERSION.MF
+++ b/src/test/resources/META-INF/bogus-manifests/MANIFEST-WITHOUT-VERSION.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Implementation-SCM-Revision: 123456


### PR DESCRIPTION
Related to #246 

This PR adds dynamic resolution of version info. The version number is only used if it is a release version (i.e. non-snapshot). Otherwise, falls back on the commit hash (shortened to 8 characters for readability and prefixed with `commit: ` to make it clear that it's a commit hash).

The version and commit hash are added to the MANIFEST.MF file in the jar, which is configured in `pom.xml`

What's also new here is that `sorald --version` now prints the version number, which it did not previously.