### PR TITLE
chore: Add missing parenthesis in support workflow

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -33,7 +33,7 @@ jobs:
           git switch -c "$branch_name"
 
           git add docs/ACHIEVEMENTS.md
-          git commit -m "doc: Update docs/ACHIEVEMENTS.md" || echo "Nothing to commit" && exit 0
+          git commit -m "doc: Update docs/ACHIEVEMENTS.md" || (echo "Nothing to commit" && exit 0)
 
           git push https://${{ github.owner }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 


### PR DESCRIPTION
I thought that `expr1 || expr2 && expr3` would implicitly be `expr1 || (expr2 && expr3)` as `&&` typically binds "harder" than `||`. That's apparently not the case in bash :D