### PR TITLE
chore: Fix support workflow creating redundant branches

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -33,7 +33,10 @@ jobs:
           git switch -c "$branch_name"
 
           git add docs/ACHIEVEMENTS.md
-          git commit -m "doc: Update docs/ACHIEVEMENTS.md" || (echo "Nothing to commit" && exit 0)
+          git commit -m "doc: Update docs/ACHIEVEMENTS.md" || {
+            echo "Nothing to commit"
+            exit 0
+          }
 
           git push https://${{ github.owner }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 


### PR DESCRIPTION
Fixes a problem where the support workflow would create a branch on each commit, even if `ACHIEVEMENTS.md` did not need updating.