### PR TITLE
chore: Set fetch-depth to 2 to allow Codecov to find the commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          fetch-depth: 2
       - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: 11


### PR DESCRIPTION
Fix #274 

Codecov needs a fetch depth > 1 to be able to identify the commit. Now we should see the PR statuses being posted again.