### PR TITLE
refactor: Cast boxed type to Integer instead of directly to int

### DIFF
--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -113,7 +113,7 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
 
     private static void repairWithLiteralSuffix(
             CtLiteral<?> literalInt, CtTypeReference<?> typeForSuffix) {
-        int value = (int) literalInt.getValue();
+        Integer value = (Integer) literalInt.getValue();
         CtCodeSnippetExpression<?> literalWithSuffix =
                 literalInt
                         .getFactory()


### PR DESCRIPTION
This is a tiny refactor. The cast that's changed here casted a boxed value (i.e. an object) directly to int, which _works_, but IDEA flags it as an error. It's technically not an error, but it's a bit of bad practice as technically the cast is to `Integer` and then it auto-unboxes to `int`. The value is also immediately boxed again, so it's pointless.