### PR TITLE
feat: Respect NOSONAR comments

### DIFF
--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
@@ -222,6 +223,13 @@ public class RuleVerifier {
         public List<AnalyzerMessage> getMessages() {
             return messages.stream()
                     .filter(message -> postFilter.accept(getRuleKey(message), message))
+                    .filter(
+                            message -> {
+                                DefaultInputFile inputFile =
+                                        (DefaultInputFile) message.getInputComponent();
+                                Integer line = message.getLine();
+                                return line == null || !inputFile.hasNoSonarAt(line);
+                            })
                     .collect(Collectors.toList());
         }
 

--- a/src/test/java/sorald/NoSonarTest.java
+++ b/src/test/java/sorald/NoSonarTest.java
@@ -30,6 +30,6 @@ public class NoSonarTest {
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);
         RuleVerifier.verifyHasIssue(
-                pathToBuggyFile, new ArrayHashCodeAndToStringCheck()); // one bug left
+                pathToRepairedFile, new ArrayHashCodeAndToStringCheck()); // one bug left
     }
 }

--- a/src/test/java/sorald/TestHelper.java
+++ b/src/test/java/sorald/TestHelper.java
@@ -6,18 +6,20 @@ import java.io.FileReader;
 
 public class TestHelper {
 
-    /*
-    Simple helper method that removes the mandatory // Noncompliant comments from test files.
+    /**
+     * Simple helper method that removes the mandatory // Noncompliant comments from test files,
+     * except for lines that contain NOSONAR comments.
      */
     public static void removeComplianceComments(String pathToRepairedFile) {
         final String complianceComment = "// Noncompliant";
+        final String noSonar = "NOSONAR";
         try {
             BufferedReader file = new BufferedReader(new FileReader(pathToRepairedFile));
             StringBuffer inputBuffer = new StringBuffer();
             String line;
 
             while ((line = file.readLine()) != null) {
-                if (line.contains(complianceComment)) {
+                if (line.contains(complianceComment) && !line.contains(noSonar)) {
                     line.trim();
                     line = line.substring(0, line.indexOf(complianceComment));
                 }

--- a/src/test/java/sorald/sonar/RuleVerifierTest.java
+++ b/src/test/java/sorald/sonar/RuleVerifierTest.java
@@ -1,12 +1,17 @@
 package sorald.sonar;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
@@ -57,6 +62,29 @@ class RuleVerifierTest {
                         new CheckWithNoLocation());
 
         assertThat(violations, is(empty()));
+    }
+
+    @Test
+    public void analyze_doesNotReturnViolation_fromNosonarLine() throws IOException {
+        // arrange
+        Path testFile =
+                Paths.get(Constants.PATH_TO_RESOURCES_FOLDER).resolve("NOSONARCommentTest.java");
+        int nosonarLine = 7;
+        int violationLine = 8;
+        List<String> lines = Files.readAllLines(testFile);
+        assertThat(lines.get(nosonarLine - 1), containsString("// Noncompliant, NOSONAR"));
+        assertThat(lines.get(violationLine - 1), containsString("// Noncompliant"));
+
+        // act
+        var violations =
+                RuleVerifier.analyze(
+                        List.of(testFile.toString()),
+                        new File(Constants.PATH_TO_RESOURCES_FOLDER),
+                        List.of(Checks.getCheckInstance("S2116")));
+
+        // assert
+        assertThat(violations.size(), equalTo(1));
+        assertThat(violations.stream().findFirst().get().getStartLine(), equalTo(violationLine));
     }
 
     @Rule(key = "0000")

--- a/src/test/java/sorald/sonar/RuleVerifierTest.java
+++ b/src/test/java/sorald/sonar/RuleVerifierTest.java
@@ -17,9 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.sonar.check.Rule;
-import org.sonar.plugins.java.api.JavaFileScanner;
-import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.java.checks.DefaultPackageCheck;
 import sorald.Constants;
 
 class RuleVerifierTest {
@@ -51,6 +49,8 @@ class RuleVerifierTest {
 
     @Test
     public void analyze_filtersOutMessages_thatLackPrimaryLocation() {
+        var checkWithNoLocation = new DefaultPackageCheck();
+
         String testFile =
                 Paths.get(Constants.PATH_TO_RESOURCES_FOLDER)
                         .resolve("ArrayHashCodeAndToString.java")
@@ -59,7 +59,7 @@ class RuleVerifierTest {
                 RuleVerifier.analyze(
                         List.of(testFile),
                         new File(Constants.PATH_TO_RESOURCES_FOLDER),
-                        new CheckWithNoLocation());
+                        checkWithNoLocation);
 
         assertThat(violations, is(empty()));
     }
@@ -85,15 +85,5 @@ class RuleVerifierTest {
         // assert
         assertThat(violations.size(), equalTo(1));
         assertThat(violations.stream().findFirst().get().getStartLine(), equalTo(violationLine));
-    }
-
-    @Rule(key = "0000")
-    @SuppressWarnings("UnstableApiUsage")
-    private static class CheckWithNoLocation implements JavaFileScanner {
-        @Override
-        public void scanFile(JavaFileScannerContext context) {
-            // setting the line to -1 causes the message to not have a primary location
-            context.addIssue(-1, this, "This is a bogus message");
-        }
     }
 }


### PR DESCRIPTION
Fix #316 

Re-implements feature for respecting `// NOSONAR` comments in the source code. The test to check this functionality has also been fixed, and a new one added.