### PR TITLE
fix: Fix null dereference in ArrayHashCodeAndToStringProcessor

### DIFF
--- a/src/main/java/sorald/event/StatsMetadataKeys.java
+++ b/src/main/java/sorald/event/StatsMetadataKeys.java
@@ -11,6 +11,7 @@ public class StatsMetadataKeys {
     public static final String START_TIME_MS = "startTimeMs";
     public static final String END_TIME_MS = "endTimeMs";
     public static final String VIOLATION_SPECIFIER = "violationSpecifier";
+    public static final String CRASHES = "crashes";
 
     public static final String EXECUTION_INFO = "executionInfo";
     public static final String SORALD_VERSION = "soraldVersion";

--- a/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
@@ -17,10 +17,11 @@ public class ArrayHashCodeAndToStringProcessor extends SoraldAbstractProcessor<C
 
     @Override
     public boolean canRepairInternal(CtInvocation<?> candidate) {
-        if (candidate.getTarget() == null) {
+        CtExpression<?> target = candidate.getTarget();
+        if (target == null || target.getType() == null) {
             return false;
         }
-        if (candidate.getTarget().getType().isArray()) {
+        if (target.getType().isArray()) {
             if (candidate
                             .getExecutable()
                             .getSignature()

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -26,6 +26,7 @@ import sorald.sonar.RuleVerifier;
 public class ProcessorTestHelper {
     public static final Path TEST_FILES_ROOT =
             Paths.get(Constants.PATH_TO_RESOURCES_FOLDER).resolve("processor_test_files");
+
     static final String EXPECTED_FILE_SUFFIX = ".expected";
     // The processors related to these checks currently cause problems with the sniper printer
     static final List<Class<?>> BROKEN_WITH_SNIPER =

--- a/src/test/resources/processor_test_files/2116_ArrayHashCodeAndToString/UnresolvableType.java
+++ b/src/test/resources/processor_test_files/2116_ArrayHashCodeAndToString/UnresolvableType.java
@@ -1,0 +1,10 @@
+// the type of this method cannot be resolved
+import static some.unavailable.pkg.someMethod;
+
+public class UnresolvableType {
+    public static void main(String[] args) {
+        int[] arr = new int[]{1,2,3};
+
+        System.out.println(someMethod().toString() + arr.toString()); // Noncompliant
+    }
+}


### PR DESCRIPTION
Fix #276 

This PR does three things.

1. 9451185 Adds a check in the `ProcessorTest.testProcessSingleFile` that the statistics collector does not report any crashes
    - This is necessary, as the crash reported in #276 is now caught and reported, instead of causing an application failure
2. 8ee678c Adds a new test case file to replicate the problem from #276 
3. 5be0956 Fixes the problem