### PR TITLE
refactor: Commit generated code instead of generating on compile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+        with:
+          java-version: 11
+          java-package: jdk
+          architecture: x64
       - name: Test that generated code is up-to-date
         run: |
           mvn clean compile dependency:build-classpath -Dmdep.outputFile=cp.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,3 +51,15 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
           pytest test_prrecorder.py
+
+  test-code-generation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - name: Test that generated code is up-to-date
+        run: |
+          mvn clean compile dependency:build-classpath -Dmdep.outputFile=cp.txt
+          java -cp "$(cat cp.txt):./target/classes" sorald.CodeGenerator
+          mvn spotless:apply
+          git diff --exit-code

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,9 +66,9 @@ with `ProcessorAnnotation`.
 
 As soon as you have created a skeleton for the processor, with the
 `ProcessorAnnotation` properly filled in, you should update the `Processors`
-class. You do this by running the main method of
-`sorald.annotations.ProcessorsClassGenerator`, which you can either do with
-your favorite IDE, or by running the following shell commands in `bash`:
+class. You do this by running the main method of `sorald.CodeGenerator`, which
+you can either do with your favorite IDE, or by running the following shell
+commands in `bash`:
 
 ```bash
 $ mvn clean compile dependency:build-classpath -Dmdep.outputFile=cp.txt

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,22 +2,6 @@
 
 Pull requests are very welcome by the Sorald team!
 
-### A note on using an IDE to develop Sorald
-
-Due to a somewhat unconventional annotation processor setup that includes a
-precompile step to compile the processor, IDEs sometimes have trouble building
-Sorald. There are currently two workarounds for this.
-
-1. If your IDE supports it, you may delegate building of the project to Maven
-2. Simply build with Maven from the command line
-    - `mvn test-compile`
-    - You can then run the tests with the IDE as per usual
-
-In addition, you must ensure that `target/generated-sources` is marked as a
-source root within your IDE. Otherwise, it may complain about the `Processors`
-class not existing. The IDE should pick this up from `pom.xml`, but it has
-happened that it doesn't do so correctly.
-
 ### Guidelines for all pull-requests
 
 You may open a PR at any time when working on something. Prefix the title of
@@ -72,19 +56,34 @@ So the name of your new processor is `CastArithmeticOperandCheck` replacing "Che
 
 Once you have the name for the new processor, you can create a class using that
 name in `src/main/java/sorald/processor`.  This new class must extend
-`SoraldAbstractProcessor` and implement the abstract methods.
+`SoraldAbstractProcessor` and implement the abstract methods, and be annotated
+with `ProcessorAnnotation`.
 
 > See the documentation for the abstract methods in
 > [SoraldAbstractProcessor](src/main/java/sorald/processor/SoraldAbstractProcessor.java),
 > and check out [the existing implementations
 > here](/src/main/java/sorald/processor) for guidance.
 
-When you have created your processor, you must also add the check class to one
-of the four categories of check classes in the static code block in
-[Checks.java](/src/main/java/sorald/sonar/Checks.java), if it is not already
-present. To find out which category to add your check to, look it up on the
-[SonarSource website](https://rules.sonarsource.com/java), the category is
-listed just below the rule title.
+As soon as you have created a skeleton for the processor, with the
+`ProcessorAnnotation` properly filled in, you should update the `Processors`
+class. You do this by running the main method of
+`sorald.annotations.ProcessorsClassGenerator`, which you can either do with
+your favorite IDE, or by running the following shell commands in `bash`:
+
+```bash
+$ mvn clean compile dependency:build-classpath -Dmdep.outputFile=cp.txt
+$ java -cp "$(cat cp.txt):./target/classes" sorald.CodeGenerator
+$ mvn spotless:apply
+```
+
+After that, you can start developing your processor for real! Note that if you
+update the annotations of your processor, you must update the `Processors`
+class again as described above.
+
+> **Complicated?:** The procedure for adding a processor is a little bit
+> contrived. It used to be automatic through processor annotations, which
+> worked excellently with Maven, but we experienced so many issues with IDE and
+> editor integration that we eventually gave up on it.
 
 3) Add at least one test file with expected output for your processor
 

--- a/pom.xml
+++ b/pom.xml
@@ -222,36 +222,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <!-- The annotation processor(s) must be available at compile time,
-                        so we must compile them before the normal compile phase -->
-                        <id>precompile-annotation-processor</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <!-- setting proc to none is very important,
-                            or Maven will try to run annotation processors during this execution! -->
-                            <proc>none</proc>
-                            <includes>
-                                <include>sorald/annotations/*.java</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <generatedSourcesDirectory>${project.build.directory}/generated-sources</generatedSourcesDirectory>
-                    <annotationProcessors>
-                        <annotationProcessor>
-                            sorald.annotations.ProcessorsClassGenerator
-                        </annotationProcessor>
-                    </annotationProcessors>
-                    <compilerArgs>
-                        <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
             <!-- adapted from https://www.jacoco.org/jacoco/trunk/doc/examples/build/pom.xml -->
             <plugin>

--- a/src/main/java/sorald/CodeGenerator.java
+++ b/src/main/java/sorald/CodeGenerator.java
@@ -1,5 +1,7 @@
 package sorald;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import sorald.annotations.ProcessorsClassGenerator;
 import spoon.Launcher;
 
@@ -7,16 +9,16 @@ import spoon.Launcher;
 public class CodeGenerator {
 
     public static void main(String[] args) {
-        generateSources();
+        generateSources(Paths.get("src/main/java"));
     }
 
-    private static void generateSources() {
+    static void generateSources(Path outputDirectory) {
         final Launcher launcher = new Launcher();
         launcher.getEnvironment().setAutoImports(true);
         launcher.getEnvironment().setNoClasspath(true);
         launcher.getEnvironment().setCommentEnabled(true);
 
-        launcher.setSourceOutputDirectory("./src/main/java");
+        launcher.setSourceOutputDirectory(outputDirectory.toString());
         launcher.addInputResource("src/main/java/sorald");
 
         launcher.addProcessor(new ProcessorsClassGenerator<>());

--- a/src/main/java/sorald/CodeGenerator.java
+++ b/src/main/java/sorald/CodeGenerator.java
@@ -4,7 +4,7 @@ import sorald.annotations.ProcessorsClassGenerator;
 import spoon.Launcher;
 
 /** Wrapper class for all (present and future) code generation in Sorald. */
-public class GenerateCode {
+public class CodeGenerator {
     public static void main(String[] args) {
         final Launcher launcher = new Launcher();
         launcher.getEnvironment().setAutoImports(true);

--- a/src/main/java/sorald/CodeGenerator.java
+++ b/src/main/java/sorald/CodeGenerator.java
@@ -5,13 +5,18 @@ import spoon.Launcher;
 
 /** Wrapper class for all (present and future) code generation in Sorald. */
 public class CodeGenerator {
+
     public static void main(String[] args) {
+        generateSources();
+    }
+
+    private static void generateSources() {
         final Launcher launcher = new Launcher();
         launcher.getEnvironment().setAutoImports(true);
         launcher.getEnvironment().setNoClasspath(true);
         launcher.getEnvironment().setCommentEnabled(true);
-        launcher.setSourceOutputDirectory("./src/main/java");
 
+        launcher.setSourceOutputDirectory("./src/main/java");
         launcher.addInputResource("src/main/java/sorald");
 
         launcher.addProcessor(new ProcessorsClassGenerator<>());

--- a/src/main/java/sorald/GenerateCode.java
+++ b/src/main/java/sorald/GenerateCode.java
@@ -1,0 +1,22 @@
+package sorald;
+
+import sorald.annotations.ProcessorsClassGenerator;
+import spoon.Launcher;
+
+/** Wrapper class for all (present and future) code generation in Sorald. */
+public class GenerateCode {
+    public static void main(String[] args) {
+        final Launcher launcher = new Launcher();
+        launcher.getEnvironment().setAutoImports(true);
+        launcher.getEnvironment().setNoClasspath(true);
+        launcher.getEnvironment().setCommentEnabled(true);
+        launcher.setSourceOutputDirectory("./src/main/java");
+
+        launcher.addInputResource("src/main/java/sorald");
+
+        launcher.addProcessor(new ProcessorsClassGenerator<>());
+        launcher.setOutputFilter("sorald.Processors");
+
+        launcher.run();
+    }
+}

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -1,0 +1,20 @@
+package sorald;
+
+import java.util.HashMap;
+import java.util.Map;
+import sorald.processor.*;
+
+public class Processors {
+    private static final Map<Integer, Class<? extends SoraldAbstractProcessor<?>>>
+            RULE_KEY_TO_PROCESSOR =
+                    new HashMap<>() {
+                        {
+                        }
+                    };
+
+    public static final String RULE_DESCRIPTIONS = "";
+
+    public static Class<? extends SoraldAbstractProcessor<?>> getProcessor(int key) {
+        return RULE_KEY_TO_PROCESSOR.get(key);
+    }
+}

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -8,32 +8,32 @@ public class Processors {
             RULE_KEY_TO_PROCESSOR =
                     new java.util.HashMap<>() {
                         {
-                            put(2272, IteratorNextExceptionProcessor.class);
                             put(1217, ThreadRunProcessor.class);
-                            put(2755, XxeProcessingProcessor.class);
-                            put(2116, ArrayHashCodeAndToStringProcessor.class);
                             put(1444, PublicStaticFieldShouldBeFinalProcessor.class);
+                            put(1656, SelfAssignementProcessor.class);
+                            put(1854, DeadStoreProcessor.class);
                             put(1860, SynchronizationOnStringOrBoxedProcessor.class);
-                            put(2184, CastArithmeticOperandProcessor.class);
-                            put(4973, CompareStringsBoxedTypesWithEqualsProcessor.class);
+                            put(1948, SerializableFieldInSerializableClassProcessor.class);
                             put(2095, UnclosedResourcesProcessor.class);
-                            put(3984, UnusedThrowableProcessor.class);
-                            put(2225, ToStringReturningNullProcessor.class);
+                            put(2111, BigDecimalDoubleConstructorProcessor.class);
+                            put(2116, ArrayHashCodeAndToStringProcessor.class);
+                            put(2142, InterruptedExceptionProcessor.class);
                             put(2164, MathOnFloatProcessor.class);
                             put(2167, CompareToReturnValueProcessor.class);
-                            put(3032, GetClassLoaderProcessor.class);
-                            put(1656, SelfAssignementProcessor.class);
-                            put(3067, SynchronizationOnGetClassProcessor.class);
+                            put(2184, CastArithmeticOperandProcessor.class);
                             put(2204, EqualsOnAtomicClassProcessor.class);
-                            put(1948, SerializableFieldInSerializableClassProcessor.class);
-                            put(1854, DeadStoreProcessor.class);
-                            put(2142, InterruptedExceptionProcessor.class);
-                            put(2111, BigDecimalDoubleConstructorProcessor.class);
+                            put(2225, ToStringReturningNullProcessor.class);
+                            put(2272, IteratorNextExceptionProcessor.class);
+                            put(2755, XxeProcessingProcessor.class);
+                            put(3032, GetClassLoaderProcessor.class);
+                            put(3067, SynchronizationOnGetClassProcessor.class);
+                            put(3984, UnusedThrowableProcessor.class);
+                            put(4973, CompareStringsBoxedTypesWithEqualsProcessor.class);
                         }
                     };
 
     public static final String RULE_DESCRIPTIONS =
-            "\n2116: \"hashCode\" and \"toString\" should not be called on array instances\n2111: \"BigDecimal(double)\" should not be used\n2184: Math operands should be cast before assignment\n4973: Strings and Boxed types should be compared using \"equals()\"\n2167: \"compareTo\" should not return \"Integer.MIN_VALUE\"\n1854: Unused assignments should be removed\n2204: \".equals()\" should not be used to test the values of \"Atomic\" classes\n3032: JEE applications should not \"getClassLoader\"\n2142: \"InterruptedException\" should not be ignored\n2272: \"Iterator.next()\" methods should throw \"NoSuchElementException\"\n2164: Math should not be performed on floats\n1444: \"public static\" fields should be constant\n\t(incomplete: does not fix variable naming)\n1656: Variables should not be self-assigned\n1948: Fields in a \"Serializable\" class should either be transient or serializable\n3067: \"getClass\" should not be used for synchronization\n1860: Synchronization should not be based on Strings or boxed primitives\n1217: \"Thread.run()\" should not be called directly\n2225: \"toString()\" and \"clone()\" methods should not return null\n\t(incomplete: does not fix null returning clone())\n2095: Resources should be closed\n3984: Exception should not be created without being thrown\n2755: XML parsers should not be vulnerable to XXE attacks\n\t(incomplete: This processor is a WIP and currently supports a subset of rule 2755. See Sorald\'s documentation for details.)";
+            "1217: \"Thread.run()\" should not be called directly\n1444: \"public static\" fields should be constant\n\t(incomplete: does not fix variable naming)\n1656: Variables should not be self-assigned\n1854: Unused assignments should be removed\n1860: Synchronization should not be based on Strings or boxed primitives\n1948: Fields in a \"Serializable\" class should either be transient or serializable\n2095: Resources should be closed\n2111: \"BigDecimal(double)\" should not be used\n2116: \"hashCode\" and \"toString\" should not be called on array instances\n2142: \"InterruptedException\" should not be ignored\n2164: Math should not be performed on floats\n2167: \"compareTo\" should not return \"Integer.MIN_VALUE\"\n2184: Math operands should be cast before assignment\n2204: \".equals()\" should not be used to test the values of \"Atomic\" classes\n2225: \"toString()\" and \"clone()\" methods should not return null\n\t(incomplete: does not fix null returning clone())\n2272: \"Iterator.next()\" methods should throw \"NoSuchElementException\"\n2755: XML parsers should not be vulnerable to XXE attacks\n\t(incomplete: This processor is a WIP and currently supports a subset of rule 2755. See Sorald\'s documentation for details.)\n3032: JEE applications should not \"getClassLoader\"\n3067: \"getClass\" should not be used for synchronization\n3984: Exception should not be created without being thrown\n4973: Strings and Boxed types should be compared using \"equals()\"";
 
     public static Class<? extends SoraldAbstractProcessor<?>> getProcessor(int key) {
         return RULE_KEY_TO_PROCESSOR.get(key);

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -1,18 +1,39 @@
 package sorald;
 
-import java.util.HashMap;
 import java.util.Map;
 import sorald.processor.*;
 
 public class Processors {
     private static final Map<Integer, Class<? extends SoraldAbstractProcessor<?>>>
             RULE_KEY_TO_PROCESSOR =
-                    new HashMap<>() {
+                    new java.util.HashMap<>() {
                         {
+                            put(2272, IteratorNextExceptionProcessor.class);
+                            put(1217, ThreadRunProcessor.class);
+                            put(2755, XxeProcessingProcessor.class);
+                            put(2116, ArrayHashCodeAndToStringProcessor.class);
+                            put(1444, PublicStaticFieldShouldBeFinalProcessor.class);
+                            put(1860, SynchronizationOnStringOrBoxedProcessor.class);
+                            put(2184, CastArithmeticOperandProcessor.class);
+                            put(4973, CompareStringsBoxedTypesWithEqualsProcessor.class);
+                            put(2095, UnclosedResourcesProcessor.class);
+                            put(3984, UnusedThrowableProcessor.class);
+                            put(2225, ToStringReturningNullProcessor.class);
+                            put(2164, MathOnFloatProcessor.class);
+                            put(2167, CompareToReturnValueProcessor.class);
+                            put(3032, GetClassLoaderProcessor.class);
+                            put(1656, SelfAssignementProcessor.class);
+                            put(3067, SynchronizationOnGetClassProcessor.class);
+                            put(2204, EqualsOnAtomicClassProcessor.class);
+                            put(1948, SerializableFieldInSerializableClassProcessor.class);
+                            put(1854, DeadStoreProcessor.class);
+                            put(2142, InterruptedExceptionProcessor.class);
+                            put(2111, BigDecimalDoubleConstructorProcessor.class);
                         }
                     };
 
-    public static final String RULE_DESCRIPTIONS = "";
+    public static final String RULE_DESCRIPTIONS =
+            "\n2116: \"hashCode\" and \"toString\" should not be called on array instances\n2111: \"BigDecimal(double)\" should not be used\n2184: Math operands should be cast before assignment\n4973: Strings and Boxed types should be compared using \"equals()\"\n2167: \"compareTo\" should not return \"Integer.MIN_VALUE\"\n1854: Unused assignments should be removed\n2204: \".equals()\" should not be used to test the values of \"Atomic\" classes\n3032: JEE applications should not \"getClassLoader\"\n2142: \"InterruptedException\" should not be ignored\n2272: \"Iterator.next()\" methods should throw \"NoSuchElementException\"\n2164: Math should not be performed on floats\n1444: \"public static\" fields should be constant\n\t(incomplete: does not fix variable naming)\n1656: Variables should not be self-assigned\n1948: Fields in a \"Serializable\" class should either be transient or serializable\n3067: \"getClass\" should not be used for synchronization\n1860: Synchronization should not be based on Strings or boxed primitives\n1217: \"Thread.run()\" should not be called directly\n2225: \"toString()\" and \"clone()\" methods should not return null\n\t(incomplete: does not fix null returning clone())\n2095: Resources should be closed\n3984: Exception should not be created without being thrown\n2755: XML parsers should not be vulnerable to XXE attacks\n\t(incomplete: This processor is a WIP and currently supports a subset of rule 2755. See Sorald\'s documentation for details.)";
 
     public static Class<? extends SoraldAbstractProcessor<?>> getProcessor(int key) {
         return RULE_KEY_TO_PROCESSOR.get(key);

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -3,7 +3,12 @@ package sorald;
 import java.util.Map;
 import sorald.processor.*;
 
+/**
+ * This class is partially generated. It is fine to edit non-generated code as per usual, but don't
+ * change any of the generated fields unless you know precisely what you are doing.
+ */
 public class Processors {
+    // GENERATED FIELD
     private static final Map<Integer, Class<? extends SoraldAbstractProcessor<?>>>
             RULE_KEY_TO_PROCESSOR =
                     new java.util.HashMap<>() {
@@ -32,6 +37,7 @@ public class Processors {
                         }
                     };
 
+    // GENERATED FIELD
     public static final String RULE_DESCRIPTIONS =
             "1217: \"Thread.run()\" should not be called directly\n1444: \"public static\" fields should be constant\n\t(incomplete: does not fix variable naming)\n1656: Variables should not be self-assigned\n1854: Unused assignments should be removed\n1860: Synchronization should not be based on Strings or boxed primitives\n1948: Fields in a \"Serializable\" class should either be transient or serializable\n2095: Resources should be closed\n2111: \"BigDecimal(double)\" should not be used\n2116: \"hashCode\" and \"toString\" should not be called on array instances\n2142: \"InterruptedException\" should not be ignored\n2164: Math should not be performed on floats\n2167: \"compareTo\" should not return \"Integer.MIN_VALUE\"\n2184: Math operands should be cast before assignment\n2204: \".equals()\" should not be used to test the values of \"Atomic\" classes\n2225: \"toString()\" and \"clone()\" methods should not return null\n\t(incomplete: does not fix null returning clone())\n2272: \"Iterator.next()\" methods should throw \"NoSuchElementException\"\n2755: XML parsers should not be vulnerable to XXE attacks\n\t(incomplete: This processor is a WIP and currently supports a subset of rule 2755. See Sorald\'s documentation for details.)\n3032: JEE applications should not \"getClassLoader\"\n3067: \"getClass\" should not be used for synchronization\n3984: Exception should not be created without being thrown\n4973: Strings and Boxed types should be compared using \"equals()\"";
 

--- a/src/main/java/sorald/annotations/ProcessorsClassGenerator.java
+++ b/src/main/java/sorald/annotations/ProcessorsClassGenerator.java
@@ -1,217 +1,71 @@
 package sorald.annotations;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.processing.AbstractProcessor;
-import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.tools.Diagnostic;
-import javax.tools.JavaFileObject;
-import spoon.Launcher;
+import spoon.processing.AbstractAnnotationProcessor;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtReturn;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.reference.CtWildcardReference;
 
-/**
- * Annotation processor that generates the class sorald.Processors, which contains utility methods
- * for fetching Sorald processors and their descriptions.
- */
-@SupportedAnnotationTypes({
-    "sorald.annotations.ProcessorAnnotation",
-})
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
-public class ProcessorsClassGenerator extends AbstractProcessor {
-    private static final Set<ModifierKind> PUBLIC_STATIC_FINAL =
-            new HashSet<>(
-                    Arrays.asList(ModifierKind.PUBLIC, ModifierKind.STATIC, ModifierKind.FINAL));
-
-    private static final Set<ModifierKind> PRIVATE_STATIC_FINAL =
-            new HashSet<>(
-                    Arrays.asList(ModifierKind.PRIVATE, ModifierKind.STATIC, ModifierKind.FINAL));
-
-    private static final String PROCESSORS_CLASS_QUALNAME = "sorald.Processors";
-    private static final String SORALD_ABSTRACT_PROCESSOR_QUALNAME =
-            "sorald.processor.SoraldAbstractProcessor";
-
-    private final Factory factory;
-
-    public ProcessorsClassGenerator() {
-        Launcher launcher = new Launcher();
-        launcher.getEnvironment().setNoClasspath(true);
-        factory = launcher.getFactory();
-    }
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class ProcessorsClassGenerator<T>
+        extends AbstractAnnotationProcessor<ProcessorAnnotation, CtClass<T>> {
+    private CtCompilationUnit cu = null;
+    private CtType<?> processorsClass = null;
+    private final Map<Integer, CtClass<?>> processorMap = new HashMap<>();
+    private String ruleDescriptions = "";
 
     @Override
-    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        if (annotations.isEmpty()) {
-            return false;
-        } else if (annotations.size() > 1) {
-            processingEnv
-                    .getMessager()
-                    .printMessage(
-                            Diagnostic.Kind.ERROR,
-                            "Unexpected amount of annotations " + annotations);
-            return false;
+    public void process(ProcessorAnnotation annotation, CtClass<T> element) {
+        if (cu == null) {
+            cu = getFactory().createCompilationUnit();
+            processorsClass = getFactory().Type().get("sorald.Processors");
         }
 
-        TypeElement processorAnnotation = getAnnotationFrom(ProcessorAnnotation.class, annotations);
-        Set<? extends Element> processors = roundEnv.getElementsAnnotatedWith(processorAnnotation);
-        try {
-            CtType<?> processorsClass = createProcessorsClass(processors);
-            writeType(processorsClass);
-        } catch (Exception e) {
-            processingEnv
-                    .getMessager()
-                    .printMessage(
-                            Diagnostic.Kind.ERROR,
-                            "Something went wrong generating the "
-                                    + PROCESSORS_CLASS_QUALNAME
-                                    + " class");
-            e.printStackTrace();
-            return false;
-        }
-        return true;
+        processorMap.put(annotation.key(), element);
+        updateProcessorMapField();
+        updateRuleDescriptions(annotation, element.getAnnotation(IncompleteProcessor.class));
     }
 
-    private CtType<?> createProcessorsClass(Set<? extends Element> processors) {
-        CtType<?> processorsClass = factory.createClass(PROCESSORS_CLASS_QUALNAME);
-        processorsClass.setModifiers(new HashSet<>(Arrays.asList(ModifierKind.PUBLIC)));
-        CtField<String> ruleKeyToProcessor =
-                addRuleKeyToProcessorField(processorsClass, processors);
-        addGetProcessorMethod(processorsClass, ruleKeyToProcessor);
-        addRuleDescriptionsField(processorsClass, processors);
-        return processorsClass;
+    private void updateProcessorMapField() {
+        CtField procMapField = processorsClass.getField("RULE_KEY_TO_PROCESSOR");
+        procMapField.setDefaultExpression(generateProductionProcessorMapInitializer());
     }
 
-    private void writeType(CtType<?> type) throws IOException {
-        JavaFileObject processorsFile =
-                processingEnv.getFiler().createSourceFile(type.getQualifiedName());
-
-        try (PrintWriter out = new PrintWriter(processorsFile.openWriter())) {
-            out.println(type.toStringWithImports());
-        }
+    private void updateRuleDescriptions(
+            ProcessorAnnotation processorAnnotation, IncompleteProcessor incompleteAnnotation) {
+        ruleDescriptions +=
+                "\n" + generateRuleDescription(processorAnnotation, incompleteAnnotation);
+        CtField<String> field = (CtField<String>) processorsClass.getField("RULE_DESCRIPTIONS");
+        field.setDefaultExpression(getFactory().createLiteral(ruleDescriptions));
     }
 
-    private void addRuleDescriptionsField(CtType<?> type, Set<? extends Element> elements) {
-        String ruleDescriptions = generateRuleDescriptions(elements);
-        factory.createField(
-                type,
-                PUBLIC_STATIC_FINAL,
-                factory.Type().STRING,
-                "RULE_DESCRIPTIONS",
-                factory.createLiteral(ruleDescriptions));
+    private CtExpression<?> generateProductionProcessorMapInitializer() {
+        String mapInitializer =
+                "new java.util.HashMap<>() {{\n"
+                        + processorMap.entrySet().stream()
+                                .map(
+                                        entry ->
+                                                "put("
+                                                        + entry.getKey()
+                                                        + ","
+                                                        + entry.getValue().getSimpleName()
+                                                        + ".class);")
+                                .collect(Collectors.joining("\n"))
+                        + "\n}}\n";
+        return getFactory().createCodeSnippetExpression(mapInitializer);
     }
 
-    private void addGetProcessorMethod(CtType<?> type, CtField<String> ruleKeyToProcessor) {
-        CtTypeReference<?> returnType =
-                createClassTypeRefWithUpperBound(
-                        factory.createReference(SORALD_ABSTRACT_PROCESSOR_QUALNAME));
-        CtMethod<String> getProcessor =
-                factory.createMethod(
-                        type,
-                        PUBLIC_STATIC_FINAL,
-                        returnType,
-                        "getProcessor",
-                        Collections.emptyList(),
-                        Collections.emptySet());
-        factory.createParameter(getProcessor, factory.Type().INTEGER_PRIMITIVE, "key");
-
-        CtReturn<String> retStatement = factory.createReturn();
-        retStatement.setReturnedExpression(
-                factory.createCodeSnippetExpression(
-                        ruleKeyToProcessor.getSimpleName() + ".get(key)"));
-        getProcessor.setBody(factory.createCtBlock(retStatement));
-    }
-
-    private CtField<String> addRuleKeyToProcessorField(
-            CtType<?> type, Set<? extends Element> elements) {
-        CtTypeReference<?> mapTypeRef = factory.createCtTypeReference(Map.class);
-        mapTypeRef.addActualTypeArgument(factory.Type().INTEGER);
-        mapTypeRef.addActualTypeArgument(
-                createClassTypeRefWithUpperBound(
-                        factory.createReference(SORALD_ABSTRACT_PROCESSOR_QUALNAME)));
-        return factory.createField(
-                type,
-                PRIVATE_STATIC_FINAL,
-                mapTypeRef,
-                "RULE_KEY_TO_PROCESSOR",
-                generateRuleKeyToProcessorInitializer(elements));
-    }
-
-    /** Generate the CLI descriptions of rules based on ProcessorAnotations. */
-    private String generateRuleDescriptions(Set<? extends Element> elements) {
-        return elements.stream()
-                .map(this::generateRuleDescription)
-                .collect(Collectors.joining("\n"));
-    }
-
-    private String generateRuleDescription(Element processor) {
-        ProcessorAnnotation processorAnnotation =
-                processor.getAnnotation(ProcessorAnnotation.class);
-        IncompleteProcessor incompleteAnnotation =
-                processor.getAnnotation(IncompleteProcessor.class);
+    private String generateRuleDescription(
+            ProcessorAnnotation processorAnnotation, IncompleteProcessor incompleteAnnotation) {
         return processorAnnotation.key()
                 + ": "
                 + processorAnnotation.description()
                 + (incompleteAnnotation == null
                         ? ""
                         : "\n\t(incomplete: " + incompleteAnnotation.description() + ")");
-    }
-
-    /**
-     * Generate a static initializer for a Map<Integer, ? extends SoraldAbstractProcessor> that maps
-     * a rule key to its corresponding processor.
-     */
-    private CtExpression<?> generateRuleKeyToProcessorInitializer(Set<? extends Element> elements) {
-        String mapInitializer =
-                "new java.util.HashMap() {{\n"
-                        + elements.stream()
-                                .map(
-                                        type ->
-                                                "put("
-                                                        + type.getAnnotation(
-                                                                        ProcessorAnnotation.class)
-                                                                .key()
-                                                        + ","
-                                                        + type.toString()
-                                                        + ".class);")
-                                .collect(Collectors.joining("\n"))
-                        + "\n}}\n";
-        return factory.createCodeSnippetExpression(mapInitializer);
-    }
-
-    /** Create a type reference to Class<? extends upperBound> */
-    private CtTypeReference<?> createClassTypeRefWithUpperBound(CtTypeReference<?> upperBound) {
-        CtTypeReference<?> clsWithBound = factory.Type().get(Class.class).getReference();
-        CtWildcardReference wildcard = factory.createWildcardReference();
-        wildcard.setBoundingType(upperBound);
-        wildcard.setUpper(true);
-        clsWithBound.addActualTypeArgument(wildcard);
-        return clsWithBound;
-    }
-
-    /** Get a specific annotation from a set of annotations */
-    private static TypeElement getAnnotationFrom(
-            Class<?> annotation, Set<? extends TypeElement> annotations) {
-        return annotations.stream()
-                .filter(te -> te.getQualifiedName().toString().equals(annotation.getName()))
-                .findFirst()
-                .orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/src/test/java/sorald/CodeGeneratorTest.java
+++ b/src/test/java/sorald/CodeGeneratorTest.java
@@ -1,0 +1,45 @@
+package sorald;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import spoon.Launcher;
+import spoon.reflect.CtModel;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.visitor.PrettyPrinter;
+
+public class CodeGeneratorTest {
+
+    /** Test that there is no difference between the generated code and the committed code. */
+    @Test
+    public void generateSources_generatesCommittedProcessorsClass(
+            @TempDir File generatedSourceDir) {
+        Path sourceDir = Paths.get("src/main/java");
+
+        CodeGenerator.generateSources(generatedSourceDir.toPath());
+
+        CtType<?> committed = parseJavaFile(sourceDir.resolve("sorald/Processors.java"));
+        CtType<?> generated = parseJavaFile(generatedSourceDir.toPath().resolve("sorald/"));
+
+        assertThat(printType(generated), equalTo(printType(committed)));
+    }
+
+    private static CtType<?> parseJavaFile(Path javaFile) {
+        Launcher launcher = new Launcher();
+        launcher.getEnvironment().setCommentEnabled(true);
+        launcher.addInputResource(javaFile.toString());
+
+        CtModel model = launcher.buildModel();
+        return model.getAllTypes().stream().filter(CtType::isTopLevel).findFirst().get();
+    }
+
+    private static String printType(CtType<?> type) {
+        PrettyPrinter printer = type.getFactory().getEnvironment().createPrettyPrinter();
+        return printer.printTypes(type);
+    }
+}


### PR DESCRIPTION
Fix #294 

This PR redesigns the code generation such that we commit the code to the repository, instead of relying on annotation processing during compile time. While annotation processing at compile time works great for Maven, I've found that it's in general very tricky to get various IDEs and editors to recognize the generated code as part of the code base. We've only gotten it to work somewhat well with IntelliJ IDEA so far.

So, this PR is meant to make Sorald development friendlier for more development environments. There's one unfortunate side effect, and that is that adding a new processor requires one to manually run the code generation. This isn't hard, but it is an extra step. It's described in CONTRIBUTING.md. There's also a new GitHub Actions job that checks that the generated code is up-to-date.

Overall, this also greatly simplifies interaction with the `Processors` class, as it is now possible to add/remove/edit methods and fields by just editing the source file, as long as one does not touch the generated fields.