### PR TITLE
doc: Update ACHIEVEMENTS.md generation script for keeping legacy records

### DIFF
--- a/experimentation/tools/sorald/_helpers/jsonkeys.py
+++ b/experimentation/tools/sorald/_helpers/jsonkeys.py
@@ -59,3 +59,5 @@ class SORALD_STATS:
 
         REPO_SLUG = "repo_slug"
         PR_URL = "PR_url"
+        RULE_KEY = "rule_id"
+        NUM_VIOLATIONS = "nb_violations"

--- a/experimentation/tools/sorald/achievements.py
+++ b/experimentation/tools/sorald/achievements.py
@@ -18,8 +18,10 @@ TEMPLATE = r"""# Achievements
 This document presents an overview of the pull requests performed with Sorald.
 {% for pr in pull_requests %}
 ## [{{ pr.repo_slug }}#{{ pr.number }}](https://github.com/{{ pr.repo_slug }}/pull/{{ pr.number }})
-This PR was opened at {{ pr.created_at }}{% if pr.closed_at %} and {{ pr.status }} at {{ pr.closed_at }}{% endif %}.
-{% if pr.contains_manual_edits %}Some manual edits were performed after applying Sorald{% else %}The patch was generated fully automatically with Sorald{% endif %}.
+This PR was opened at {{ pr.created_at }}{% if pr.closed_at %} and {{ pr.status }} at {{ pr.closed_at }}{% endif %}.{% if pr.contains_manual_edits %}
+Some manual edits were performed after applying Sorald.{% elif not pr.is_legacy %}
+The patch was generated fully automatically with Sorald.{% else %}
+This is a legacy PR made before detailed record-keeping, and so we cannot say if any manual edits have been applied.{% endif %}
 {% if pr.repairs|length > 0 %}
 It provide{% if pr.closed_at %}d{% else %}s{% endif %} the following repairs:
 {% for repair in pr.repairs %}
@@ -51,6 +53,7 @@ class PullRequest:
     status: str
     contains_manual_edits: bool
     repairs: List[RepairStats]
+    is_legacy: bool
 
 
 def main(args: List[str]):
@@ -90,13 +93,20 @@ def generate_achievements_file(
     output_file: pathlib.Path,
     template: str,
 ) -> None:
-    pull_requests = parse_pull_requests(prs_json)
+    pull_requests = sorted(
+        parse_pull_requests(prs_json),
+        key=lambda pr: f"{'b' if pr.is_legacy else 'a'}{pr.repo_slug}#{pr.number}",
+    )
     rendered_content = jinja2.Template(template).render(pull_requests=pull_requests)
     output_file.write_text(rendered_content, encoding=ENCODING)
 
 
 def parse_pull_requests(prs_json: pathlib.Path) -> List[PullRequest]:
     prs_data = json.loads(prs_json.read_text(ENCODING))
+
+    def _is_legacy(data: dict) -> bool:
+        return data[jsonkeys.RECORD.SECTION_KEY][jsonkeys.RECORD.IS_LEGACY]
+
     return [
         PullRequest(
             repo_slug=data[jsonkeys.TOP_LEVEL.REPO_SLUG],
@@ -108,24 +118,30 @@ def parse_pull_requests(prs_json: pathlib.Path) -> List[PullRequest]:
             else pr_meta[jsonkeys.PR.STATE],
             contains_manual_edits=len(data[jsonkeys.MANUAL_EDITS.SECTION_KEY] or [])
             > 0,
-            repairs=get_all_repairs(data[jsonkeys.SORALD_STATS.SECTION_KEY]),
+            repairs=get_all_repairs(
+                data[jsonkeys.SORALD_STATS.SECTION_KEY], _is_legacy(data)
+            ),
+            is_legacy=_is_legacy(data),
         )
         for _, data in prs_data.items()
         if (pr_meta := data[jsonkeys.PR.SECTION_KEY])
     ]
 
 
-def get_all_repairs(sorald_stats: dict) -> List[RepairStats]:
-    lst = list(
-        map(
-            parse_repair_stats,
-            sorted(
-                sorald_stats.get(jsonkeys.SORALD_STATS.REPAIRS) or [],
-                key=lambda rep: int(rep[jsonkeys.SORALD_STATS.RULE_KEY]),
-            ),
+def get_all_repairs(sorald_stats: dict, is_legacy: bool) -> List[RepairStats]:
+    return (
+        [parse_legacy_repair_stats(sorald_stats)]
+        if is_legacy
+        else list(
+            map(
+                parse_repair_stats,
+                sorted(
+                    sorald_stats.get(jsonkeys.SORALD_STATS.REPAIRS) or [],
+                    key=lambda rep: int(rep[jsonkeys.SORALD_STATS.RULE_KEY]),
+                ),
+            )
         )
     )
-    return lst
 
 
 def parse_repair_stats(repair_data: dict) -> RepairStats:
@@ -134,6 +150,15 @@ def parse_repair_stats(repair_data: dict) -> RepairStats:
         num_violations_found=repair_data[jsonkeys.SORALD_STATS.VIOLATIONS_BEFORE],
         num_violations_repaired=repair_data[jsonkeys.SORALD_STATS.VIOLATIONS_BEFORE]
         - repair_data[jsonkeys.SORALD_STATS.VIOLATIONS_AFTER],
+    )
+
+
+def parse_legacy_repair_stats(repair_data: dict) -> RepairStats:
+    num_violations = repair_data[jsonkeys.SORALD_STATS.LEGACY.NUM_VIOLATIONS]
+    return RepairStats(
+        rule_key=int(repair_data[jsonkeys.SORALD_STATS.LEGACY.RULE_KEY]),
+        num_violations_found=num_violations,
+        num_violations_repaired=num_violations,
     )
 
 

--- a/experimentation/tools/sorald/achievements.py
+++ b/experimentation/tools/sorald/achievements.py
@@ -6,6 +6,7 @@ import dataclasses
 import json
 import pathlib
 import sys
+import datetime
 from typing import List
 
 import jinja2
@@ -95,7 +96,8 @@ def generate_achievements_file(
 ) -> None:
     pull_requests = sorted(
         parse_pull_requests(prs_json),
-        key=lambda pr: f"{'b' if pr.is_legacy else 'a'}{pr.repo_slug}#{pr.number}",
+        key=lambda pr: datetime.datetime.fromisoformat(pr.created_at),
+        reverse=True,
     )
     rendered_content = jinja2.Template(template).render(pull_requests=pull_requests)
     output_file.write_text(rendered_content, encoding=ENCODING)

--- a/experimentation/tools/tests/resources/prs_final.json
+++ b/experimentation/tools/tests/resources/prs_final.json
@@ -85,7 +85,8 @@
         "manualEdits": [],
         "recordMetadata": {
             "createdAt": "2020-12-18 08:50:28.743261",
-            "lastModified": "2020-12-18 08:51:19.637048"
+            "lastModified": "2020-12-18 08:51:19.637048",
+            "isLegacyRecord": false
         }
     }
 }

--- a/experimentation/tools/tests/resources/prs_final_with_legacy.json
+++ b/experimentation/tools/tests/resources/prs_final_with_legacy.json
@@ -1,0 +1,36 @@
+{
+    "apache/jspwiki#11": {
+        "repoSlug": "apache/jspwiki",
+        "prMetadata": {
+            "url": "https://github.com/apache/jspwiki/pull/11",
+            "createdAt": "2019-11-05 11:42:48",
+            "closedAt": "2019-11-05 19:11:09",
+            "mergedAt": "2019-11-05 19:11:08",
+            "state": "closed",
+            "isMerged": true,
+            "number": 11
+        },
+        "soraldStatistics": {
+            "rule_id": 4973,
+            "rule_name": "CompareStringsBoxedTypesWithEquals",
+            "nb_violations": 3,
+            "repo_slug": "apache/jspwiki",
+            "PR_url": "https://github.com/apache/jspwiki/pull/11",
+            "PR_opening_date": "Nov 5, 2019",
+            "PR_status": "Merged",
+            "PR_status_date": "Nov 5, 2019",
+            "notes": "https://github.com/SpoonLabs/sorald/pull/32",
+            "diff": "https://github.com/SpoonLabs/sorald/tree/master/experimentation/pull-requests/jspwiki/4973"
+        },
+        "diffs": {
+            "initial": "diff --git a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java\nindex b75e91129f..eb58b90eed 100644\n--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java\n+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java\n@@ -484,7 +484,7 @@ public void actionPerformed( WikiEvent event )\n                     case WikiSecurityEvent.PRINCIPAL_ADD:\n                     {\n                         WikiSession target = (WikiSession)e.getTarget();\n-                        if ( this.equals( target ) && m_status == AUTHENTICATED )\n+                        if ( this.equals( target ) && m_status.equals(AUTHENTICATED) )\n                         {\n                             Set<Principal> principals = m_subject.getPrincipals();\n                             principals.add( (Principal)e.getPrincipal());\n@@ -569,7 +569,7 @@ public void actionPerformed( WikiEvent event )\n                     {\n                         // Refresh user principals based on new user profile\n                         WikiSession source = e.getSrc();\n-                        if ( this.equals( source ) && m_status == AUTHENTICATED )\n+                        if ( this.equals( source ) && m_status.equals(AUTHENTICATED) )\n                         {\n                             // To prepare for refresh, set the new full name as the primary principal\n                             UserProfile[] profiles = (UserProfile[])e.getTarget();\ndiff --git a/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java b/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java\nindex 10906ba04a..afc12e334c 100644\n--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java\n+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java\n@@ -212,7 +212,7 @@ public String execute( WikiContext context, Map<String, String> params )\n \n                 res.append(\"<div class=\\\"inserted-page \");\n                 if( clazz != null ) res.append( clazz );\n-                if( style != DEFAULT_STYLE ) res.append(\"\\\" style=\\\"\"+style );\n+                if( !style.equals(DEFAULT_STYLE) ) res.append(\"\\\" style=\\\"\"+style );\n                 if( showOnce ) res.append(\"\\\" data-once=\\\"\"+cookieName );\n                 res.append(\"\\\" >\");\n \n",
+            "final": "diff --git a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java\nindex b75e91129f..eb58b90eed 100644\n--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java\n+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java\n@@ -484,7 +484,7 @@ public void actionPerformed( WikiEvent event )\n                     case WikiSecurityEvent.PRINCIPAL_ADD:\n                     {\n                         WikiSession target = (WikiSession)e.getTarget();\n-                        if ( this.equals( target ) && m_status == AUTHENTICATED )\n+                        if ( this.equals( target ) && m_status.equals(AUTHENTICATED) )\n                         {\n                             Set<Principal> principals = m_subject.getPrincipals();\n                             principals.add( (Principal)e.getPrincipal());\n@@ -569,7 +569,7 @@ public void actionPerformed( WikiEvent event )\n                     {\n                         // Refresh user principals based on new user profile\n                         WikiSession source = e.getSrc();\n-                        if ( this.equals( source ) && m_status == AUTHENTICATED )\n+                        if ( this.equals( source ) && m_status.equals(AUTHENTICATED) )\n                         {\n                             // To prepare for refresh, set the new full name as the primary principal\n                             UserProfile[] profiles = (UserProfile[])e.getTarget();\ndiff --git a/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java b/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java\nindex 10906ba04a..afc12e334c 100644\n--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java\n+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/InsertPage.java\n@@ -212,7 +212,7 @@ public String execute( WikiContext context, Map<String, String> params )\n \n                 res.append(\"<div class=\\\"inserted-page \");\n                 if( clazz != null ) res.append( clazz );\n-                if( style != DEFAULT_STYLE ) res.append(\"\\\" style=\\\"\"+style );\n+                if( !style.equals(DEFAULT_STYLE) ) res.append(\"\\\" style=\\\"\"+style );\n                 if( showOnce ) res.append(\"\\\" data-once=\\\"\"+cookieName );\n                 res.append(\"\\\" >\");\n \n"
+        },
+        "manualEdits": [],
+        "recordMetadata": {
+            "createdAt": "2021-02-05 08:51:25.905857",
+            "lastModified": "2021-02-05 08:51:27.586815",
+            "isLegacyRecord": true
+        }
+    }
+}

--- a/experimentation/tools/tests/resources/prs_initial.json
+++ b/experimentation/tools/tests/resources/prs_initial.json
@@ -85,7 +85,8 @@
         "manualEdits": [],
         "recordMetadata": {
             "createdAt": "2020-12-18 08:50:28.743261",
-            "lastModified": "2020-12-18 08:50:28.743261"
+            "lastModified": "2020-12-18 08:50:28.743261",
+            "isLegacyRecord": false
         }
     }
 }

--- a/experimentation/tools/tests/test_achievements.py
+++ b/experimentation/tools/tests/test_achievements.py
@@ -8,6 +8,9 @@ from sorald._helpers import jsonkeys
 import _constants
 
 PRS_JSON_FINAL = _constants.RESOURCES_DIR / "prs_final.json"
+PRS_JSON_FINAL_WITH_LEGACY = (
+    _constants.RESOURCES_DIR / "prs_final_with_legacy.json"
+)
 
 
 def test_correctly_renders_merged_pr(tmp_path):
@@ -71,4 +74,38 @@ This PR was opened at 2020-11-25 12:01:06 and merged at 2020-11-30 20:45:38.
 The patch was generated fully automatically with Sorald.
 
 Detailed repair information is missing for this PR.""".strip()
+    )
+
+
+def test_correctly_renders_legacy_pr(tmp_path):
+    # arrange
+    output_file = tmp_path / "ACHIEVEMENTS.md"
+    prs_json_fil = tmp_path / "prs.json"
+
+    args = shlex.split(
+        f"{achievements.PRS_JSON_ARG} {PRS_JSON_FINAL_WITH_LEGACY} "
+        f"{achievements.OUTPUT_ARG} {output_file}"
+    )
+
+    # act
+    achievements.main(args)
+
+    # assert
+    rendered_content = output_file.read_text(achievements.ENCODING)
+    assert (
+        rendered_content.strip()
+        == """
+# Achievements
+This document presents an overview of the pull requests performed with Sorald.
+
+## [apache/jspwiki#11](https://github.com/apache/jspwiki/pull/11)
+This PR was opened at 2019-11-05 11:42:48 and merged at 2019-11-05 19:11:09.
+This is a legacy PR made before detailed record-keeping, and so we cannot say if any manual edits have been applied.
+
+It provided the following repairs:
+
+* [Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973)
+    - Number of violations found: 3
+    - Number of violations repaired: 3
+""".strip()
     )


### PR DESCRIPTION
Fix #255 

This PR adds support for the legacy records added to `prs.json` in #364. In addition, to ensure that our newest achievements don't get lost amidst older achievements, the PRs are now sorted in descending order by date created.

Here is a sample of the markdown generated for a legacy record (note that the hyperlink to the PR is intentionally broken to not display a useless notification in that PR):

## [apache/jspwiki#11](https://github.com/apache/intentionally/broken/link)
This PR was opened at 2019-11-05 11:42:48 and merged at 2019-11-05 19:11:09.
This is a legacy PR made before detailed record-keeping, and so we cannot say if any manual edits have been applied.

It provided the following repairs:

* [Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973)
    - Number of violations found: 3
    - Number of violations repaired: 3