### PR TITLE
fix: Fix detection of protected repairInternal

### DIFF
--- a/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sorald/processor/ArrayHashCodeAndToStringProcessor.java
@@ -16,7 +16,7 @@ import spoon.reflect.reference.CtExecutableReference;
 public class ArrayHashCodeAndToStringProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
 
     @Override
-    public boolean canRepairInternal(CtInvocation<?> candidate) {
+    protected boolean canRepairInternal(CtInvocation<?> candidate) {
         CtExpression<?> target = candidate.getTarget();
         if (target == null || target.getType() == null) {
             return false;
@@ -37,7 +37,7 @@ public class ArrayHashCodeAndToStringProcessor extends SoraldAbstractProcessor<C
     }
 
     @Override
-    public void repairInternal(CtInvocation<?> element) {
+    protected void repairInternal(CtInvocation<?> element) {
         CtExpression prevTarget = element.getTarget();
         CtClass arraysClass = getFactory().Class().get(Arrays.class);
         CtTypeAccess<?> newTarget = getFactory().createTypeAccess(arraysClass.getReference());

--- a/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
+++ b/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.java
@@ -14,7 +14,7 @@ public class BigDecimalDoubleConstructorProcessor
         extends SoraldAbstractProcessor<CtConstructorCall> {
 
     @Override
-    public boolean canRepairInternal(CtConstructorCall cons) {
+    protected boolean canRepairInternal(CtConstructorCall cons) {
         CtTypeReference bigDecimalTypeRef = getFactory().createCtTypeReference(BigDecimal.class);
         CtTypeReference doubleTypeRef = getFactory().createCtTypeReference(double.class);
         CtTypeReference floatTypeRef = getFactory().createCtTypeReference(float.class);
@@ -31,7 +31,7 @@ public class BigDecimalDoubleConstructorProcessor
     }
 
     @Override
-    public void repairInternal(CtConstructorCall cons) {
+    protected void repairInternal(CtConstructorCall cons) {
         if (cons.getArguments().size() == 1) {
             CtType bigDecimalClass = getFactory().Class().get(BigDecimal.class);
             CtCodeSnippetExpression invoker =

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -15,7 +15,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBinaryOperator> {
 
     @Override
-    public boolean canRepairInternal(CtBinaryOperator candidate) {
+    protected boolean canRepairInternal(CtBinaryOperator candidate) {
         List<CtBinaryOperator> binaryOperatorChildren =
                 candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
         if (binaryOperatorChildren.size()
@@ -38,7 +38,7 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
     }
 
     @Override
-    public void repairInternal(CtBinaryOperator element) {
+    protected void repairInternal(CtBinaryOperator element) {
         CtTypeReference<?> typeToBeUsedToCast = getExpectedType(element);
         CtCodeSnippetExpression newBinaryOperator =
                 element.getFactory()

--- a/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -17,7 +17,7 @@ public class CompareStringsBoxedTypesWithEqualsProcessor
         extends SoraldAbstractProcessor<CtBinaryOperator<?>> {
 
     @Override
-    public boolean canRepairInternal(CtBinaryOperator<?> candidate) {
+    protected boolean canRepairInternal(CtBinaryOperator<?> candidate) {
         BinaryOperatorKind opKind = candidate.getKind();
         if (opKind == BinaryOperatorKind.EQ || opKind == BinaryOperatorKind.NE) {
             CtExpression<?> left = candidate.getLeftHandOperand();
@@ -48,7 +48,7 @@ public class CompareStringsBoxedTypesWithEqualsProcessor
     }
 
     @Override
-    public void repairInternal(CtBinaryOperator<?> element) {
+    protected void repairInternal(CtBinaryOperator<?> element) {
         CtExpression<?> lhs = element.getLeftHandOperand();
         CtExpression<?> rhs = element.getRightHandOperand();
 

--- a/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
+++ b/src/main/java/sorald/processor/CompareToReturnValueProcessor.java
@@ -12,7 +12,7 @@ import spoon.reflect.declaration.CtMethod;
 public class CompareToReturnValueProcessor extends SoraldAbstractProcessor<CtReturn<?>> {
 
     @Override
-    public boolean canRepairInternal(CtReturn<?> ctReturn) {
+    protected boolean canRepairInternal(CtReturn<?> ctReturn) {
         CtMethod ctMethod = ctReturn.getParent(CtMethod.class);
         String returnTypeName = ctMethod.getType().getSimpleName();
         if (ctMethod.getSimpleName().equals("compareTo")
@@ -24,7 +24,7 @@ public class CompareToReturnValueProcessor extends SoraldAbstractProcessor<CtRet
     }
 
     @Override
-    public void repairInternal(CtReturn<?> ctReturn) {
+    protected void repairInternal(CtReturn<?> ctReturn) {
         CtLiteral<?> elem2Replace = ctReturn.getFactory().createLiteral(-1);
         ctReturn.getReturnedExpression().replace(elem2Replace);
     }

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -9,7 +9,7 @@ import spoon.reflect.code.CtStatement;
 public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
 
     @Override
-    public boolean canRepairInternal(CtStatement element) {
+    protected boolean canRepairInternal(CtStatement element) {
         if (element instanceof CtLocalVariable || element instanceof CtAssignment) {
             return true;
         }
@@ -17,7 +17,7 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
     }
 
     @Override
-    public void repairInternal(CtStatement element) {
+    protected void repairInternal(CtStatement element) {
         element.delete();
     }
 }

--- a/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
+++ b/src/main/java/sorald/processor/EqualsOnAtomicClassProcessor.java
@@ -18,7 +18,7 @@ import spoon.reflect.reference.CtExecutableReference;
 public class EqualsOnAtomicClassProcessor extends SoraldAbstractProcessor<CtInvocation> {
 
     @Override
-    public boolean canRepairInternal(CtInvocation candidate) {
+    protected boolean canRepairInternal(CtInvocation candidate) {
         if (candidate.getExecutable().getSignature().equals("equals(java.lang.Object)")
                 && isAtomicClassRef(candidate.getTarget())) {
             return true;
@@ -27,7 +27,7 @@ public class EqualsOnAtomicClassProcessor extends SoraldAbstractProcessor<CtInvo
     }
 
     @Override
-    public void repairInternal(CtInvocation element) {
+    protected void repairInternal(CtInvocation element) {
         CtType atomicClass;
         if (isAtomicInteger(element.getTarget())) {
             atomicClass = getFactory().Class().get(AtomicInteger.class);

--- a/src/main/java/sorald/processor/GetClassLoaderProcessor.java
+++ b/src/main/java/sorald/processor/GetClassLoaderProcessor.java
@@ -16,7 +16,7 @@ public class GetClassLoaderProcessor extends SoraldAbstractProcessor<CtInvocatio
     private HashMap<Integer, Boolean> hashCodesOfTypesUsingJEE = new HashMap<Integer, Boolean>();
 
     @Override
-    public boolean canRepairInternal(CtInvocation<?> invocation) {
+    protected boolean canRepairInternal(CtInvocation<?> invocation) {
         String invocationStr = invocation.toString();
         if (invocationStr.contains("getClass().getClassLoader()")
                 || invocationStr.contains(".class.getClassLoader()")) {
@@ -40,7 +40,7 @@ public class GetClassLoaderProcessor extends SoraldAbstractProcessor<CtInvocatio
     }
 
     @Override
-    public void repairInternal(CtInvocation<?> element) {
+    protected void repairInternal(CtInvocation<?> element) {
         Factory factory = element.getFactory();
         CtClass<?> c = factory.Class().get(Thread.class);
         CtTypeAccess<?> access = factory.createTypeAccess(c.getReference());

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -12,12 +12,12 @@ import spoon.reflect.factory.Factory;
 public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCatch> {
 
     @Override
-    public boolean canRepairInternal(CtCatch candidate) {
+    protected boolean canRepairInternal(CtCatch candidate) {
         return true;
     }
 
     @Override
-    public void repairInternal(CtCatch element) {
+    protected void repairInternal(CtCatch element) {
         Factory factory = element.getFactory();
         CtClass<?> threadClass = factory.Class().get(Thread.class);
         CtTypeAccess<?> threadClassAccess = factory.createTypeAccess(threadClass.getReference());

--- a/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
+++ b/src/main/java/sorald/processor/IteratorNextExceptionProcessor.java
@@ -25,7 +25,7 @@ public class IteratorNextExceptionProcessor extends SoraldAbstractProcessor<CtMe
      *     already throw the correct error.
      */
     @Override
-    public boolean canRepairInternal(CtMethod candidate) {
+    protected boolean canRepairInternal(CtMethod candidate) {
         CtType iteratorInterface = getFactory().Interface().get(Iterator.class);
         CtMethod next = (CtMethod) iteratorInterface.getMethodsByName("next").get(0);
         if (candidate.isOverriding(next)) {
@@ -52,7 +52,7 @@ public class IteratorNextExceptionProcessor extends SoraldAbstractProcessor<CtMe
     }
 
     @Override
-    public void repairInternal(CtMethod method) {
+    protected void repairInternal(CtMethod method) {
         CtIf anIf = getFactory().Core().createIf();
         CtCodeSnippetExpression expr = getFactory().Core().createCodeSnippetExpression();
         expr.setValue("!hasNext()");

--- a/src/main/java/sorald/processor/MathOnFloatProcessor.java
+++ b/src/main/java/sorald/processor/MathOnFloatProcessor.java
@@ -13,7 +13,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class MathOnFloatProcessor extends SoraldAbstractProcessor<CtBinaryOperator> {
 
     @Override
-    public boolean canRepairInternal(CtBinaryOperator candidate) {
+    protected boolean canRepairInternal(CtBinaryOperator candidate) {
         List<CtBinaryOperator> binaryOperatorChildren =
                 candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
         if (binaryOperatorChildren.size()
@@ -28,7 +28,7 @@ public class MathOnFloatProcessor extends SoraldAbstractProcessor<CtBinaryOperat
     }
 
     @Override
-    public void repairInternal(CtBinaryOperator element) {
+    protected void repairInternal(CtBinaryOperator element) {
         CtCodeSnippetExpression newLeftHandOperand =
                 element.getFactory()
                         .createCodeSnippetExpression("(double) " + element.getLeftHandOperand());

--- a/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
+++ b/src/main/java/sorald/processor/PublicStaticFieldShouldBeFinalProcessor.java
@@ -9,12 +9,12 @@ import spoon.reflect.declaration.ModifierKind;
 @ProcessorAnnotation(key = 1444, description = "\"public static\" fields should be constant")
 public class PublicStaticFieldShouldBeFinalProcessor extends SoraldAbstractProcessor<CtField<?>> {
     @Override
-    public boolean canRepairInternal(CtField<?> candidate) {
+    protected boolean canRepairInternal(CtField<?> candidate) {
         return true;
     }
 
     @Override
-    public void repairInternal(CtField<?> element) {
+    protected void repairInternal(CtField<?> element) {
         element.addModifier(ModifierKind.FINAL);
     }
 }

--- a/src/main/java/sorald/processor/SelfAssignementProcessor.java
+++ b/src/main/java/sorald/processor/SelfAssignementProcessor.java
@@ -17,7 +17,7 @@ import spoon.reflect.factory.Factory;
 public class SelfAssignementProcessor extends SoraldAbstractProcessor<CtAssignment<?, ?>> {
 
     @Override
-    public boolean canRepairInternal(CtAssignment<?, ?> candidate) {
+    protected boolean canRepairInternal(CtAssignment<?, ?> candidate) {
         CtExpression<?> leftExpression = candidate.getAssigned();
         CtExpression<?> rightExpression = candidate.getAssignment();
         if (rightExpression == null || candidate.getParent(CtAssignment.class) != null) {
@@ -33,7 +33,7 @@ public class SelfAssignementProcessor extends SoraldAbstractProcessor<CtAssignme
     }
 
     @Override
-    public void repairInternal(CtAssignment<?, ?> element) {
+    protected void repairInternal(CtAssignment<?, ?> element) {
         Factory factory = element.getFactory();
         CtType<?> type = element.getParent(CtType.class);
 

--- a/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sorald/processor/SerializableFieldInSerializableClassProcessor.java
@@ -12,12 +12,12 @@ public class SerializableFieldInSerializableClassProcessor
         extends SoraldAbstractProcessor<CtField> {
 
     @Override
-    public boolean canRepairInternal(CtField element) {
+    protected boolean canRepairInternal(CtField element) {
         return true;
     }
 
     @Override
-    public void repairInternal(CtField element) {
+    protected void repairInternal(CtField element) {
         element.addModifier(ModifierKind.TRANSIENT);
     }
 }

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -31,7 +31,7 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         // the process method, which with type erasure will always be CtElement for
         // SoraldAbstractProcessor::process
         clearProcessedElementType();
-        Arrays.stream(getClass().getMethods())
+        Arrays.stream(getClass().getDeclaredMethods())
                 .filter(
                         meth ->
                                 meth.getName().equals("repairInternal")

--- a/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnGetClassProcessor.java
@@ -17,7 +17,7 @@ import spoon.reflect.reference.CtTypeReference;
 public class SynchronizationOnGetClassProcessor extends SoraldAbstractProcessor<CtSynchronized> {
 
     @Override
-    public boolean canRepairInternal(CtSynchronized element) {
+    protected boolean canRepairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         if (expression.toString().endsWith("getClass()")) {
             CtExpression target = ((CtInvocation) expression).getTarget();
@@ -46,7 +46,7 @@ public class SynchronizationOnGetClassProcessor extends SoraldAbstractProcessor<
     }
 
     @Override
-    public void repairInternal(CtSynchronized element) {
+    protected void repairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         CtTypeReference<?> typeRef;
         if (expression.toString().equals("getClass()")) {

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -34,7 +34,7 @@ public class SynchronizationOnStringOrBoxedProcessor
     }
 
     @Override
-    public boolean canRepairInternal(CtSynchronized element) {
+    protected boolean canRepairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         if (!expression.getType().toString().equals("String")
                 && !expression.getType().unbox().isPrimitive()) {
@@ -67,7 +67,7 @@ public class SynchronizationOnStringOrBoxedProcessor
     }
 
     @Override
-    public void repairInternal(CtSynchronized element) {
+    protected void repairInternal(CtSynchronized element) {
         CtExpression<?> expression = element.getExpression();
         Factory factory = element.getFactory();
         CtFieldRead<?> fieldRead4Update;

--- a/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
@@ -17,12 +17,12 @@ import spoon.reflect.reference.CtVariableReference;
 public class UnclosedResourcesProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
 
     @Override
-    public boolean canRepairInternal(CtConstructorCall element) {
+    protected boolean canRepairInternal(CtConstructorCall element) {
         return element.getParent(e -> e instanceof CtConstructorCall) == null;
     }
 
     @Override
-    public void repairInternal(CtConstructorCall element) {
+    protected void repairInternal(CtConstructorCall element) {
         CtElement parent =
                 element.getParent(e -> e instanceof CtAssignment || e instanceof CtLocalVariable);
 

--- a/src/main/java/sorald/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sorald/processor/UnusedThrowableProcessor.java
@@ -10,12 +10,12 @@ import spoon.reflect.code.CtThrow;
 public class UnusedThrowableProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
 
     @Override
-    public boolean canRepairInternal(CtConstructorCall element) {
+    protected boolean canRepairInternal(CtConstructorCall element) {
         return true;
     }
 
     @Override
-    public void repairInternal(CtConstructorCall element) {
+    protected void repairInternal(CtConstructorCall element) {
         CtThrow ctThrow = getFactory().createCtThrow(element.toString());
         element.replace(ctThrow);
     }

--- a/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -36,7 +36,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
     private static final String XML_INPUT_FACTORY = "XMLInputFactory";
 
     @Override
-    public boolean canRepairInternal(CtInvocation<?> candidate) {
+    protected boolean canRepairInternal(CtInvocation<?> candidate) {
         return isSupported(candidate);
     }
 
@@ -49,7 +49,7 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
     }
 
     @Override
-    public void repairInternal(CtInvocation<?> element) {
+    protected void repairInternal(CtInvocation<?> element) {
         CtType<?> declaringType = element.getParent(CtType.class);
 
         CtMethod<?> factoryMethod = createFactoryMethod(element, declaringType);


### PR DESCRIPTION
This PR makes all implementations of `repairInternal` and `canRepairInternal` protected (as they should be as they are protected in `SoraldAbstractProcessor`) to demonstrate that it doesn't actually work (833b84d). That is to say, if you implement `SoraldAbstractProcessor` with `protected` `repairInternal` and `canRepairInternal`, the processor won't work.

The problem is fixed in 50a8673 by using `Class.getDeclaredMethods()` (which finds all declared methods) instead of `Class.getMethods()` (which finds all public methods).