### PR TITLE
feat: Enable stats collection in segment mode

### DIFF
--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import sorald.event.EventHelper;
 import sorald.event.EventType;
 import sorald.event.SoraldEventHandler;
+import sorald.event.models.CrashEvent;
 import sorald.event.models.miner.MinedViolationEvent;
 import sorald.processor.SoraldAbstractProcessor;
 import sorald.segment.FirstFitSegmentationAlgorithm;
@@ -191,7 +192,13 @@ public class Repair {
                                 EventHelper.fireEvent(EventType.REPAIR_END, eventHandlers);
                                 return model;
                             } catch (Exception e) {
-                                // TODO record as crash event
+                                List<String> rootPaths =
+                                        segment.stream()
+                                                .map(Node::getRootPath)
+                                                .collect(Collectors.toList());
+                                EventHelper.fireEvent(
+                                        new CrashEvent("Crash in segment: " + rootPaths, e),
+                                        eventHandlers);
                                 e.printStackTrace();
                                 return null;
                             }

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -182,8 +182,13 @@ public class Repair {
                 .map(
                         segment -> {
                             try {
+                                EventHelper.fireEvent(EventType.PARSE_START, eventHandlers);
                                 CtModel model = parseSegment.apply(segment);
+                                EventHelper.fireEvent(EventType.PARSE_END, eventHandlers);
+
+                                EventHelper.fireEvent(EventType.REPAIR_START, eventHandlers);
                                 repairModelWithInitializedProcessor(model, processor, violations);
+                                EventHelper.fireEvent(EventType.REPAIR_END, eventHandlers);
                                 return model;
                             } catch (Exception e) {
                                 // TODO record as crash event

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -192,19 +192,25 @@ public class Repair {
                                 EventHelper.fireEvent(EventType.REPAIR_END, eventHandlers);
                                 return model;
                             } catch (Exception e) {
-                                List<String> rootPaths =
-                                        segment.stream()
-                                                .map(Node::getRootPath)
-                                                .collect(Collectors.toList());
-                                EventHelper.fireEvent(
-                                        new CrashEvent("Crash in segment: " + rootPaths, e),
-                                        eventHandlers);
+                                reportSegmentCrash(segment, e);
                                 e.printStackTrace();
                                 return null;
                             }
                         })
                 .filter(Objects::nonNull)
                 .takeWhile(model -> processor.getNbFixes() < config.getMaxFixesPerRule());
+    }
+
+    private void reportSegmentCrash(LinkedList<Node> segment, Exception e) {
+        List<String> paths =
+                segment.stream()
+                        .map(
+                                node ->
+                                        node.isDirNode()
+                                                ? node.getRootPath()
+                                                : node.getJavaFiles().toString())
+                        .collect(Collectors.toList());
+        EventHelper.fireEvent(new CrashEvent("Crash in segment: " + paths, e), eventHandlers);
     }
 
     private Pair<Path, Path> computeInOutPaths(boolean isFirstRule, boolean isLastRule) {

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -173,13 +173,6 @@ class RepairCommand extends BaseCommand {
                     Constants.ARG_MAX_FILES_PER_SEGMENT + " must be greater than 0");
         }
 
-        if (statsOutputFile != null && repairStrategy == RepairStrategy.SEGMENT) {
-            throw new CommandLine.ParameterException(
-                    spec.commandLine(),
-                    RepairStrategy.SEGMENT.name()
-                            + " repair does not currently support statistics collection");
-        }
-
         validateRuleKeys();
     }
 


### PR DESCRIPTION
Fix #289 

This PR introduces stats collection for segment mode. As there are so few differences between segment mode and default mode, this is fairly trivial. It's just a matter of collecting the running times for parsing and repairing slightly differently.