### PR TITLE
fix: Fix printing of compilation units with multiple top-level types

### DIFF
--- a/src/main/java/sorald/CompilationUnitHelpers.java
+++ b/src/main/java/sorald/CompilationUnitHelpers.java
@@ -14,7 +14,6 @@ import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.support.DefaultOutputDestinationHandler;
-import spoon.support.OutputDestinationHandler;
 
 /** Helpers for dealing with {@link CtCompilationUnit}s. */
 class CompilationUnitHelpers {
@@ -28,12 +27,12 @@ class CompilationUnitHelpers {
      * @return Output path for the compilation unit.
      */
     static Path resolveOutputPath(CtCompilationUnit cu, File rootDir) {
-        OutputDestinationHandler destHandler =
-                new DefaultOutputDestinationHandler(rootDir, cu.getFactory().getEnvironment());
         CtModule mod = cu.getDeclaredModule();
         CtPackage pack = cu.getDeclaredPackage();
         CtType<?> type = findPrimaryType(cu).orElseGet(() -> guessIntendedPrimaryType(cu));
-        return destHandler.getOutputPath(mod, pack, type).normalize();
+        return new DefaultOutputDestinationHandler(rootDir, cu.getFactory().getEnvironment())
+                .getOutputPath(mod, pack, type)
+                .normalize();
     }
 
     /**

--- a/src/main/java/sorald/CompilationUnitHelpers.java
+++ b/src/main/java/sorald/CompilationUnitHelpers.java
@@ -2,8 +2,12 @@ package sorald;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtModule;
@@ -12,8 +16,8 @@ import spoon.reflect.declaration.CtType;
 import spoon.support.DefaultOutputDestinationHandler;
 import spoon.support.OutputDestinationHandler;
 
-/** Class with utility methods for determining output paths. */
-class OutputPaths {
+/** Helpers for dealing with {@link CtCompilationUnit}s. */
+class CompilationUnitHelpers {
 
     /**
      * Compute the output path for the given compilation unit with the provided root directory as
@@ -72,5 +76,22 @@ class OutputPaths {
                 .filter(CtType::isTopLevel)
                 .min(Comparator.comparing(visibilityOrdering))
                 .orElseThrow();
+    }
+
+    /**
+     * @param types A collection of types.
+     * @return All unique compilation units related to the provided types.
+     */
+    static Set<CtCompilationUnit> resolveCompilationUnits(Collection<CtType<?>> types) {
+        Set<CtCompilationUnit> compilationUnits =
+                Collections.newSetFromMap(new IdentityHashMap<>());
+        types.stream()
+                .map(CompilationUnitHelpers::getCompilationUnit)
+                .forEach(compilationUnits::add);
+        return compilationUnits;
+    }
+
+    private static CtCompilationUnit getCompilationUnit(CtType<?> type) {
+        return type.getFactory().CompilationUnit().getOrCreate(type);
     }
 }

--- a/src/main/java/sorald/OutputPaths.java
+++ b/src/main/java/sorald/OutputPaths.java
@@ -1,0 +1,76 @@
+package sorald;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Function;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtType;
+import spoon.support.DefaultOutputDestinationHandler;
+import spoon.support.OutputDestinationHandler;
+
+/** Class with utility methods for determining output paths. */
+class OutputPaths {
+
+    /**
+     * Compute the output path for the given compilation unit with the provided root directory as
+     * the project root.
+     *
+     * @param cu A compilation unit.
+     * @param rootDir The root directory to print output in.
+     * @return Output path for the compilation unit.
+     */
+    static Path resolveOutputPath(CtCompilationUnit cu, File rootDir) {
+        OutputDestinationHandler destHandler =
+                new DefaultOutputDestinationHandler(rootDir, cu.getFactory().getEnvironment());
+        CtModule mod = cu.getDeclaredModule();
+        CtPackage pack = cu.getDeclaredPackage();
+        CtType<?> type = findPrimaryType(cu).orElseGet(() -> guessIntendedPrimaryType(cu));
+        return destHandler.getOutputPath(mod, pack, type).normalize();
+    }
+
+    /**
+     * Get the primary type from the given compilation unit. This only returns a non-empty value if
+     * there is a type with the CU's file name in the CU.
+     *
+     * @param cu A compilation unit.
+     * @return The primary type of the compilation unit, or empty if there is no clear primary type.
+     */
+    private static Optional<CtType<?>> findPrimaryType(CtCompilationUnit cu) {
+        String primaryTypeName =
+                cu.getPosition().getFile().getName().replace(Constants.JAVA_EXT, "");
+        return cu.getDeclaredTypes().stream()
+                .filter(CtType::isTopLevel)
+                .filter(type -> type.getSimpleName().equals(primaryTypeName))
+                .findFirst();
+    }
+
+    /**
+     * In the event that a compilation unit has no top-level type that matches the file name, this
+     * method can be used to find the most likely "intended" top-level type.
+     *
+     * @param cu A compilation unit that lacks a well-defined primary type.
+     * @return The most likely primary type of this compilation unit.
+     */
+    private static CtType<?> guessIntendedPrimaryType(CtCompilationUnit cu) {
+        Function<CtType<?>, Integer> visibilityOrdering =
+                (type) -> {
+                    if (type.isPublic()) {
+                        return 1;
+                    } else if (!(type.isPrivate() || type.isProtected())) { // is package-private
+                        return 2;
+                    } else {
+                        // is private or protected, which is not legal for a top-level type
+                        return 3;
+                    }
+                };
+
+        return cu.getDeclaredTypes().stream()
+                .filter(CtType::isTopLevel)
+                .min(Comparator.comparing(visibilityOrdering))
+                .orElseThrow();
+    }
+}

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -10,7 +10,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -285,7 +284,7 @@ public class Repair {
                 outputStrategy == FileOutputStrategy.ALL || isIntermediateOutputDir
                         ? model.getAllTypes()
                         : UniqueTypesCollector.getInstance().getTopLevelTypes4Output().values();
-        for (CtCompilationUnit cu : resolveCompilationUnits(types)) {
+        for (CtCompilationUnit cu : CompilationUnitHelpers.resolveCompilationUnits(types)) {
             List<CtType<?>> typesToPrint =
                     cu.getDeclaredTypes().stream()
                             .filter(CtType::isTopLevel)
@@ -294,7 +293,7 @@ public class Repair {
             Path outputPath =
                     outputStrategy == FileOutputStrategy.IN_PLACE
                             ? sourcePath
-                            : OutputPaths.resolveOutputPath(cu, outputDir.toFile());
+                            : CompilationUnitHelpers.resolveOutputPath(cu, outputDir.toFile());
             String output =
                     env.createPrettyPrinter().printTypes(typesToPrint.toArray(CtType[]::new));
             writeToFile(outputPath, output);
@@ -303,17 +302,6 @@ public class Repair {
                 createPatches(sourcePath, outputPath);
             }
         }
-    }
-
-    private static Set<CtCompilationUnit> resolveCompilationUnits(Collection<CtType<?>> types) {
-        Set<CtCompilationUnit> compilationUnits =
-                Collections.newSetFromMap(new IdentityHashMap<>());
-        types.stream().map(Repair::getCompilationUnit).forEach(compilationUnits::add);
-        return compilationUnits;
-    }
-
-    private static CtCompilationUnit getCompilationUnit(CtType<?> type) {
-        return type.getFactory().CompilationUnit().getOrCreate(type);
     }
 
     private static void writeToFile(Path filepath, String output) {

--- a/src/main/java/sorald/UniqueTypesCollector.java
+++ b/src/main/java/sorald/UniqueTypesCollector.java
@@ -9,10 +9,10 @@ import spoon.reflect.declaration.CtType;
 public class UniqueTypesCollector {
     private static UniqueTypesCollector uniqueTypesCollector;
 
-    private Map<String, CtType> topLevelTypes4Output;
+    private Map<String, CtType<?>> topLevelTypes4Output;
 
     private UniqueTypesCollector() {
-        this.topLevelTypes4Output = new HashMap<String, CtType>();
+        this.topLevelTypes4Output = new HashMap<>();
     }
 
     public static UniqueTypesCollector getInstance() {
@@ -22,7 +22,7 @@ public class UniqueTypesCollector {
         return uniqueTypesCollector;
     }
 
-    public Map<String, CtType> getTopLevelTypes4Output() {
+    public Map<String, CtType<?>> getTopLevelTypes4Output() {
         return this.topLevelTypes4Output;
     }
 
@@ -32,8 +32,8 @@ public class UniqueTypesCollector {
 
     public void collect(CtElement element) {
         if (this.topLevelTypes4Output != null) {
-            CtType t = (CtType) element.getParent(CtType.class);
-            CtType topParent = t.getReference().getTopLevelType().getDeclaration();
+            CtType<?> t = (CtType<?>) element.getParent(CtType.class);
+            CtType<?> topParent = t.getReference().getTopLevelType().getDeclaration();
             String filePath = element.getPosition().getFile().getAbsolutePath();
 
             checkIfThereIsTheSameClassInTheOriginalPath(filePath);
@@ -52,7 +52,7 @@ public class UniqueTypesCollector {
     */
     private void checkIfThereIsTheSameClassInTheOriginalPath(String filePath) {
         Object topLevelTypeToBeRemoved = null;
-        for (Map.Entry topLevelType : this.topLevelTypes4Output.entrySet()) {
+        for (Map.Entry<String, CtType<?>> topLevelType : this.topLevelTypes4Output.entrySet()) {
             int index = filePath.indexOf(Constants.SPOONED_INTERMEDIATE);
             filePath =
                     ".*"

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -12,9 +12,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.sonar.java.checks.InterruptedExceptionCheck;
 import org.sonar.java.checks.SynchronizationOnStringOrBoxedCheck;
-import org.sonar.java.checks.serialization.SerializableFieldInSerializableClassCheck;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.Main;
@@ -30,10 +28,7 @@ public class ProcessorTestHelper {
     static final String EXPECTED_FILE_SUFFIX = ".expected";
     // The processors related to these checks currently cause problems with the sniper printer
     static final List<Class<?>> BROKEN_WITH_SNIPER =
-            Arrays.asList(
-                    SynchronizationOnStringOrBoxedCheck.class,
-                    InterruptedExceptionCheck.class,
-                    SerializableFieldInSerializableClassCheck.class);
+            Arrays.asList(SynchronizationOnStringOrBoxedCheck.class);
 
     /**
      * Create a {@link ProcessorTestCase} from a non-compliant (according to SonarQube rules) Java

--- a/src/test/resources/processor_test_files/1948_SerializableFieldInSerializableClass/SerializableFieldProcessorTest.java.expected
+++ b/src/test/resources/processor_test_files/1948_SerializableFieldInSerializableClass/SerializableFieldProcessorTest.java.expected
@@ -1,0 +1,16 @@
+import java.io.Serializable;
+
+public class SerializableFieldProcessorTest implements Serializable
+{
+    private transient Unser uns;// Noncompliant
+    public static void doNothing()
+    {
+        int x = 500;
+        int y = x*x+x;
+    }
+}
+
+class Unser
+{
+
+}


### PR DESCRIPTION
Fix #333 

Fixes the bug in Sorald described in #333, which solves the problem for us. The related bug in Spoon that's mentioned is not a problem for us, although I'll fix that too eventually. Here's the gist of the bug in Sorald:

> In Sorald, we only print top-level types that have been edited. This means that a CU with multiple top-level types may be printed with fewer types than it should, if any of the top-level types have not been edited. This bug is severe, as even when running with the default printer, there are types missing from the output. This also shows the dire need for expected output files for all test cases.

This PR changes the printing logic to work on compilation units instead of individual types. This both fixes the crash in the sniper printer, and the incorrect output of the normal printer.

In the future, the `UniqueTypesCollector` should probably be rewritten as a "compilation unit collector" instead, as that's the level of granularity we are concerned with when writing output.