### PR TITLE
feat(rule 1217): "Thread.run()" should not be called directly

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -346,15 +346,13 @@ class SelfAssignement {
 
 #### "Thread.run" should not be called directly ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
 
-The purpose of the Thread.run() method is to execute code in a separate, dedicated thread. Calling this method directly doesn't make sense because it causes its code to be executed in the current thread.
-
-To get the expected behavior, call the Thread.start() method instead.
+Sorald fixes the violations of this rule by replacing each invocation of `Thread.run()` with an invocation of `Thread.start()`. 
 
 Example:
 ```diff
     Thread myThread = new Thread(runnable);
--   myThread.run(); // Noncompliant
-+   myThread.start(); // Compliant
+-   myThread.run();
++   myThread.start();
 ```
 
 -----

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -18,6 +18,7 @@ Sorald can currently repair violations of the following rules:
     * [Strings and Boxed types should be compared using "equals()"](#strings-and-boxed-types-should-be-compared-using-equals-sonar-rule-4973) ([Sonar Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973))
     * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
+    * ["Thread.run()" should not be called directly](#threadrun-should-not-be-called-directly-sonar-rule-1217) ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
 * [Code Smell](#code-smell)
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
@@ -339,6 +340,21 @@ class SelfAssignement {
      return 0;
    }
 }
+```
+
+-----
+
+#### "Thread.run" should not be called directly ([Sonar Rule 1217](https://rules.sonarsource.com/java/type/Bug/RSPEC-1217))
+
+The purpose of the Thread.run() method is to execute code in a separate, dedicated thread. Calling this method directly doesn't make sense because it causes its code to be executed in the current thread.
+
+To get the expected behavior, call the Thread.start() method instead.
+
+Example:
+```diff
+    Thread myThread = new Thread(runnable);
+-   myThread.run(); // Noncompliant
++   myThread.start(); // Compliant
 ```
 
 -----

--- a/src/main/java/sorald/processor/ThreadRunProcessor.java
+++ b/src/main/java/sorald/processor/ThreadRunProcessor.java
@@ -2,7 +2,6 @@ package sorald.processor;
 
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
@@ -11,9 +10,14 @@ import spoon.reflect.factory.Factory;
 public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
     @Override
     protected boolean canRepairInternal(CtInvocation candidate) {
-        return candidate.getExecutable() != null && candidate.getExecutable().getDeclaringType() != null &&
-                candidate.getExecutable().getSignature().equals("run()")
-                && candidate.getExecutable().getDeclaringType().toString().equals("java.lang.Thread");
+        return candidate.getExecutable() != null
+                && candidate.getExecutable().getDeclaringType() != null
+                && candidate.getExecutable().getSignature().equals("run()")
+                && candidate
+                        .getExecutable()
+                        .getDeclaringType()
+                        .toString()
+                        .equals("java.lang.Thread");
     }
 
     @Override
@@ -23,7 +27,8 @@ public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
 
         CtMethod<?> method = threadClass.getMethodsByName("start").get(0);
 
-        CtInvocation threadStartInvocation = factory.createInvocation(element.getTarget(), method.getReference());
+        CtInvocation threadStartInvocation =
+                factory.createInvocation(element.getTarget(), method.getReference());
 
         element.replace(threadStartInvocation);
     }

--- a/src/main/java/sorald/processor/ThreadRunProcessor.java
+++ b/src/main/java/sorald/processor/ThreadRunProcessor.java
@@ -7,9 +7,9 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 
 @ProcessorAnnotation(key = 1217, description = "\"Thread.run()\" should not be called directly")
-public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
+public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation<?>> {
     @Override
-    protected boolean canRepairInternal(CtInvocation candidate) {
+    protected boolean canRepairInternal(CtInvocation<?> candidate) {
         return candidate.getExecutable() != null
                 && candidate.getExecutable().getDeclaringType() != null
                 && candidate.getExecutable().getSignature().equals("run()")
@@ -21,13 +21,13 @@ public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
     }
 
     @Override
-    protected void repairInternal(CtInvocation element) {
+    protected void repairInternal(CtInvocation<?> element) {
         Factory factory = element.getFactory();
         CtClass<?> threadClass = factory.Class().get(Thread.class);
 
         CtMethod<?> method = threadClass.getMethodsByName("start").get(0);
 
-        CtInvocation threadStartInvocation =
+        CtInvocation<?> threadStartInvocation =
                 factory.createInvocation(element.getTarget(), method.getReference());
 
         element.replace(threadStartInvocation);

--- a/src/main/java/sorald/processor/ThreadRunProcessor.java
+++ b/src/main/java/sorald/processor/ThreadRunProcessor.java
@@ -1,0 +1,29 @@
+package sorald.processor;
+
+import sorald.annotations.ProcessorAnnotation;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+
+@ProcessorAnnotation(key = 1217, description = "\"Thread.run()\" should not be called directly")
+public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
+    @Override
+    protected boolean canRepairInternal(CtInvocation candidate) {
+        return candidate.getExecutable().getSignature().equals("java.lang.Thread.run()");
+    }
+
+    @Override
+    protected void repairInternal(CtInvocation element) {
+        Factory factory = element.getFactory();
+        CtClass<?> threadClass = factory.Class().get(Thread.class);
+        CtTypeAccess<?> access = factory.createTypeAccess(threadClass.getReference());
+
+        CtMethod<?> method = threadClass.getMethodsByName("start").get(0);
+
+        CtInvocation threadStartInvocation = factory.createInvocation(access, method.getReference());
+
+        element.replace(threadStartInvocation);
+    }
+}

--- a/src/main/java/sorald/processor/ThreadRunProcessor.java
+++ b/src/main/java/sorald/processor/ThreadRunProcessor.java
@@ -11,7 +11,8 @@ import spoon.reflect.factory.Factory;
 public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
     @Override
     protected boolean canRepairInternal(CtInvocation candidate) {
-        return candidate.getExecutable().getSignature().equals("java.lang.Thread.run()");
+        return candidate.getExecutable().getSignature().equals("run()")
+                && candidate.getExecutable().getDeclaringType().toString().equals("java.lang.Thread");
     }
 
     @Override

--- a/src/main/java/sorald/processor/ThreadRunProcessor.java
+++ b/src/main/java/sorald/processor/ThreadRunProcessor.java
@@ -11,7 +11,8 @@ import spoon.reflect.factory.Factory;
 public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
     @Override
     protected boolean canRepairInternal(CtInvocation candidate) {
-        return candidate.getExecutable().getSignature().equals("run()")
+        return candidate.getExecutable() != null && candidate.getExecutable().getDeclaringType() != null &&
+                candidate.getExecutable().getSignature().equals("run()")
                 && candidate.getExecutable().getDeclaringType().toString().equals("java.lang.Thread");
     }
 
@@ -19,11 +20,10 @@ public class ThreadRunProcessor extends SoraldAbstractProcessor<CtInvocation> {
     protected void repairInternal(CtInvocation element) {
         Factory factory = element.getFactory();
         CtClass<?> threadClass = factory.Class().get(Thread.class);
-        CtTypeAccess<?> access = factory.createTypeAccess(threadClass.getReference());
 
         CtMethod<?> method = threadClass.getMethodsByName("start").get(0);
 
-        CtInvocation threadStartInvocation = factory.createInvocation(access, method.getReference());
+        CtInvocation threadStartInvocation = factory.createInvocation(element.getTarget(), method.getReference());
 
         element.replace(threadStartInvocation);
     }

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
@@ -1,0 +1,8 @@
+package sorald;
+
+public class ThreadRunInvocation {
+    public void method(){
+        Thread myThread = new Thread();
+        myThread.run(); // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
@@ -1,78 +1,13 @@
-// Test for rule s1217
-// Tests from https://raw.githubusercontent.com/SonarSource/sonar-java/master/java-checks-test-sources/src/main/java/checks/ThreadRunCheck.java
-
-package checks;
-
-import java.io.Serializable;
-
-class ThreadRunCheck {
-
-  {
-    Thread t = new Thread(new B());
-    t.run(); // Noncompliant
-  }
-
+class ThreadRunInvocation {
   public static void main(String[] args) {
     Runnable runnable = null;
 
     Thread myThread = new Thread(runnable);
-    myThread.run(); // Noncompliant [[sc=14;ec=17]] {{Call the method Thread.start() to execute the content of the run() method in a dedicated thread.}}
+    myThread.run(); // Noncompliant
 
     Thread myThread2 = new Thread(runnable);
     myThread2.start();
 
     run();
-    UselessIncrementCheck a = new UselessIncrementCheck();
-    a.run();
-
-    B b = new B();
-    b.run(); // Noncompliant
-
-    C c = new C();
-    c.run(); // Compliant
-
-    D d = new D();
-    d.run(); // Noncompliant
-
-    E e = new E();
-    e.run();
-
-    F f = new F();
-    f.run();
-
-    runnable.run(); // Compliant
-  }
-
-  public static void run() {
-  }
-
-  static class B extends Thread {
-  }
-
-  static class C implements Runnable {
-
-    @Override
-    public void run() {
-    }
-
-  }
-
-  static class D extends B {
-    @Override
-    public void run() {
-      C c = new C();
-      c.run(); // compliant, within run method
-      super.run(); // compliant, within run method
-    }
-  }
-
-  static class E implements Serializable {
-
-    public void run() {
-    }
-
-  }
-
-  static class F extends E {
   }
 }

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
@@ -1,8 +1,75 @@
-package sorald;
+package checks;
 
-public class ThreadRunInvocation {
-    public void method(){
-        Thread myThread = new Thread();
-        myThread.run(); // Noncompliant
+import java.io.Serializable;
+
+class ThreadRunCheck {
+
+  {
+    Thread t = new Thread(new B());
+    t.run(); // Noncompliant
+  }
+
+  public static void main(String[] args) {
+    Runnable runnable = null;
+
+    Thread myThread = new Thread(runnable);
+    myThread.run(); // Noncompliant [[sc=14;ec=17]] {{Call the method Thread.start() to execute the content of the run() method in a dedicated thread.}}
+
+    Thread myThread2 = new Thread(runnable);
+    myThread2.start();
+
+    run();
+    UselessIncrementCheck a = new UselessIncrementCheck();
+    a.run();
+
+    B b = new B();
+    b.run(); // Noncompliant
+
+    C c = new C();
+    c.run(); // Compliant
+
+    D d = new D();
+    d.run(); // Noncompliant
+
+    E e = new E();
+    e.run();
+
+    F f = new F();
+    f.run();
+
+    runnable.run(); // Compliant
+  }
+
+  public static void run() {
+  }
+
+  static class B extends Thread {
+  }
+
+  static class C implements Runnable {
+
+    @Override
+    public void run() {
     }
+
+  }
+
+  static class D extends B {
+    @Override
+    public void run() {
+      C c = new C();
+      c.run(); // compliant, within run method
+      super.run(); // compliant, within run method
+    }
+  }
+
+  static class E implements Serializable {
+
+    public void run() {
+    }
+
+  }
+
+  static class F extends E {
+  }
 }

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java
@@ -1,3 +1,6 @@
+// Test for rule s1217
+// Tests from https://raw.githubusercontent.com/SonarSource/sonar-java/master/java-checks-test-sources/src/main/java/checks/ThreadRunCheck.java
+
 package checks;
 
 import java.io.Serializable;

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
@@ -1,78 +1,13 @@
-// Test for rule s1217
-// Tests from https://raw.githubusercontent.com/SonarSource/sonar-java/master/java-checks-test-sources/src/main/java/checks/ThreadRunCheck.java
-
-package checks;
-
-import java.io.Serializable;
-
-class ThreadRunCheck {
-
-  {
-    Thread t = new Thread(new B());
-    t.start(); // Noncompliant
-  }
-
+class ThreadRunInvocation {
   public static void main(String[] args) {
     Runnable runnable = null;
 
     Thread myThread = new Thread(runnable);
-    myThread.start(); // Noncompliant [[sc=14;ec=17]] {{Call the method Thread.start() to execute the content of the run() method in a dedicated thread.}}
+    myThread.start(); // Noncompliant
 
     Thread myThread2 = new Thread(runnable);
     myThread2.start();
 
     run();
-    UselessIncrementCheck a = new UselessIncrementCheck();
-    a.run();
-
-    B b = new B();
-    b.start(); // Noncompliant
-
-    C c = new C();
-    c.run(); // Compliant
-
-    D d = new D();
-    d.start(); // Noncompliant
-
-    E e = new E();
-    e.run();
-
-    F f = new F();
-    f.run();
-
-    runnable.run(); // Compliant
-  }
-
-  public static void run() {
-  }
-
-  static class B extends Thread {
-  }
-
-  static class C implements Runnable {
-
-    @Override
-    public void run() {
-    }
-
-  }
-
-  static class D extends B {
-    @Override
-    public void run() {
-      C c = new C();
-      c.run(); // compliant, within run method
-      super.run(); // compliant, within run method
-    }
-  }
-
-  static class E implements Serializable {
-
-    public void run() {
-    }
-
-  }
-
-  static class F extends E {
   }
 }

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
@@ -1,0 +1,8 @@
+package sorald;
+
+public class ThreadRunInvocation {
+    public void method(){
+        Thread myThread = new Thread();
+        myThread.start(); // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
@@ -1,8 +1,75 @@
-package sorald;
+package checks;
 
-public class ThreadRunInvocation {
-    public void method(){
-        Thread myThread = new Thread();
-        myThread.start(); // Noncompliant
+import java.io.Serializable;
+
+class ThreadRunCheck {
+
+  {
+    Thread t = new Thread(new B());
+    t.start(); // Noncompliant
+  }
+
+  public static void main(String[] args) {
+    Runnable runnable = null;
+
+    Thread myThread = new Thread(runnable);
+    myThread.start(); // Noncompliant [[sc=14;ec=17]] {{Call the method Thread.start() to execute the content of the run() method in a dedicated thread.}}
+
+    Thread myThread2 = new Thread(runnable);
+    myThread2.start();
+
+    run();
+    UselessIncrementCheck a = new UselessIncrementCheck();
+    a.run();
+
+    B b = new B();
+    b.start(); // Noncompliant
+
+    C c = new C();
+    c.run(); // Compliant
+
+    D d = new D();
+    d.start(); // Noncompliant
+
+    E e = new E();
+    e.run();
+
+    F f = new F();
+    f.run();
+
+    runnable.run(); // Compliant
+  }
+
+  public static void run() {
+  }
+
+  static class B extends Thread {
+  }
+
+  static class C implements Runnable {
+
+    @Override
+    public void run() {
     }
+
+  }
+
+  static class D extends B {
+    @Override
+    public void run() {
+      C c = new C();
+      c.run(); // compliant, within run method
+      super.run(); // compliant, within run method
+    }
+  }
+
+  static class E implements Serializable {
+
+    public void run() {
+    }
+
+  }
+
+  static class F extends E {
+  }
 }

--- a/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
+++ b/src/test/resources/processor_test_files/1217_ThreadRun/ThreadRunInvocation.java.expected
@@ -1,3 +1,6 @@
+// Test for rule s1217
+// Tests from https://raw.githubusercontent.com/SonarSource/sonar-java/master/java-checks-test-sources/src/main/java/checks/ThreadRunCheck.java
+
 package checks;
 
 import java.io.Serializable;


### PR DESCRIPTION
This processes [1217](https://rules.sonarsource.com/java/RSPEC-1217) warnings.