### PR TITLE
experiment: Add script for recording Sorald PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,20 @@ jobs:
         uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9 # v1.0.15
         with:
           fail_ci_if_error: true
+
+  test-prrecorder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/setup-python@8c5ea631b2b2d5d8840cf4a2b183a8a0edc1e40d # v2.2.0
+        with:
+          python-version: 3.8
+      - name: Install prerequisites
+        run:
+          cd experimentation/tools/pr_recorder/
+          pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Test prrecorder
+        run:
+          pytest test_prrecorder.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,9 @@ jobs:
       - uses: actions/setup-python@8c5ea631b2b2d5d8840cf4a2b183a8a0edc1e40d # v2.2.0
         with:
           python-version: 3.8
-      - name: Install prerequisites
+      - name: Test prrecorder
         run: |
           cd experimentation/tools/pr_recorder/
           pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Test prrecorder
-        run:
           pytest test_prrecorder.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install prerequisites
-        run:
+        run: |
           cd experimentation/tools/pr_recorder/
           pip install --upgrade pip
           pip install -r requirements.txt

--- a/experimentation/tools/pr_recorder/prrecorder.py
+++ b/experimentation/tools/pr_recorder/prrecorder.py
@@ -1,0 +1,180 @@
+"""Script for recording PRs made with Sorald."""
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+import copy
+from typing import List, Optional
+
+import git
+import github
+import requests
+
+
+PRS_JSON = "prs.json"
+
+RECORD_INITIAL = "record-initial"
+RECORD_FINAL = "record-final"
+
+ENCODING = "utf8"
+
+PR_DATA_KEY = "pr"
+DIFF_DATA_KEY = "diff"
+RECORD_DATA_KEY = "record_metadata"
+MANUAL_EDITS_KEY = "manual_edits"
+
+
+def main():
+    parsed_args = parse_args(sys.argv[1:])
+
+    data = read_json_if_exists(parsed_args.prs_json_file, ENCODING)
+
+    repo_slug = f"{parsed_args.owner}/{parsed_args.repo_name}"
+    record_id = f"{repo_slug}#{parsed_args.pr_number}"
+
+    gh = github.Github(base_url="https://api.github.com")
+    repo = gh.get_repo(repo_slug)
+    pr = repo.get_pull(parsed_args.pr_number)
+
+    if parsed_args.command == RECORD_INITIAL:
+        record = execute_record_initial(
+            repo_slug, record_id, data, pr, parsed_args.sorald_stats_file
+        )
+        data[record_id] = record
+    elif parsed_args.command == RECORD_FINAL:
+        record = execute_record_final(record_id, data, pr)
+        data[record_id] = record
+    else:
+        raise RuntimeError(f"Unrecognized command {parsed_args.command}")
+
+    parsed_args.prs_json_file.write_text(json.dumps(data, indent=4), encoding=ENCODING)
+
+
+def execute_record_initial(
+    repo_slug: str,
+    record_id: str,
+    data: dict,
+    pr: github.PullRequest.PullRequest,
+    sorald_stats_file: Optional[pathlib.Path],
+) -> dict:
+    if record_id in data:
+        print(
+            f"Cannot create inital record for {record_id}: already exists!",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    sorald_stats = read_json_if_exists(sorald_stats_file, sys.getdefaultencoding())
+    return create_initial_record(repo_slug, pr, sorald_stats)
+
+
+def execute_record_final(
+    record_id: str,
+    data: dict,
+    pr: github.PullRequest.PullRequest,
+):
+    if record_id not in data:
+        print(
+            f"Cannot create final record for {record_id}: "
+            f"initial record does not exist. Please run {RECORD_INITIAL} "
+            "for this record first."
+        )
+        sys.exit(1)
+
+    record = copy.deepcopy(data[record_id])
+    record[PR_DATA_KEY].update(get_pr_state(pr))
+    record[DIFF_DATA_KEY]["final"] = get_diff(pr.diff_url)
+
+    return record
+
+
+def create_initial_record(
+    repo_slug: str, pr: github.PullRequest.PullRequest, sorald_stats: dict
+) -> dict:
+    created_at = str(datetime.datetime.now())
+    return {
+        "repo_slug": repo_slug,
+        PR_DATA_KEY: get_pr_state(pr),
+        "sorald_statistics": sorald_stats,
+        DIFF_DATA_KEY: dict(initial=get_diff(pr.diff_url), final=None),
+        MANUAL_EDITS_KEY: dict(pre_pr_open=None, post_pr_open=None),
+        RECORD_DATA_KEY: dict(created_at=created_at, last_modified=created_at),
+    }
+
+
+def get_diff(diff_url: str) -> str:
+    resp = requests.get(diff_url)
+    return resp.content.decode(encoding=resp.encoding)
+
+
+def read_json_if_exists(path: Optional[pathlib.Path], encoding: str) -> dict:
+    return (
+        json.loads(path.read_text(encoding=encoding))
+        if path is not None and path.is_file()
+        else {}
+    )
+
+
+def get_pr_state(pr: github.PullRequest.PullRequest) -> dict:
+    return dict(
+        url=pr.html_url,
+        created_at=str(pr.created_at),
+        closed_at=str(pr.closed_at) if pr.closed_at else None,
+        merged_at=str(pr.merged_at) if pr.closed_at else None,
+        state=pr.state,
+        is_merged=pr.merged,
+        number=pr.number,
+    )
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    subparsers = parser.add_subparsers(required=True, dest="command")
+
+    base_parser = argparse.ArgumentParser(add_help=False)
+    base_parser.add_argument(
+        "-o", "--owner", help="owner of the repository", type=str, required=True
+    )
+    base_parser.add_argument(
+        "-r", "--repo-name", help="name of the repository", type=str, required=True
+    )
+    base_parser.add_argument(
+        "-p", "--pr-number", help="the PR number", type=int, required=True
+    )
+    base_parser.add_argument(
+        "-f",
+        "--prs-json-file",
+        help=f"the file to store records in (default: {PRS_JSON})",
+        type=pathlib.Path,
+        default=PRS_JSON,
+    )
+
+    initial_record_cmd = subparsers.add_parser(
+        RECORD_INITIAL,
+        help="make the initial record for a PR",
+        description="Make the initial record for a PR.",
+        parents=[base_parser],
+    )
+    initial_record_cmd.add_argument(
+        "-s",
+        "--sorald-stats-file",
+        help="path to Sorald's statistics output",
+        type=pathlib.Path,
+    )
+
+    subparsers.add_parser(
+        RECORD_FINAL,
+        help="make the final record for a PR",
+        description="Make the final record for a PR. This requires an "
+        "initial record to exist.",
+        parents=[base_parser],
+    )
+
+    # workaround for bug
+    return parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/experimentation/tools/pr_recorder/prrecorder.py
+++ b/experimentation/tools/pr_recorder/prrecorder.py
@@ -32,12 +32,18 @@ RECORD_MODIFIED_KEY = "last_modified"
 
 
 def main():
-    parsed_args = parse_args(sys.argv[1:])
+    run_cli(sys.argv[1:])
+
+
+def run_cli(sys_args: List[str]) -> None:
+    parsed_args = parse_args(sys_args)
 
     data = read_json_if_exists(parsed_args.prs_json_file, ENCODING)
 
     repo_slug = f"{parsed_args.owner}/{parsed_args.repo_name}"
-    record_id = f"{repo_slug}#{parsed_args.pr_number}"
+    record_id = create_record_id(
+        parsed_args.owner, parsed_args.repo_name, parsed_args.pr_number
+    )
 
     gh = github.Github(base_url="https://api.github.com")
     repo = gh.get_repo(repo_slug)
@@ -64,6 +70,10 @@ def main():
 
     data[record_id] = record
     parsed_args.prs_json_file.write_text(json.dumps(data, indent=4), encoding=ENCODING)
+
+
+def create_record_id(owner: str, repo: str, pr_number: int) -> str:
+    return f"{owner}/{repo}#{pr_number}"
 
 
 def execute_record_initial(

--- a/experimentation/tools/pr_recorder/prrecorder.py
+++ b/experimentation/tools/pr_recorder/prrecorder.py
@@ -20,8 +20,8 @@ ADD_MANUAL_EDIT = "add-manual-edit"
 
 ENCODING = "utf8"
 
-PR_DATA_KEY = "pr"
-DIFF_DATA_KEY = "diff"
+PR_DATA_KEY = "pr_metadata"
+DIFF_DATA_KEY = "diffs"
 
 MANUAL_EDITS_KEY = "manual_edits"
 BEFORE_OPEN_PR_KEY = "before_open_pr"

--- a/experimentation/tools/pr_recorder/prrecorder.py
+++ b/experimentation/tools/pr_recorder/prrecorder.py
@@ -199,6 +199,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         "--sorald-stats-file",
         help="path to Sorald's statistics output",
         type=pathlib.Path,
+        required=True,
     )
 
     subparsers.add_parser(

--- a/experimentation/tools/pr_recorder/requirements.txt
+++ b/experimentation/tools/pr_recorder/requirements.txt
@@ -1,3 +1,4 @@
 git-python
 pygithub
 requests
+pytest

--- a/experimentation/tools/pr_recorder/requirements.txt
+++ b/experimentation/tools/pr_recorder/requirements.txt
@@ -1,0 +1,3 @@
+git-python
+pygithub
+requests

--- a/experimentation/tools/pr_recorder/resources/prs_final.json
+++ b/experimentation/tools/pr_recorder/resources/prs_final.json
@@ -1,0 +1,91 @@
+{
+    "redhat-developer/rsp-server#619": {
+        "repo_slug": "redhat-developer/rsp-server",
+        "pr_metadata": {
+            "url": "https://github.com/redhat-developer/rsp-server/pull/619",
+            "created_at": "2020-11-25 12:01:06",
+            "closed_at": "2020-11-30 20:45:38",
+            "merged_at": "2020-11-30 20:45:38",
+            "state": "closed",
+            "is_merged": true,
+            "number": 619
+        },
+        "sorald_statistics": {
+            "repairs": [
+                {
+                    "nbPerformedRepairs": 4,
+                    "ruleName": "XxeProcessing",
+                    "crashedRepairsLocations": [],
+                    "nbCrashedRepairs": 0,
+                    "ruleKey": "2755",
+                    "nbViolationsBefore": 4,
+                    "performedRepairsLocations": [
+                        {
+                            "endLine": 85,
+                            "endColumn": 52,
+                            "startColumn": 41,
+                            "startLine": 85,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java:85:41:85:52"
+                        },
+                        {
+                            "endLine": 92,
+                            "endColumn": 70,
+                            "startColumn": 59,
+                            "startLine": 92,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:92:59:92:70"
+                        },
+                        {
+                            "endLine": 129,
+                            "endColumn": 48,
+                            "startColumn": 37,
+                            "startLine": 129,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:129:37:129:48"
+                        },
+                        {
+                            "endLine": 351,
+                            "endColumn": 62,
+                            "startColumn": 51,
+                            "startLine": 351,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:351:51:351:62"
+                        }
+                    ],
+                    "nbViolationsAfter": 0
+                }
+            ],
+            "executionInfo": {
+                "soraldVersion": "commit: 33c4d13b",
+                "javaVersion": "11.0.8",
+                "originalArgs": [
+                    "repair",
+                    "--rule-keys",
+                    "2755",
+                    "--file-output-strategy",
+                    "IN_PLACE",
+                    "--original-files-path",
+                    ".",
+                    "--stats-output-file",
+                    "stats.json"
+                ]
+            },
+            "totalTimeMs": 11659,
+            "repairTimeMs": 315,
+            "startTimeMs": 1608221551366,
+            "crashes": [],
+            "endTimeMs": 1608221563025,
+            "parseTimeMs": 2886
+        },
+        "diffs": {
+            "initial": "diff --git a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\nindex 26e318d6..e8f3d908 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n@@ -7,6 +7,7 @@\n  * Contributors: Red Hat, Inc.\n  ******************************************************************************/\n package org.jboss.tools.rsp.internal.launching.java.util;\n+import javax.xml.XMLConstants;\n \n import java.io.ByteArrayInputStream;\n import java.io.File;\n@@ -82,7 +83,7 @@\n \tprivate static DocumentBuilder getParser() throws CoreException {\n \t\tif (fgXMLParser == null) {\n \t\t\ttry {\n-\t\t\t\tfgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();\n+\t\t\t\tfgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();\n \t\t\t\tfgXMLParser.setErrorHandler(new DefaultHandler());\n \t\t\t} catch (ParserConfigurationException e) {\n \t\t\t\tabort(LaunchingPlugin_34, e);\n@@ -348,4 +349,11 @@ protected static void abort(String message, Throwable exception, int code) throw\n \t\tthrow new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,\n \t\t\t\tcode, message, exception));\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n }\ndiff --git a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\nindex 291d3814..92e60d19 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n@@ -89,7 +89,7 @@ public static XMLMemento createReadRoot(InputStream in) {\n \t\t\n \t\tDocument document = null;\n \t\ttry {\t\n-\t\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\t\tDocumentBuilderFactory factory = createDocumentBuilderFactory();\n \t\t\tDocumentBuilder parser = factory.newDocumentBuilder();\n \t\t\tdocument = parser.parse(new InputSource(in));\n \t\t\tNode node = document.getFirstChild();\n@@ -126,7 +126,7 @@ private static void logError(Exception t) {\n \tpublic static XMLMemento createWriteRoot(String type) {\n \t\tDocument document;\n \t\ttry {\n-\t\t\tdocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();\n+\t\t\tdocument = createDocumentBuilderFactory().newDocumentBuilder().newDocument();\n \t\t\tElement element = document.createElement(type);\n \t\t\tdocument.appendChild(element);\n \t\t\treturn new XMLMemento(document, element);\n@@ -348,7 +348,7 @@ public void save(OutputStream os) throws IOException {\n \t\tResult result = new StreamResult(os);\n \t\tSource source = new DOMSource(factory);\n \t\ttry {\n-\t\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\t\tTransformerFactory factory = createTransformerFactory();\n \t\t\tfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n \t\t\tTransformer transformer = factory.newTransformer();\n \t\t\ttransformer.setOutputProperty(OutputKeys.INDENT, \"yes\"); //$NON-NLS-1$\n@@ -436,4 +436,18 @@ public String getTextData() {\n \t\t}\n \t\treturn \"\"; //$NON-NLS-1$\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n+\n+\tprivate static TransformerFactory createTransformerFactory() {\n+\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, \"\");\n+\t\treturn factory;\n+\t}\n }\n\\ No newline at end of file\n",
+            "final": "diff --git a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\nindex 26e318d6..e8f3d908 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n@@ -7,6 +7,7 @@\n  * Contributors: Red Hat, Inc.\n  ******************************************************************************/\n package org.jboss.tools.rsp.internal.launching.java.util;\n+import javax.xml.XMLConstants;\n \n import java.io.ByteArrayInputStream;\n import java.io.File;\n@@ -82,7 +83,7 @@\n \tprivate static DocumentBuilder getParser() throws CoreException {\n \t\tif (fgXMLParser == null) {\n \t\t\ttry {\n-\t\t\t\tfgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();\n+\t\t\t\tfgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();\n \t\t\t\tfgXMLParser.setErrorHandler(new DefaultHandler());\n \t\t\t} catch (ParserConfigurationException e) {\n \t\t\t\tabort(LaunchingPlugin_34, e);\n@@ -348,4 +349,11 @@ protected static void abort(String message, Throwable exception, int code) throw\n \t\tthrow new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,\n \t\t\t\tcode, message, exception));\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n }\ndiff --git a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\nindex 291d3814..92e60d19 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n@@ -89,7 +89,7 @@ public static XMLMemento createReadRoot(InputStream in) {\n \t\t\n \t\tDocument document = null;\n \t\ttry {\t\n-\t\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\t\tDocumentBuilderFactory factory = createDocumentBuilderFactory();\n \t\t\tDocumentBuilder parser = factory.newDocumentBuilder();\n \t\t\tdocument = parser.parse(new InputSource(in));\n \t\t\tNode node = document.getFirstChild();\n@@ -126,7 +126,7 @@ private static void logError(Exception t) {\n \tpublic static XMLMemento createWriteRoot(String type) {\n \t\tDocument document;\n \t\ttry {\n-\t\t\tdocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();\n+\t\t\tdocument = createDocumentBuilderFactory().newDocumentBuilder().newDocument();\n \t\t\tElement element = document.createElement(type);\n \t\t\tdocument.appendChild(element);\n \t\t\treturn new XMLMemento(document, element);\n@@ -348,7 +348,7 @@ public void save(OutputStream os) throws IOException {\n \t\tResult result = new StreamResult(os);\n \t\tSource source = new DOMSource(factory);\n \t\ttry {\n-\t\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\t\tTransformerFactory factory = createTransformerFactory();\n \t\t\tfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n \t\t\tTransformer transformer = factory.newTransformer();\n \t\t\ttransformer.setOutputProperty(OutputKeys.INDENT, \"yes\"); //$NON-NLS-1$\n@@ -436,4 +436,18 @@ public String getTextData() {\n \t\t}\n \t\treturn \"\"; //$NON-NLS-1$\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n+\n+\tprivate static TransformerFactory createTransformerFactory() {\n+\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, \"\");\n+\t\treturn factory;\n+\t}\n }\n\\ No newline at end of file\n"
+        },
+        "manual_edits": [],
+        "record_metadata": {
+            "created_at": "2020-12-18 08:50:28.743261",
+            "last_modified": "2020-12-18 08:51:19.637048"
+        }
+    }
+}

--- a/experimentation/tools/pr_recorder/resources/prs_initial.json
+++ b/experimentation/tools/pr_recorder/resources/prs_initial.json
@@ -1,0 +1,91 @@
+{
+    "redhat-developer/rsp-server#619": {
+        "repo_slug": "redhat-developer/rsp-server",
+        "pr_metadata": {
+            "url": "https://github.com/redhat-developer/rsp-server/pull/619",
+            "created_at": "2020-11-25 12:01:06",
+            "closed_at": "2020-11-30 20:45:38",
+            "merged_at": "2020-11-30 20:45:38",
+            "state": "closed",
+            "is_merged": true,
+            "number": 619
+        },
+        "sorald_statistics": {
+            "repairs": [
+                {
+                    "nbPerformedRepairs": 4,
+                    "ruleName": "XxeProcessing",
+                    "crashedRepairsLocations": [],
+                    "nbCrashedRepairs": 0,
+                    "ruleKey": "2755",
+                    "nbViolationsBefore": 4,
+                    "performedRepairsLocations": [
+                        {
+                            "endLine": 85,
+                            "endColumn": 52,
+                            "startColumn": 41,
+                            "startLine": 85,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java:85:41:85:52"
+                        },
+                        {
+                            "endLine": 92,
+                            "endColumn": 70,
+                            "startColumn": 59,
+                            "startLine": 92,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:92:59:92:70"
+                        },
+                        {
+                            "endLine": 129,
+                            "endColumn": 48,
+                            "startColumn": 37,
+                            "startLine": 129,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:129:37:129:48"
+                        },
+                        {
+                            "endLine": 351,
+                            "endColumn": 62,
+                            "startColumn": 51,
+                            "startLine": 351,
+                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:351:51:351:62"
+                        }
+                    ],
+                    "nbViolationsAfter": 0
+                }
+            ],
+            "executionInfo": {
+                "soraldVersion": "commit: 33c4d13b",
+                "javaVersion": "11.0.8",
+                "originalArgs": [
+                    "repair",
+                    "--rule-keys",
+                    "2755",
+                    "--file-output-strategy",
+                    "IN_PLACE",
+                    "--original-files-path",
+                    ".",
+                    "--stats-output-file",
+                    "stats.json"
+                ]
+            },
+            "totalTimeMs": 11659,
+            "repairTimeMs": 315,
+            "startTimeMs": 1608221551366,
+            "crashes": [],
+            "endTimeMs": 1608221563025,
+            "parseTimeMs": 2886
+        },
+        "diffs": {
+            "initial": "diff --git a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\nindex 26e318d6..e8f3d908 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n@@ -7,6 +7,7 @@\n  * Contributors: Red Hat, Inc.\n  ******************************************************************************/\n package org.jboss.tools.rsp.internal.launching.java.util;\n+import javax.xml.XMLConstants;\n \n import java.io.ByteArrayInputStream;\n import java.io.File;\n@@ -82,7 +83,7 @@\n \tprivate static DocumentBuilder getParser() throws CoreException {\n \t\tif (fgXMLParser == null) {\n \t\t\ttry {\n-\t\t\t\tfgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();\n+\t\t\t\tfgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();\n \t\t\t\tfgXMLParser.setErrorHandler(new DefaultHandler());\n \t\t\t} catch (ParserConfigurationException e) {\n \t\t\t\tabort(LaunchingPlugin_34, e);\n@@ -348,4 +349,11 @@ protected static void abort(String message, Throwable exception, int code) throw\n \t\tthrow new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,\n \t\t\t\tcode, message, exception));\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n }\ndiff --git a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\nindex 291d3814..92e60d19 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n@@ -89,7 +89,7 @@ public static XMLMemento createReadRoot(InputStream in) {\n \t\t\n \t\tDocument document = null;\n \t\ttry {\t\n-\t\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\t\tDocumentBuilderFactory factory = createDocumentBuilderFactory();\n \t\t\tDocumentBuilder parser = factory.newDocumentBuilder();\n \t\t\tdocument = parser.parse(new InputSource(in));\n \t\t\tNode node = document.getFirstChild();\n@@ -126,7 +126,7 @@ private static void logError(Exception t) {\n \tpublic static XMLMemento createWriteRoot(String type) {\n \t\tDocument document;\n \t\ttry {\n-\t\t\tdocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();\n+\t\t\tdocument = createDocumentBuilderFactory().newDocumentBuilder().newDocument();\n \t\t\tElement element = document.createElement(type);\n \t\t\tdocument.appendChild(element);\n \t\t\treturn new XMLMemento(document, element);\n@@ -348,7 +348,7 @@ public void save(OutputStream os) throws IOException {\n \t\tResult result = new StreamResult(os);\n \t\tSource source = new DOMSource(factory);\n \t\ttry {\n-\t\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\t\tTransformerFactory factory = createTransformerFactory();\n \t\t\tfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n \t\t\tTransformer transformer = factory.newTransformer();\n \t\t\ttransformer.setOutputProperty(OutputKeys.INDENT, \"yes\"); //$NON-NLS-1$\n@@ -436,4 +436,18 @@ public String getTextData() {\n \t\t}\n \t\treturn \"\"; //$NON-NLS-1$\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n+\n+\tprivate static TransformerFactory createTransformerFactory() {\n+\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, \"\");\n+\t\treturn factory;\n+\t}\n }\n\\ No newline at end of file\n",
+            "final": null
+        },
+        "manual_edits": [],
+        "record_metadata": {
+            "created_at": "2020-12-18 08:50:28.743261",
+            "last_modified": "2020-12-18 08:50:28.743261"
+        }
+    }
+}

--- a/experimentation/tools/pr_recorder/resources/stats.json
+++ b/experimentation/tools/pr_recorder/resources/stats.json
@@ -1,0 +1,66 @@
+{
+    "repairs": [{
+        "nbPerformedRepairs": 4,
+        "ruleName": "XxeProcessing",
+        "crashedRepairsLocations": [],
+        "nbCrashedRepairs": 0,
+        "ruleKey": "2755",
+        "nbViolationsBefore": 4,
+        "performedRepairsLocations": [
+            {
+                "endLine": 85,
+                "endColumn": 52,
+                "startColumn": 41,
+                "startLine": 85,
+                "filePath": "framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java",
+                "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java:85:41:85:52"
+            },
+            {
+                "endLine": 92,
+                "endColumn": 70,
+                "startColumn": 59,
+                "startLine": 92,
+                "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:92:59:92:70"
+            },
+            {
+                "endLine": 129,
+                "endColumn": 48,
+                "startColumn": 37,
+                "startLine": 129,
+                "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:129:37:129:48"
+            },
+            {
+                "endLine": 351,
+                "endColumn": 62,
+                "startColumn": 51,
+                "startLine": 351,
+                "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
+                "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:351:51:351:62"
+            }
+        ],
+        "nbViolationsAfter": 0
+    }],
+    "executionInfo": {
+        "soraldVersion": "commit: 33c4d13b",
+        "javaVersion": "11.0.8",
+        "originalArgs": [
+            "repair",
+            "--rule-keys",
+            "2755",
+            "--file-output-strategy",
+            "IN_PLACE",
+            "--original-files-path",
+            ".",
+            "--stats-output-file",
+            "stats.json"
+        ]
+    },
+    "totalTimeMs": 11659,
+    "repairTimeMs": 315,
+    "startTimeMs": 1608221551366,
+    "crashes": [],
+    "endTimeMs": 1608221563025,
+    "parseTimeMs": 2886
+}

--- a/experimentation/tools/pr_recorder/test_prrecorder.py
+++ b/experimentation/tools/pr_recorder/test_prrecorder.py
@@ -1,0 +1,80 @@
+"""Test cases for the prrecorder. Run with pytest."""
+import pathlib
+import sys
+import json
+import datetime
+import shutil
+import shlex
+
+import pytest
+
+import prrecorder
+
+CUR_DIR = pathlib.Path(__file__).absolute().parent
+STATS_JSON = CUR_DIR / "stats.json"
+
+PRS_JSON_FINAL = CUR_DIR / "prs_final.json"
+
+OWNER = "redhat-developer"
+REPO = "rsp-server"
+PR_NUMBER = 619
+RECORD_ID = prrecorder.create_record_id(OWNER, REPO, PR_NUMBER)
+
+
+def test_make_full_record(tmp_path):
+    # arrange
+    prs_json_file = tmp_path / "prs.json"
+
+    record_initial_args = shlex.split(
+        f"-o {OWNER} -r {REPO} -p {PR_NUMBER} -f {prs_json_file} -s {STATS_JSON}"
+    )
+    record_final_args = record_initial_args[:-2]
+
+    # act
+    prrecorder.run_cli([prrecorder.RECORD_INITIAL] + record_initial_args)
+    prrecorder.run_cli([prrecorder.RECORD_FINAL] + record_final_args)
+
+    # assert
+    expected_record = prrecorder.read_json_if_exists(
+        PRS_JSON_FINAL, prrecorder.ENCODING
+    )[RECORD_ID]
+    actual_record = prrecorder.read_json_if_exists(prs_json_file, prrecorder.ENCODING)[
+        RECORD_ID
+    ]
+
+    # must remove the record metadata section as it will always differ due to time
+    del actual_record[prrecorder.RECORD_DATA_KEY]
+    del expected_record[prrecorder.RECORD_DATA_KEY]
+
+    assert actual_record == expected_record
+
+
+def test_add_manual_edit(tmp_path):
+    # arrange
+    prs_json_file = tmp_path / "prs.json"
+    shutil.copy(PRS_JSON_FINAL, prs_json_file)
+
+    diff_text = "hello there :)"
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text(diff_text, encoding=sys.getdefaultencoding())
+
+    edit_reason = "It felt like the right thing to do"
+    edit_type = "before_open_pr"
+
+    args = shlex.split(
+        f"add-manual-edit -o {OWNER} -r {REPO} -p {PR_NUMBER} "
+        f"-e '{edit_reason}' -t {edit_type} -d {diff_file} -f {prs_json_file}"
+    )
+
+    # act
+    prrecorder.run_cli(args)
+
+    # assert
+    record = prrecorder.read_json_if_exists(prs_json_file, prrecorder.ENCODING)[
+        RECORD_ID
+    ]
+    manual_edits = record[prrecorder.MANUAL_EDITS_KEY]
+    assert len(manual_edits) == 1
+    assert sorted(manual_edits[0].values()) == sorted(
+        [diff_text, edit_reason, edit_type]
+    )

--- a/experimentation/tools/pr_recorder/test_prrecorder.py
+++ b/experimentation/tools/pr_recorder/test_prrecorder.py
@@ -11,9 +11,9 @@ import pytest
 import prrecorder
 
 CUR_DIR = pathlib.Path(__file__).absolute().parent
-STATS_JSON = CUR_DIR / "stats.json"
-
-PRS_JSON_FINAL = CUR_DIR / "prs_final.json"
+RESOURCES = CUR_DIR / "resources"
+STATS_JSON = RESOURCES / "stats.json"
+PRS_JSON_FINAL = RESOURCES / "prs_final.json"
 
 OWNER = "redhat-developer"
 REPO = "rsp-server"


### PR DESCRIPTION
Fix #265 

@fermadeiral This is my suggestion for recording PRs. Could you have a look at the data in the file, and the general approach? So, this is ready for review ~of the usage and data, but I also want to add some basic tests for this so it's not quite ready to merge.~

Here's an example use case for this PR, based on the PR we made to rsp-server. The script has the following CLI:

```
$ python prrecorder.py --help
usage: prrecorder.py [-h] {record-initial,record-final,add-manual-edit} ...

positional arguments:
  {record-initial,record-final,add-manual-edit}
    record-initial      make the initial record for a PR
    record-final        make the final record for a PR
    add-manual-edit     add a diff representing a manual edit of a PR

optional arguments:
  -h, --help            show this help message and exit
```

### Step 1: Make the initial record (`record-initial`)
When the PR has been opened, one should make the initial record. It can be done like so.

```
$ python prrecorder.py record-initial \
    --owner redhat-developer \
    --repo-name rsp-server \
    --pr-number 619 \
    --sorald-stats-file stats.json
```

This creates a file `prs.json` with an initial record like this:

```
{
    "redhat-developer/rsp-server#619": {
        "repo_slug": "redhat-developer/rsp-server",
        "pr_metadata": {
            "url": "https://github.com/redhat-developer/rsp-server/pull/619",
            "created_at": "2020-11-25 12:01:06",
            "closed_at": null,
            "merged_at": null",
            "state": "open",
            "is_merged": false,
            "number": 619
        },
        "sorald_statistics": {
            "repairs": [
                {
                    "nbPerformedRepairs": 4,
                    "ruleName": "XxeProcessing",
                    "crashedRepairsLocations": [],
                    "nbCrashedRepairs": 0,
                    "ruleKey": "2755",
                    "nbViolationsBefore": 4,
                    "performedRepairsLocations": [
                        {
                            "endLine": 85,
                            "endColumn": 52,
                            "startColumn": 41,
                            "startLine": 85,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java:85:41:85:52"
                        },
                        {
                            "endLine": 92,
                            "endColumn": 70,
                            "startColumn": 59,
                            "startLine": 92,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:92:59:92:70"
                        },
                        {
                            "endLine": 129,
                            "endColumn": 48,
                            "startColumn": 37,
                            "startLine": 129,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:129:37:129:48"
                        },
                        {
                            "endLine": 351,
                            "endColumn": 62,
                            "startColumn": 51,
                            "startLine": 351,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:351:51:351:62"
                        }
                    ],
                    "nbViolationsAfter": 0
                }
            ],
            "executionInfo": {
                "soraldVersion": "commit: 33c4d13b",
                "javaVersion": "11.0.8",
                "originalArgs": [
                    "repair",
                    "--rule-keys",
                    "2755",
                    "--file-output-strategy",
                    "IN_PLACE",
                    "--original-files-path",
                    ".",
                    "--stats-output-file",
                    "stats.json"
                ]
            },
            "totalTimeMs": 11659,
            "repairTimeMs": 315,
            "startTimeMs": 1608221551366,
            "crashes": [],
            "endTimeMs": 1608221563025,
            "parseTimeMs": 2886
        },
        "diffs": {
            "initial": "diff --git a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\nindex 26e318d6..e8f3d908 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n@@ -7,6 +7,7 @@\n  * Contributors: Red Hat, Inc.\n  ******************************************************************************/\n package org.jboss.tools.rsp.internal.launching.java.util;\n+import javax.xml.XMLConstants;\n \n import java.io.ByteArrayInputStream;\n import java.io.File;\n@@ -82,7 +83,7 @@\n \tprivate static DocumentBuilder getParser() throws CoreException {\n \t\tif (fgXMLParser == null) {\n \t\t\ttry {\n-\t\t\t\tfgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();\n+\t\t\t\tfgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();\n \t\t\t\tfgXMLParser.setErrorHandler(new DefaultHandler());\n \t\t\t} catch (ParserConfigurationException e) {\n \t\t\t\tabort(LaunchingPlugin_34, e);\n@@ -348,4 +349,11 @@ protected static void abort(String message, Throwable exception, int code) throw\n \t\tthrow new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,\n \t\t\t\tcode, message, exception));\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n }\ndiff --git a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\nindex 291d3814..92e60d19 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n@@ -89,7 +89,7 @@ public static XMLMemento createReadRoot(InputStream in) {\n \t\t\n \t\tDocument document = null;\n \t\ttry {\t\n-\t\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\t\tDocumentBuilderFactory factory = createDocumentBuilderFactory();\n \t\t\tDocumentBuilder parser = factory.newDocumentBuilder();\n \t\t\tdocument = parser.parse(new InputSource(in));\n \t\t\tNode node = document.getFirstChild();\n@@ -126,7 +126,7 @@ private static void logError(Exception t) {\n \tpublic static XMLMemento createWriteRoot(String type) {\n \t\tDocument document;\n \t\ttry {\n-\t\t\tdocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();\n+\t\t\tdocument = createDocumentBuilderFactory().newDocumentBuilder().newDocument();\n \t\t\tElement element = document.createElement(type);\n \t\t\tdocument.appendChild(element);\n \t\t\treturn new XMLMemento(document, element);\n@@ -348,7 +348,7 @@ public void save(OutputStream os) throws IOException {\n \t\tResult result = new StreamResult(os);\n \t\tSource source = new DOMSource(factory);\n \t\ttry {\n-\t\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\t\tTransformerFactory factory = createTransformerFactory();\n \t\t\tfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n \t\t\tTransformer transformer = factory.newTransformer();\n \t\t\ttransformer.setOutputProperty(OutputKeys.INDENT, \"yes\"); //$NON-NLS-1$\n@@ -436,4 +436,18 @@ public String getTextData() {\n \t\t}\n \t\treturn \"\"; //$NON-NLS-1$\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n+\n+\tprivate static TransformerFactory createTransformerFactory() {\n+\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, \"\");\n+\t\treturn factory;\n+\t}\n }\n\\ No newline at end of file\n",
            "final": null
        },
        "manual_edits": [],
        "record_metadata": {
            "created_at": "2020-12-17 17:19:56.195013",
            "last_modified": "2020-12-17 17:19:56.195013"
        }
    }
}
```

### Step 2: Update the record after PR has been accepted/rejected (`record-final`)

This step really only updates the PR metadata (`closed_at`, `is_merged` etc),  and inserts the `diffs.final` value. Can be executed like so:

```
$ python prrecorder.py record-final \
    --owner redhat-developer \
    --repo-name rsp-server \
    --pr-number 619
```

So it's just like `record-initial`, except that it doesn't take the `--sorald-stats-file` input.

### Step 3 (optional): Record manual edits (`add-manual-edit`)

If we make manual edits to a PR, we need to make note of this. For example, if we make an edit after the PR has been opened, we can record it like so:

```
$ python prrecorder.py add-manual-edit \
    --owner redhat-developer \
    --repo-name rsp-server \
    --pr-number 619 \
    --diff-file diff.txt \
    --edit-type after_open_pr \
    --edit-reason "this can be whatever"
```

This shows up like so in the record:

```
        "manual_edits": [
            {
                "type": "after_open_pr",
                "reason": "this can be whatever",
                "diff": "I didn't actually do any manual edits :)\n"
            }
        ],
```

### Final result

After these three command shave been executed, my `prs.json` looks like this:

```{
    "redhat-developer/rsp-server#619": {
        "repo_slug": "redhat-developer/rsp-server",
        "pr_metadata": {
            "url": "https://github.com/redhat-developer/rsp-server/pull/619",
            "created_at": "2020-11-25 12:01:06",
            "closed_at": "2020-11-30 20:45:38",
            "merged_at": "2020-11-30 20:45:38",
            "state": "closed",
            "is_merged": true,
            "number": 619
        },
        "sorald_statistics": {
            "repairs": [
                {
                    "nbPerformedRepairs": 4,
                    "ruleName": "XxeProcessing",
                    "crashedRepairsLocations": [],
                    "nbCrashedRepairs": 0,
                    "ruleKey": "2755",
                    "nbViolationsBefore": 4,
                    "performedRepairsLocations": [
                        {
                            "endLine": 85,
                            "endColumn": 52,
                            "startColumn": 41,
                            "startLine": 85,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java:85:41:85:52"
                        },
                        {
                            "endLine": 92,
                            "endColumn": 70,
                            "startColumn": 59,
                            "startLine": 92,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:92:59:92:70"
                        },
                        {
                            "endLine": 129,
                            "endColumn": 48,
                            "startColumn": 37,
                            "startLine": 129,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:129:37:129:48"
                        },
                        {
                            "endLine": 351,
                            "endColumn": 62,
                            "startColumn": 51,
                            "startLine": 351,
                            "filePath": "framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java",
                            "violationSpecifier": "2755:framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java:351:51:351:62"
                        }
                    ],
                    "nbViolationsAfter": 0
                }
            ],
            "executionInfo": {
                "soraldVersion": "commit: 33c4d13b",
                "javaVersion": "11.0.8",
                "originalArgs": [
                    "repair",
                    "--rule-keys",
                    "2755",
                    "--file-output-strategy",
                    "IN_PLACE",
                    "--original-files-path",
                    ".",
                    "--stats-output-file",
                    "stats.json"
                ]
            },
            "totalTimeMs": 11659,
            "repairTimeMs": 315,
            "startTimeMs": 1608221551366,
            "crashes": [],
            "endTimeMs": 1608221563025,
            "parseTimeMs": 2886
        },
        "diffs": {
            "initial": "diff --git a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\nindex 26e318d6..e8f3d908 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n@@ -7,6 +7,7 @@\n  * Contributors: Red Hat, Inc.\n  ******************************************************************************/\n package org.jboss.tools.rsp.internal.launching.java.util;\n+import javax.xml.XMLConstants;\n \n import java.io.ByteArrayInputStream;\n import java.io.File;\n@@ -82,7 +83,7 @@\n \tprivate static DocumentBuilder getParser() throws CoreException {\n \t\tif (fgXMLParser == null) {\n \t\t\ttry {\n-\t\t\t\tfgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();\n+\t\t\t\tfgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();\n \t\t\t\tfgXMLParser.setErrorHandler(new DefaultHandler());\n \t\t\t} catch (ParserConfigurationException e) {\n \t\t\t\tabort(LaunchingPlugin_34, e);\n@@ -348,4 +349,11 @@ protected static void abort(String message, Throwable exception, int code) throw\n \t\tthrow new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,\n \t\t\t\tcode, message, exception));\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n }\ndiff --git a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\nindex 291d3814..92e60d19 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n@@ -89,7 +89,7 @@ public static XMLMemento createReadRoot(InputStream in) {\n \t\t\n \t\tDocument document = null;\n \t\ttry {\t\n-\t\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\t\tDocumentBuilderFactory factory = createDocumentBuilderFactory();\n \t\t\tDocumentBuilder parser = factory.newDocumentBuilder();\n \t\t\tdocument = parser.parse(new InputSource(in));\n \t\t\tNode node = document.getFirstChild();\n@@ -126,7 +126,7 @@ private static void logError(Exception t) {\n \tpublic static XMLMemento createWriteRoot(String type) {\n \t\tDocument document;\n \t\ttry {\n-\t\t\tdocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();\n+\t\t\tdocument = createDocumentBuilderFactory().newDocumentBuilder().newDocument();\n \t\t\tElement element = document.createElement(type);\n \t\t\tdocument.appendChild(element);\n \t\t\treturn new XMLMemento(document, element);\n@@ -348,7 +348,7 @@ public void save(OutputStream os) throws IOException {\n \t\tResult result = new StreamResult(os);\n \t\tSource source = new DOMSource(factory);\n \t\ttry {\n-\t\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\t\tTransformerFactory factory = createTransformerFactory();\n \t\t\tfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n \t\t\tTransformer transformer = factory.newTransformer();\n \t\t\ttransformer.setOutputProperty(OutputKeys.INDENT, \"yes\"); //$NON-NLS-1$\n@@ -436,4 +436,18 @@ public String getTextData() {\n \t\t}\n \t\treturn \"\"; //$NON-NLS-1$\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n+\n+\tprivate static TransformerFactory createTransformerFactory() {\n+\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, \"\");\n+\t\treturn factory;\n+\t}\n }\n\\ No newline at end of file\n",
            "final": "diff --git a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\nindex 26e318d6..e8f3d908 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java\n@@ -7,6 +7,7 @@\n  * Contributors: Red Hat, Inc.\n  ******************************************************************************/\n package org.jboss.tools.rsp.internal.launching.java.util;\n+import javax.xml.XMLConstants;\n \n import java.io.ByteArrayInputStream;\n import java.io.File;\n@@ -82,7 +83,7 @@\n \tprivate static DocumentBuilder getParser() throws CoreException {\n \t\tif (fgXMLParser == null) {\n \t\t\ttry {\n-\t\t\t\tfgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();\n+\t\t\t\tfgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();\n \t\t\t\tfgXMLParser.setErrorHandler(new DefaultHandler());\n \t\t\t} catch (ParserConfigurationException e) {\n \t\t\t\tabort(LaunchingPlugin_34, e);\n@@ -348,4 +349,11 @@ protected static void abort(String message, Throwable exception, int code) throw\n \t\tthrow new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,\n \t\t\t\tcode, message, exception));\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n }\ndiff --git a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\nindex 291d3814..92e60d19 100644\n--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java\n@@ -89,7 +89,7 @@ public static XMLMemento createReadRoot(InputStream in) {\n \t\t\n \t\tDocument document = null;\n \t\ttry {\t\n-\t\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\t\tDocumentBuilderFactory factory = createDocumentBuilderFactory();\n \t\t\tDocumentBuilder parser = factory.newDocumentBuilder();\n \t\t\tdocument = parser.parse(new InputSource(in));\n \t\t\tNode node = document.getFirstChild();\n@@ -126,7 +126,7 @@ private static void logError(Exception t) {\n \tpublic static XMLMemento createWriteRoot(String type) {\n \t\tDocument document;\n \t\ttry {\n-\t\t\tdocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();\n+\t\t\tdocument = createDocumentBuilderFactory().newDocumentBuilder().newDocument();\n \t\t\tElement element = document.createElement(type);\n \t\t\tdocument.appendChild(element);\n \t\t\treturn new XMLMemento(document, element);\n@@ -348,7 +348,7 @@ public void save(OutputStream os) throws IOException {\n \t\tResult result = new StreamResult(os);\n \t\tSource source = new DOMSource(factory);\n \t\ttry {\n-\t\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\t\tTransformerFactory factory = createTransformerFactory();\n \t\t\tfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n \t\t\tTransformer transformer = factory.newTransformer();\n \t\t\ttransformer.setOutputProperty(OutputKeys.INDENT, \"yes\"); //$NON-NLS-1$\n@@ -436,4 +436,18 @@ public String getTextData() {\n \t\t}\n \t\treturn \"\"; //$NON-NLS-1$\n \t}\n+\n+\tprivate static DocumentBuilderFactory createDocumentBuilderFactory() {\n+\t\tDocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, \"\");\n+\t\treturn factory;\n+\t}\n+\n+\tprivate static TransformerFactory createTransformerFactory() {\n+\t\tTransformerFactory factory = TransformerFactory.newInstance();\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, \"\");\n+\t\tfactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, \"\");\n+\t\treturn factory;\n+\t}\n }\n\\ No newline at end of file\n"
        },
        "manual_edits": [
            {
                "type": "after_open_pr",
                "reason": "this can be whatever",
                "diff": "I didn't actually do any manual edits :)\n"
            }
        ],
        "record_metadata": {
            "created_at": "2020-12-17 17:19:56.195013",
            "last_modified": "2020-12-17 17:29:41.391090"
        }
    }
}
```