### PR TITLE
feat: Use literal suffixes for CastArithmeticOperandProcessor when applicable

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -206,16 +206,18 @@ Example:
 
 #### Math operands should be cast before assignment ([Sonar Rule 2184](https://rules.sonarsource.com/java/RSPEC-2184))
 
-In arithmetic expressions, when the operands are `int` and/or `long`, but the result of the expression is assigned to a `long`, `double`, or `float`, the first operand is casted to the final type before the operation takes place.
+In arithmetic expressions, when the operands are `int` and/or `long`, but the result of the expression is assigned to
+a `long`, `double`, or `float`, the first left-hand is casted to the final type before the operation takes place.
+To the extent possible, literal suffixes (such as `f` for `float`) are used instead of casting literals.
 
 Example:
 ```diff
 -    float twoThirds = 2/3; // Noncompliant; int division. Yields 0.0
-+    float twoThirds = (float) 2/3;
++    float twoThirds = 2f/3;
 ...
-     public long compute(int factor){
--        return factor * 10000; // Noncompliant, won't produce the expected result if factor > 214748
-+        return (long) factor * 10000; 
+     public long multiply(int lhs, int rhs){
+-        return lhs * rhs; // Noncompliant, won't produce the expected results if lhs * rhs overflows an int
++        return (long) lhs * rhs;
      }
 ```
 

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -1,6 +1,7 @@
 package sorald.processor;
 
 import java.util.List;
+import java.util.Map;
 import sorald.Constants;
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.*;
@@ -40,14 +41,33 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
     @Override
     protected void repairInternal(CtBinaryOperator element) {
         CtTypeReference<?> typeToBeUsedToCast = getExpectedType(element);
-        CtCodeSnippetExpression newBinaryOperator =
-                element.getFactory()
-                        .createCodeSnippetExpression(
-                                "("
-                                        + typeToBeUsedToCast.getSimpleName()
-                                        + ") "
-                                        + element.getLeftHandOperand());
-        element.setLeftHandOperand(newBinaryOperator);
+
+        CtExpression<?> lhs = element.getLeftHandOperand();
+        CtExpression<?> rhs = element.getRightHandOperand();
+        if (isLiteralInt(lhs)) {
+            int value = (int) ((CtLiteral<?>) lhs).getValue();
+            CtCodeSnippetExpression<?> newLhs =
+                    element.getFactory()
+                            .createCodeSnippetExpression(
+                                    value + getLiteralSuffix(typeToBeUsedToCast));
+            element.setLeftHandOperand(newLhs);
+        } else if (isLiteralInt(rhs)) {
+            int value = (int) ((CtLiteral<?>) rhs).getValue();
+            CtCodeSnippetExpression<?> newRhs =
+                    element.getFactory()
+                            .createCodeSnippetExpression(
+                                    value + getLiteralSuffix(typeToBeUsedToCast));
+            element.setRightHandOperand(newRhs);
+        } else {
+            CtCodeSnippetExpression newBinaryOperator =
+                    element.getFactory()
+                            .createCodeSnippetExpression(
+                                    "("
+                                            + typeToBeUsedToCast.getSimpleName()
+                                            + ") "
+                                            + element.getLeftHandOperand());
+            element.setLeftHandOperand(newBinaryOperator);
+        }
 
         // A nicer code for the casting would be the next line. However, more parentheses are added
         // in
@@ -194,5 +214,17 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
             parent = parent.getParent();
         }
         return false;
+    }
+
+    private static boolean isLiteralInt(CtExpression<?> expr) {
+        return expr instanceof CtLiteral
+                && expr.getFactory().Type().INTEGER_PRIMITIVE.equals(expr.getType());
+    }
+
+    private static String getLiteralSuffix(CtTypeReference<?> floatDoubleOrLong) {
+        String simpleName = floatDoubleOrLong.getSimpleName().toLowerCase();
+        assert List.of(Constants.FLOAT, Constants.DOUBLE, Constants.LONG).contains(simpleName);
+        return Map.of(Constants.FLOAT, "f", Constants.DOUBLE, "d", Constants.LONG, "l")
+                .get(simpleName);
     }
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java
@@ -4,7 +4,7 @@ public class LiteralIntOperand {
         long longVal = 1000 + a; // Noncompliant
         float floatVal = 1000 + a; // Noncompliant
         double doubleVal = 1000 + a; // Noncompliant
-        float floatDiv = 1000 / a; // Noncompliant
+        double doubleDiv = 1000 / a; // Noncompliant
     }
 
     public static void literalIntAsRightOperand() {
@@ -12,6 +12,6 @@ public class LiteralIntOperand {
         long longVal = a + 1000; // Noncompliant
         float floatVal = a + 1000; // Noncompliant
         double doubleVal = a + 1000; // Noncompliant
-        float floatDiv = a / 1000; // Noncompliant
+        double doubleDiv = a / 1000; // Noncompliant
     }
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java
@@ -4,6 +4,7 @@ public class LiteralIntOperand {
         long longVal = 1000 + a; // Noncompliant
         float floatVal = 1000 + a; // Noncompliant
         double doubleVal = 1000 + a; // Noncompliant
+        float floatDiv = 1000 / a; // Noncompliant
     }
 
     public static void literalIntAsRightOperand() {
@@ -11,5 +12,6 @@ public class LiteralIntOperand {
         long longVal = a + 1000; // Noncompliant
         float floatVal = a + 1000; // Noncompliant
         double doubleVal = a + 1000; // Noncompliant
+        float floatDiv = a / 1000; // Noncompliant
     }
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java
@@ -1,0 +1,15 @@
+public class LiteralIntOperand {
+    public static void literalIntAsLeftOperand() {
+        int a = 22;
+        long longVal = 1000 + a; // Noncompliant
+        float floatVal = 1000 + a; // Noncompliant
+        double doubleVal = 1000 + a; // Noncompliant
+    }
+
+    public static void literalIntAsRightOperand() {
+        int a = 22;
+        long longVal = a + 1000; // Noncompliant
+        float floatVal = a + 1000; // Noncompliant
+        double doubleVal = a + 1000; // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
@@ -1,0 +1,15 @@
+public class LiteralIntOperand {
+    public static void literalIntAsLeftOperand() {
+        int a = 22;
+        long longVal = 1000L + a; // Noncompliant
+        float floatVal = 1000F + a; // Noncompliant
+        double doubleVal = 1000D + a; // Noncompliant
+    }
+
+    public static void literalIntAsRightOperand() {
+        int a = 22;
+        long longVal = a + 1000L; // Noncompliant
+        float floatVal = a + 1000F; // Noncompliant
+        double doubleVal = a + 1000D; // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
@@ -4,7 +4,7 @@ public class LiteralIntOperand {
         long longVal = 1000l + a; // Noncompliant
         float floatVal = 1000f + a; // Noncompliant
         double doubleVal = 1000d + a; // Noncompliant
-        float floatDiv = 1000f / a; // Noncompliant
+        double doubleDiv = 1000d / a; // Noncompliant
     }
 
     public static void literalIntAsRightOperand() {
@@ -12,6 +12,6 @@ public class LiteralIntOperand {
         long longVal = a + 1000l; // Noncompliant
         float floatVal = a + 1000f; // Noncompliant
         double doubleVal = a + 1000d; // Noncompliant
-        float floatDiv = a / 1000f; // Noncompliant
+        double doubleDiv = a / 1000d; // Noncompliant
     }
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
@@ -4,6 +4,7 @@ public class LiteralIntOperand {
         long longVal = 1000l + a; // Noncompliant
         float floatVal = 1000f + a; // Noncompliant
         double doubleVal = 1000d + a; // Noncompliant
+        float floatDiv = 1000f / a; // Noncompliant
     }
 
     public static void literalIntAsRightOperand() {
@@ -11,5 +12,6 @@ public class LiteralIntOperand {
         long longVal = a + 1000l; // Noncompliant
         float floatVal = a + 1000f; // Noncompliant
         double doubleVal = a + 1000d; // Noncompliant
+        float floatDiv = a / 1000f; // Noncompliant
     }
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/LiteralIntOperand.java.expected
@@ -1,15 +1,15 @@
 public class LiteralIntOperand {
     public static void literalIntAsLeftOperand() {
         int a = 22;
-        long longVal = 1000L + a; // Noncompliant
-        float floatVal = 1000F + a; // Noncompliant
-        double doubleVal = 1000D + a; // Noncompliant
+        long longVal = 1000l + a; // Noncompliant
+        float floatVal = 1000f + a; // Noncompliant
+        double doubleVal = 1000d + a; // Noncompliant
     }
 
     public static void literalIntAsRightOperand() {
         int a = 22;
-        long longVal = a + 1000L; // Noncompliant
-        float floatVal = a + 1000F; // Noncompliant
-        double doubleVal = a + 1000D; // Noncompliant
+        long longVal = a + 1000l; // Noncompliant
+        float floatVal = a + 1000f; // Noncompliant
+        double doubleVal = a + 1000d; // Noncompliant
     }
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/VariableIntOperand.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/VariableIntOperand.java
@@ -1,0 +1,10 @@
+public class VariableIntOperand {
+    public static void method() {
+        int a = 22;
+        int b = 33;
+        long longVal = a + b; // Noncompliant
+        float floatVal = a + b; // Noncompliant
+        double doubleVal = a + b; // Noncompliant
+        double doubleDiv = a / b; // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/VariableIntOperand.java.expected
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/VariableIntOperand.java.expected
@@ -1,0 +1,10 @@
+public class VariableIntOperand {
+    public static void method() {
+        int a = 22;
+        int b = 33;
+        long longVal = (long) a + b; // Noncompliant
+        float floatVal = (float) a + b; // Noncompliant
+        double doubleVal = (double) a + b; // Noncompliant
+        double doubleDiv = (double) a / b; // Noncompliant
+    }
+}


### PR DESCRIPTION
Fix #321 

This PR changes `CastArithmeticOperandProcessor`'s transformations to use literal suffixes instead of casts when applicable. Here's an example:

```java
// original statement
long val = 1000 * someIntValue;

// old transformation
long val = (long) 1000 * someIntValue;

// new transformation
long val = 1000L * someIntValue;
```

Casts are still used where literal suffixes aren't applicable.

@fermadeiral WDYT, should we make this the default? I personally prefer literal suffixes, but as you noted in #321 none of the transformations or poor from an idiomatic standpoint. We could also hold off until we have the ability to supply options to processors.