### PR TITLE
fix: Harden violation scanning against NullPointerException

### DIFF
--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -86,6 +86,7 @@ public class RuleVerifier {
         scanner.scan(inputFiles);
 
         return sonarComponents.getMessages().stream()
+                .filter(message -> message.primaryLocation() != null)
                 .map(ScannedViolation::new)
                 .collect(Collectors.toSet());
     }

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -1,12 +1,19 @@
 package sorald.sonar;
 
 import org.sonar.java.AnalyzerMessage;
+import org.sonar.plugins.java.api.JavaCheck;
 
 /** Facade around {@link org.sonar.java.AnalyzerMessage} */
 class ScannedViolation extends RuleViolation {
     private final AnalyzerMessage message;
 
     ScannedViolation(AnalyzerMessage message) {
+        if (message.primaryLocation() == null) {
+            throw new IllegalArgumentException(
+                    "message for '"
+                            + getCheckName(message.getCheck())
+                            + "' lacks primary location");
+        }
         this.message = message;
     }
 
@@ -37,11 +44,15 @@ class ScannedViolation extends RuleViolation {
 
     @Override
     public String getCheckName() {
-        return message.getCheck().getClass().getSimpleName();
+        return getCheckName(message.getCheck());
     }
 
     @Override
     public String getRuleKey() {
         return Checks.getRuleKey(message.getCheck().getClass());
+    }
+
+    private static String getCheckName(JavaCheck check) {
+        return check.getClass().getSimpleName();
     }
 }

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -6,6 +6,7 @@ import org.sonar.plugins.java.api.JavaCheck;
 /** Facade around {@link org.sonar.java.AnalyzerMessage} */
 class ScannedViolation extends RuleViolation {
     private final AnalyzerMessage message;
+    private final AnalyzerMessage.TextSpan primaryLocation;
 
     ScannedViolation(AnalyzerMessage message) {
         if (message.primaryLocation() == null) {
@@ -15,26 +16,27 @@ class ScannedViolation extends RuleViolation {
                             + "' lacks primary location");
         }
         this.message = message;
+        this.primaryLocation = message.primaryLocation();
     }
 
     @Override
     public int getStartLine() {
-        return message.primaryLocation().startLine;
+        return primaryLocation.startLine;
     }
 
     @Override
     public int getEndLine() {
-        return message.primaryLocation().endLine;
+        return primaryLocation.endLine;
     }
 
     @Override
     public int getStartCol() {
-        return message.primaryLocation().startCharacter;
+        return primaryLocation.startCharacter;
     }
 
     @Override
     public int getEndCol() {
-        return message.primaryLocation().endCharacter;
+        return primaryLocation.endCharacter;
     }
 
     @Override

--- a/src/test/java/sorald/sonar/RuleVerifierTest.java
+++ b/src/test/java/sorald/sonar/RuleVerifierTest.java
@@ -1,0 +1,42 @@
+package sorald.sonar;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import sorald.Constants;
+
+class RuleVerifierTest {
+
+    @Test
+    public void analyze_filtersOutMessages_thatLackPrimaryLocation() {
+        String testFile =
+                Paths.get(Constants.PATH_TO_RESOURCES_FOLDER)
+                        .resolve("ArrayHashCodeAndToString.java")
+                        .toString();
+        var violations =
+                RuleVerifier.analyze(
+                        List.of(testFile),
+                        new File(Constants.PATH_TO_RESOURCES_FOLDER),
+                        new CheckWithNoLocation());
+
+        assertThat(violations, is(empty()));
+    }
+
+    @Rule(key = "0000")
+    @SuppressWarnings("UnstableApiUsage")
+    private static class CheckWithNoLocation implements JavaFileScanner {
+        @Override
+        public void scanFile(JavaFileScannerContext context) {
+            // setting the line to -1 causes the message to not have a primary location
+            context.addIssue(-1, this, "This is a bogus message");
+        }
+    }
+}

--- a/src/test/java/sorald/sonar/ScannedViolationTest.java
+++ b/src/test/java/sorald/sonar/ScannedViolationTest.java
@@ -1,0 +1,19 @@
+package sorald.sonar;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.AnalyzerMessage;
+import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
+
+class ScannedViolationTest {
+
+    @Test
+    public void constructor_throws_whenPrimaryLocationIsNull() {
+        var message =
+                new AnalyzerMessage(
+                        new ArrayHashCodeAndToStringCheck(), null, -1, "bogus message", 0);
+
+        assertThrows(IllegalArgumentException.class, () -> new ScannedViolation(message));
+    }
+}


### PR DESCRIPTION
Fix #314 

Hardens violation scanning against NPEs by filtering out any `AnalyzerMessage`s that don't have primary locations. If one were to somehow slip through anyway, `ScannedViolation` is now adapted to provide better error messages.