### PR TITLE
doc: Fix javadoc warnings

### DIFF
--- a/src/main/java/sorald/event/models/miner/MinedViolationEvent.java
+++ b/src/main/java/sorald/event/models/miner/MinedViolationEvent.java
@@ -12,7 +12,12 @@ public class MinedViolationEvent implements SoraldEvent {
     private final String ruleName;
     private final WarningLocation warningLocation;
 
-    /** Wrapping just one violation inside a mined-rule event */
+    /**
+     * Wrapping just one violation inside a mined-rule event.
+     *
+     * @param violation A rule violation.
+     * @param projectPath Root path to the project being mined.
+     */
     public MinedViolationEvent(RuleViolation violation, Path projectPath) {
         this.ruleKey = violation.getRuleKey();
         this.ruleName = violation.getCheckName();

--- a/src/main/java/sorald/sonar/GreedyBestFitScanner.java
+++ b/src/main/java/sorald/sonar/GreedyBestFitScanner.java
@@ -39,6 +39,7 @@ public class GreedyBestFitScanner<E extends CtElement> extends CtScanner {
      *     single rule.
      * @param processor The processor for which to calculate best matches. Must be the processor for
      *     the single rule that the violations violate.
+     * @param <E> The type of Spoon element considered by the given processor.
      * @return A mapping from Spoon element to an associated rule violation.
      */
     public static <E extends CtElement> Map<CtElement, RuleViolation> calculateBestFits(


### PR DESCRIPTION
There are three Javadoc warnings when packaging the project:

```
[WARNING] Javadoc Warnings
[WARNING] /home/slarse/Documents/github/work/sorald/src/main/java/sorald/event/models/miner/MinedViolationEvent.java:16: warning: no @param for violation
[WARNING] public MinedViolationEvent(RuleViolation violation, Path projectPath) {
[WARNING] ^
[WARNING] /home/slarse/Documents/github/work/sorald/src/main/java/sorald/event/models/miner/MinedViolationEvent.java:16: warning: no @param for projectPath
[WARNING] public MinedViolationEvent(RuleViolation violation, Path projectPath) {
[WARNING] ^
[WARNING] /home/slarse/Documents/github/work/sorald/src/main/java/sorald/sonar/GreedyBestFitScanner.java:44: warning: no @param for <E>
[WARNING] public static <E extends CtElement> Map<CtElement, RuleViolation> calculateBestFits(
[WARNING] ^
```

This PR fixes those warnings by adding the missing javadocs.