### PR TITLE
fix: fix an IndexOutOfBoundsException in CastArithmeticOperandProcessor

### DIFF
--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -62,9 +62,14 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
                     ctBinaryOperator.getParent(CtAbstractInvocation.class);
             List<CtExpression> arguments = ctAbstractInvocation.getArguments();
 
+            CtElement argToBeFound = ctBinaryOperator;
+            while (argToBeFound.getParent() != ctAbstractInvocation) {
+                argToBeFound = argToBeFound.getParent();
+            }
+
             int indexInInvocation = -1;
             for (int i = 0; i < arguments.size(); i++) {
-                if (arguments.get(i) == ctBinaryOperator) {
+                if (arguments.get(i) == argToBeFound) {
                     indexInInvocation = i;
                     break;
                 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/CastArithmeticOperand.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/CastArithmeticOperand.java
@@ -11,6 +11,7 @@ class CastArithmeticOperand {
     long bigNegNum =  Integer.MIN_VALUE-1; // Noncompliant, gives a positive result instead of a negative one.
     int seconds;
     Date myDate = new Date(seconds * 1000); // Noncompliant, won't produce the expected result if seconds > 2_147_483
+    Date myDate2 = new Date(seconds * 1000 * 10); // Noncompliant
 
     public long compute(int factor){
         return factor * 10000; // Noncompliant, won't produce the expected result if factor > 214_748

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/CastArithmeticOperand.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/CastArithmeticOperand.java
@@ -11,7 +11,6 @@ class CastArithmeticOperand {
     long bigNegNum =  Integer.MIN_VALUE-1; // Noncompliant, gives a positive result instead of a negative one.
     int seconds;
     Date myDate = new Date(seconds * 1000); // Noncompliant, won't produce the expected result if seconds > 2_147_483
-    Date myDate2 = new Date(seconds * 1000 * 10); // Noncompliant
 
     public long compute(int factor){
         return factor * 10000; // Noncompliant, won't produce the expected result if factor > 214_748

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/MultipleBinaryOperatorsInMethodCall.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/MultipleBinaryOperatorsInMethodCall.java
@@ -3,6 +3,9 @@ is being analyzed, we don't find it directly in the list of arguments of the met
 is part of something more. Not finding it in the list of arguments causes an IndexOutOfBoundsException because
 we have index -1. This test checks that that exception doesn't happen.
  */
+import java.util.Date;
+
 class MultipleBinaryOperatorsInMethodCall {
+    int seconds = 1000;
     Date myDate = new Date(seconds * 1000 * 10); // Noncompliant
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/MultipleBinaryOperatorsInMethodCall.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/MultipleBinaryOperatorsInMethodCall.java
@@ -1,0 +1,8 @@
+/* When the arithmetic operation is inside a method call, and an inner binary operator of the arithmetic operation
+is being analyzed, we don't find it directly in the list of arguments of the method call, because that binary operator
+is part of something more. Not finding it in the list of arguments causes an IndexOutOfBoundsException because
+we have index -1. This test checks that that exception doesn't happen.
+ */
+class MultipleBinaryOperatorsInMethodCall {
+    Date myDate = new Date(seconds * 1000 * 10); // Noncompliant
+}


### PR DESCRIPTION
This PR addresses #125 partially.

The thing is: when the arithmetic operation is inside a method call, and an inner binary operator of the arithmetic operation is being analyzed, we don't find it in the list of arguments of the method call, because that binary operator is part of something more. Not finding it in the list of arguments causes an `IndexOutOfBoundsException` because we have index `-1`. This PR fixes that. Note that such a case was added in the test, which triggers the exception if the patch added in this PR does not exist.