### PR TITLE
doc: Update README with new style of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,85 +52,94 @@ with keys 2111, 2184 and 2204 in a project located at `some/project/path`, one
 can invoke Sorald like so.
 
 ```bash
-$ sorald repair --originalFilesPath some/project/path --ruleKeys 2111,2184,2204
+$ sorald repair --original-files-path some/project/path --rule-keys 2111,2184,2204
 ```
 
 The full list of options is as follows (and can also be found by running
 `sorald repair --help`):
 
 ```bash
-      --fileOutputStrategy=<fileOutputStrategy>
-                  Mode for outputting files: 'CHANGED_ONLY', which means that
-                    only changed files will be created in the workspace. 'ALL',
-                    which means that all files, including the unchanged ones,
-                    will be created in the workspace. 'IN_PLACE', which means
-                    that results are written directly to source files.
-      --gitRepoPath=<gitRepoPath>
-                  The path to a git repository directory.
-  -h, --help      Show this help message and exit.
-      --maxFilesPerSegment=<maxFilesPerSegment>
-                  Max number of files per loaded segment for segmented repair.
-                    It should be >= 3000 files per segment.
-      --maxFixesPerRule=<maxFixesPerRule>
-                  Max number of fixes per rule.
-      --originalFilesPath=<originalFilesPath>
-                  The path to the file or folder to be analyzed and possibly
-                    repaired.
-      --prettyPrintingStrategy=<prettyPrintingStrategy>
-                  Mode for pretty printing the source code: 'NORMAL', which
-                    means that all source code will be printed and its
-                    formatting might change (such as indentation), and
-                    'SNIPER', which means that only statements changed towards
-                    the repair of Sonar rule violations will be printed.
-      --repairStrategy=<repairStrategy>
-                  Type of repair strategy. DEFAULT - load everything without
-                    splitting up the folder in segments, SEGMENT - splitting
-                    the folder into smaller segments and repair one segment at
-                    a time (need to specify --maxFilesPerSegment if not default)
-      --ruleKeys=<ruleKeys>[,<ruleKeys>...]
-                  Choose one or more of the following rule keys (use ',' to
-                    separate multiple keys):
-                  1656: Variables should not be self-assigned
-                  2142: "InterruptedException" should not be ignored
-                  4973: Strings and Boxed types should be compared using
-                    "equals()"
-                  1854: Unused assignments should be removed
-                  2184: Math operands should be cast before assignment
-                  2164: Math should not be performed on floats
-                  3032: JEE applications should not "getClassLoader"
-                  1948: Fields in a "Serializable" class should either be
-                    transient or serializable
-                  2272: "Iterator.next()" methods should throw
-                    "NoSuchElementException"
-                  2111: "BigDecimal(double)" should not be used
-                  2204: ".equals()" should not be used to test the values of
-                    "Atomic" classes
-                  1444: "public static" fields should be constant
-                  	(incomplete: does not fix variable naming)
-                  1860: Synchronization should not be based on Strings or boxed
-                    primitives
-                  3984: Exception should not be created without being thrown
-                  3067: "getClass" should not be used for synchronization
-                  2167: "compareTo" should not return "Integer.MIN_VALUE"
-                  2116: "hashCode" and "toString" should not be called on array
-                    instances
-                  2095: Resources should be closed
-                  2755: XML parsers should not be vulnerable to XXE attacks
-                  	(incomplete: This processor is a WIP and currently supports
-                    a subset of rule 2755. See Sorald's documentation for
-                    details.)
-      --statsOutputFile=<statsOutputFile>
-                  Path to a file to store execution statistics in (in JSON
-                    format). If left unspecified, Sorald does not gather
-                    statistics.
-  -V, --version   Print version information and exit.
-      --violationSpecs=<ruleViolations>[,<ruleViolations>...]
-                  One or more rule violation specifiers. Specifiers can be
-                    gathered with the 'mine' command using the
-                    --statsOutputFile option.
+      --file-output-strategy=<fileOutputStrategy>
+                          Mode for outputting files: 'CHANGED_ONLY', which
+                            means that only changed files will be created in
+                            the workspace. 'ALL', which means that all files,
+                            including the unchanged ones, will be created in
+                            the workspace. 'IN_PLACE', which means that results
+                            are written directly to source files.
+      --git-repo-path=<gitRepoPath>
+                          The path to a git repository directory.
+  -h, --help              Show this help message and exit.
+      --max-files-per-segment=<maxFilesPerSegment>
+                          Max number of files per loaded segment for segmented
+                            repair. It should be >= 3000 files per segment.
+      --max-fixes-per-rule=<maxFixesPerRule>
+                          Max number of fixes per rule.
+      --original-files-path=<originalFilesPath>
+                          The path to the file or folder to be analyzed and
+                            possibly repaired.
+      --pretty-printing-strategy=<prettyPrintingStrategy>
+                          Mode for pretty printing the source code: 'NORMAL',
+                            which means that all source code will be printed
+                            and its formatting might change (such as
+                            indentation), and 'SNIPER', which means that only
+                            statements changed towards the repair of Sonar rule
+                            violations will be printed.
+      --repair-strategy=<repairStrategy>
+                          Type of repair strategy. DEFAULT - load everything
+                            without splitting up the folder in segments,
+                            SEGMENT - splitting the folder into smaller
+                            segments and repair one segment at a time (need to
+                            specify --maxFilesPerSegment if not default)
+      --rule-keys=<ruleKeys>[,<ruleKeys>...]
+                          Choose one or more of the following rule keys (use
+                            ',' to separate multiple keys):
+                          1656: Variables should not be self-assigned
+                          2142: "InterruptedException" should not be ignored
+                          4973: Strings and Boxed types should be compared
+                            using "equals()"
+                          1854: Unused assignments should be removed
+                          2184: Math operands should be cast before assignment
+                          2164: Math should not be performed on floats
+                          3032: JEE applications should not "getClassLoader"
+                          1948: Fields in a "Serializable" class should either
+                            be transient or serializable
+                          2272: "Iterator.next()" methods should throw
+                            "NoSuchElementException"
+                          2111: "BigDecimal(double)" should not be used
+                          2204: ".equals()" should not be used to test the
+                            values of "Atomic" classes
+                          1444: "public static" fields should be constant
+                          	(incomplete: does not fix variable naming)
+                          1860: Synchronization should not be based on Strings
+                            or boxed primitives
+                          3984: Exception should not be created without being
+                            thrown
+                          3067: "getClass" should not be used for
+                            synchronization
+                          2167: "compareTo" should not return "Integer.
+                            MIN_VALUE"
+                          2116: "hashCode" and "toString" should not be called
+                            on array instances
+                          2095: Resources should be closed
+                          2755: XML parsers should not be vulnerable to XXE
+                            attacks
+                          	(incomplete: This processor is a WIP and currently
+                            supports a subset of rule 2755. See Sorald's
+                            documentation for details.)
+      --stats-output-file=<statsOutputFile>
+                          Path to a file to store execution statistics in (in
+                            JSON format). If left unspecified, Sorald does not
+                            gather statistics.
+      --target=<target>   The target of this execution (ex. sorald/92d377).
+                            This will be included in the json report.
+  -V, --version           Print version information and exit.
+      --violation-specs=<ruleViolationSpecifiers>[,<ruleViolationSpecifiers>...]
+                          One or more rule violation specifiers. Specifiers can
+                            be gathered with the 'mine' command using the
+                            --stats-output-file option.
       --workspace=<soraldWorkspace>
-                  The path to a folder that will be used as workspace by
-                    Sorald, i.e. the path for the output.
+                          The path to a folder that will be used as workspace
+                            by Sorald, i.e. the path for the output.
 ```
 
 > **Note:** Some rules (e.g. 1444) are marked as "incomplete". This means that
@@ -143,7 +152,7 @@ To mine projects for Sonar warnings, use the `mine` command. Its most basic
 usage consists of simply pointing it to a project directory.
 
 ```bash
-$ sorald mine --originalFilesPath path/to/project
+$ sorald mine --original-files-path path/to/project
 ```
 
 It will then output statistics for that project with the Sonar checks available
@@ -153,7 +162,7 @@ Another option is to execute the miner on a list of remote Git repositories,
 which can be done like so.
 
 ```bash
-$ sorald mine --statsOnGitRepos --gitReposList repos.txt --statsOutputFile output.txt --tempDir /tmp
+$ sorald mine --stats-on-git-repos --git-repos-list repos.txt --stats-output-file output.txt --temp-dir /tmp
 ```
 
 The `--gitReposList` should be a plain text file with one remote repository url
@@ -164,22 +173,27 @@ The full list of options is as follows (and can also be found by running `sorald
 mine --help`).
 
 ```bash
-Mine a project for Sonar warnings.
-      --gitReposList=<reposList>
-                            The path to the repos list.
-  -h, --help                Show this help message and exit.
-      --originalFilesPath=<originalFilesPath>
-                            The path to the file or folder to be analyzed and
-                              possibly repaired.
-      --ruleTypes=<ruleTypes>[,<ruleTypes>...]
-                            One or more types of rules to check for (use ',' to
-                              separate multiple types). Choices: BUG,
-                              VULNERABILITY, CODE_SMELL, SECURITY_HOTSPOT
-      --statsOnGitRepos     If the stats should be computed on git repos.
-      --statsOutputFile=<statsOutputFile>
-                            The path to the output file.
-      --tempDir=<tempDir>   The path to the temp directory.
-  -V, --version             Print version information and exit.
+      --git-repos-list=<reposList>
+                             The path to the repos list.
+  -h, --help                 Show this help message and exit.
+      --miner-output-file=<minerOutputFile>
+                             The path to the output file.
+      --original-files-path=<originalFilesPath>
+                             The path to the file or folder to be analyzed and
+                               possibly repaired.
+      --rule-types=<ruleTypes>[,<ruleTypes>...]
+                             One or more types of rules to check for (use ','
+                               to separate multiple types). Choices: BUG,
+                               VULNERABILITY, CODE_SMELL, SECURITY_HOTSPOT
+      --stats-on-git-repos   If the stats should be computed on git repos.
+      --stats-output-file=<statsOutputFile>
+                             Path to a file to store execution statistics in
+                               (in JSON format). If left unspecified, Sorald
+                               does not gather statistics.
+      --target=<target>      The target of this execution (ex. sorald/92d377).
+                               This will be included in the json report.
+      --temp-dir=<tempDir>   The path to the temp directory.
+  -V, --version              Print version information and exit.
 ```
 
 #### Running Sorald on GitHub projects to propose PRs with fixes


### PR DESCRIPTION
This PR updates the usage instructions with options on the form `--some-option` as opposed to the no longer used form `--someOption`. We forgot to do that when updating the CLI.