### PR TITLE
feat(rule 2225): Null-returning "toString()" functions should return empty string

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -19,7 +19,7 @@ Sorald can currently repair violations of the following rules:
     * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
     * ["Thread.run()" should not be called directly](#threadrun-should-not-be-called-directly-sonar-rule-1217) ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
-    * ["toString()" and "clone()" methods should not return null](#tostring-should-not-return-null) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
+    * ["toString()" and "clone()" methods should not return null](#tostring-and-clone-methods-should-not-return-null-sonar-rule-2225) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
 * [Code Smell](#code-smell)
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
@@ -354,6 +354,10 @@ Example:
     Thread myThread = new Thread(runnable);
 -   myThread.run();
 +   myThread.start();
+```
+
+-----
+
 #### "toString()" and "clone()" methods should not return null ([Sonar Rule 2225](https://rules.sonarsource.com/java/type/Bug/RSPEC-2225))
 
 For the return statements inside "toString()", this processor replaces the return expression with an empty string. 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -20,6 +20,7 @@ Sorald can currently repair violations of the following rules:
     * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
     * ["Thread.run()" should not be called directly](#threadrun-should-not-be-called-directly-sonar-rule-1217) ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
     * ["toString()" and "clone()" methods should not return null](#tostring-should-not-return-null) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
+    * ["toString()" and "clone()" methods should not return null](#tostring-and-clone-methods-should-not-return-null) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
 * [Code Smell](#code-smell)
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -20,7 +20,6 @@ Sorald can currently repair violations of the following rules:
     * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
     * ["Thread.run()" should not be called directly](#threadrun-should-not-be-called-directly-sonar-rule-1217) ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
     * ["toString()" and "clone()" methods should not return null](#tostring-should-not-return-null) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
-    * ["toString()" and "clone()" methods should not return null](#tostring-and-clone-methods-should-not-return-null) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
 * [Code Smell](#code-smell)
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -358,6 +358,8 @@ Example:
 
 For the return statements inside "toString()", this processor replaces the return expression with an empty string. 
 
+Note that this processor is incomplete and does not fix null-returning `clone()` methods.
+
 Example:
 ```diff
 public String toString() {

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -19,6 +19,7 @@ Sorald can currently repair violations of the following rules:
     * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
     * ["Thread.run()" should not be called directly](#threadrun-should-not-be-called-directly-sonar-rule-1217) ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
+    * ["toString()" and "clone()" methods should not return null](#tostring-should-not-return-null) ([Sonar Rule 2225](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2225))
 * [Code Smell](#code-smell)
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
@@ -353,6 +354,23 @@ Example:
     Thread myThread = new Thread(runnable);
 -   myThread.run();
 +   myThread.start();
+#### "toString()" and "clone()" methods should not return null ([Sonar Rule 2225](https://rules.sonarsource.com/java/type/Bug/RSPEC-2225))
+
+For the return statements inside "toString()", this processor replaces the return expression with an empty string. 
+
+Example:
+```diff
+public String toString() {
+   Random r = new Random();
+   if(r.nextInt(10) == r.nextInt(10)){
+-     return null; // Noncompliant
++     return ""; // Noncompliant
+   }
+   else if(r.nextInt(10) == r.nextInt(10)){
+      return "null";
+   }
+   return "";
+}
 ```
 
 -----

--- a/src/main/java/sorald/processor/ToStringReturningNullProcessor.java
+++ b/src/main/java/sorald/processor/ToStringReturningNullProcessor.java
@@ -11,13 +11,13 @@ import spoon.reflect.visitor.filter.TypeFilter;
 @ProcessorAnnotation(
         key = 2225,
         description = "\"toString()\" and \"clone()\" methods should not return null")
-public class ToStringReturningNullProcessor extends SoraldAbstractProcessor<CtReturn<?>>{
+public class ToStringReturningNullProcessor extends SoraldAbstractProcessor<CtReturn<?>> {
 
     @Override
     protected boolean canRepairInternal(CtReturn<?> candidate) {
         CtMethod parentMethod = candidate.getParent(new TypeFilter<>(CtMethod.class));
-        if(parentMethod.getSignature().equals(Constants.TOSTRING_METHOD_NAME + "()")
-                && candidate.getReturnedExpression().toString().equals("null")){
+        if (parentMethod.getSignature().equals(Constants.TOSTRING_METHOD_NAME + "()")
+                && candidate.getReturnedExpression().toString().equals("null")) {
             return true;
         }
         return false;

--- a/src/main/java/sorald/processor/ToStringReturningNullProcessor.java
+++ b/src/main/java/sorald/processor/ToStringReturningNullProcessor.java
@@ -1,0 +1,30 @@
+package sorald.processor;
+
+import sorald.Constants;
+import sorald.annotations.IncompleteProcessor;
+import sorald.annotations.ProcessorAnnotation;
+import spoon.reflect.code.CtReturn;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+@IncompleteProcessor(description = "does not fix null returning clone()")
+@ProcessorAnnotation(
+        key = 2225,
+        description = "\"toString()\" and \"clone()\" methods should not return null")
+public class ToStringReturningNullProcessor extends SoraldAbstractProcessor<CtReturn<?>>{
+
+    @Override
+    protected boolean canRepairInternal(CtReturn<?> candidate) {
+        CtMethod parentMethod = candidate.getParent(new TypeFilter<>(CtMethod.class));
+        if(parentMethod.getSignature().equals(Constants.TOSTRING_METHOD_NAME + "()")
+                && candidate.getReturnedExpression().toString().equals("null")){
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void repairInternal(CtReturn<?> element) {
+        element.getReturnedExpression().replace(getFactory().Code().createLiteral(""));
+    }
+}

--- a/src/main/java/sorald/processor/ToStringReturningNullProcessor.java
+++ b/src/main/java/sorald/processor/ToStringReturningNullProcessor.java
@@ -5,7 +5,6 @@ import sorald.annotations.IncompleteProcessor;
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.visitor.filter.TypeFilter;
 
 @IncompleteProcessor(description = "does not fix null returning clone()")
 @ProcessorAnnotation(
@@ -15,12 +14,9 @@ public class ToStringReturningNullProcessor extends SoraldAbstractProcessor<CtRe
 
     @Override
     protected boolean canRepairInternal(CtReturn<?> candidate) {
-        CtMethod parentMethod = candidate.getParent(new TypeFilter<>(CtMethod.class));
-        if (parentMethod.getSignature().equals(Constants.TOSTRING_METHOD_NAME + "()")
-                && candidate.getReturnedExpression().toString().equals("null")) {
-            return true;
-        }
-        return false;
+        CtMethod<?> parentMethod = candidate.getParent(CtMethod.class);
+        return parentMethod.getSignature().equals(Constants.TOSTRING_METHOD_NAME + "()")
+                && candidate.getReturnedExpression().toString().equals("null");
     }
 
     @Override

--- a/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java
+++ b/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java
@@ -1,0 +1,17 @@
+package sorald;
+
+import java.util.Random;
+
+public class NullReturningToString {
+    @Override
+    public String toString() {
+        Random r = new Random();
+        if(r.nextInt(10) == r.nextInt(10)){
+            return null;
+        }
+        else if(r.nextInt(10) == r.nextInt(10)){
+            return "null";
+        }
+        return "";
+    }
+}

--- a/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java
+++ b/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java
@@ -7,7 +7,7 @@ public class NullReturningToString {
     public String toString() {
         Random r = new Random();
         if(r.nextInt(10) == r.nextInt(10)){
-            return null;
+            return null; // Noncompliant
         }
         else if(r.nextInt(10) == r.nextInt(10)){
             return "null";

--- a/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java.expected
+++ b/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java.expected
@@ -7,7 +7,7 @@ public class NullReturningToString {
     public String toString() {
         Random r = new Random();
         if(r.nextInt(10) == r.nextInt(10)){
-            return "";
+            return ""; // Noncompliant
         }
         else if(r.nextInt(10) == r.nextInt(10)){
             return "null";

--- a/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java.expected
+++ b/src/test/resources/processor_test_files/2225_ToStringReturningNull/NullReturningToString.java.expected
@@ -1,0 +1,17 @@
+package sorald;
+
+import java.util.Random;
+
+public class NullReturningToString {
+    @Override
+    public String toString() {
+        Random r = new Random();
+        if(r.nextInt(10) == r.nextInt(10)){
+            return "";
+        }
+        else if(r.nextInt(10) == r.nextInt(10)){
+            return "null";
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
It's an incomplete processor for [rule 2225](https://rules.sonarsource.com/java/RSPEC-2225). It only handles null-returning `toString()` and not `clone()`.