### PR TITLE
fix: completely exclude xml-apis dependency from project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,13 @@
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-checks-testkit</artifactId>
             <version>6.9.0.23563</version>
+            <exclusions>
+                <exclusion>
+                    <!-- included in stdlib -->
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.sonarsource.java</groupId>
@@ -93,11 +100,13 @@
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-checks</artifactId>
             <version>6.9.0.23563</version>
-        </dependency>
-        <dependency>
-            <groupId>org.sonarsource.java</groupId>
-            <artifactId>sonar-java-plugin</artifactId>
-            <version>6.9.0.23563</version>
+            <exclusions>
+                <exclusion>
+                    <!-- included in stdlib -->
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
Fix #330 

At long last, a fix for this very annoying problem. To summarize #330, the problem is that the `javax.xml` package is both defined in a module in the standard library, _and_ in the `xml-apis` bundle in an unnamed module (i.e. pre java 9 style). This is technically not allowed, a package can only appear in one module, and so _most_ dev environments scream bloody murder. It also causes problems at runtime as JDT has trouble resolving references to `javax.xml.*` classes.

The problem appears to be with version 1.4.01 of xml-apis in particular, whereas 2.0.2 appears to work fine. Strangely enough, 1.4.01 (released in 2011) appears to be much newer than 2.0.2 (released in 2005). I'm not quite sure what's going on there.

Now, we can exclude this dependency from `java-checks-testkit` and `java-checks`, but it turns out that it's also bundled in the packaged version of `sonar-java-api`. We therefore remove our dependency on `sonar-java-plugin`, and exclude `xml-apis` from the remaining sonar dependencies.

Coincidentally, the refactoring I had to perform to make it possible to remove the `sonar-java-plugin` dependency gives us more control over how files are scanned, and it's not more complicated code either. This is probably what it should have looking like initially, I just didn't know that at the time.