### PR TITLE
fix: fix a NPE in CastArithmeticOperandProcessor

### DIFF
--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -21,7 +21,7 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
                 candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
         if (binaryOperatorChildren.size()
                 == 1) { // in a nested binary operator expression, only one will be processed.
-            if (isArithmeticOperation(candidate) && isExpIntAndOrLong(candidate)) {
+            if (isArithmeticOperation(candidate) && areBothOperandTypesKnown(candidate) && isExpIntAndOrLong(candidate)) {
                 CtTypeReference ctType = getExpectedType(candidate);
                 if (ctType != null) {
                     if (isTypeLongOrDoubleOrFloat(ctType)
@@ -133,10 +133,13 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
                 || ctBinaryOperator.getKind().compareTo(BinaryOperatorKind.DIV) == 0;
     }
 
-    private boolean isExpIntAndOrLong(CtBinaryOperator ctBinaryOperator) {
+    private boolean areBothOperandTypesKnown(CtBinaryOperator ctBinaryOperator) {
         return (ctBinaryOperator.getLeftHandOperand().getType() != null
-                        && ctBinaryOperator.getRightHandOperand().getType() != null)
-                && (ctBinaryOperator
+                && ctBinaryOperator.getRightHandOperand().getType() != null);
+    }
+
+    private boolean isExpIntAndOrLong(CtBinaryOperator ctBinaryOperator) {
+        return (ctBinaryOperator
                                 .getLeftHandOperand()
                                 .getType()
                                 .getSimpleName()

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -21,7 +21,9 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
                 candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
         if (binaryOperatorChildren.size()
                 == 1) { // in a nested binary operator expression, only one will be processed.
-            if (isArithmeticOperation(candidate) && areBothOperandTypesKnown(candidate) && isExpIntAndOrLong(candidate)) {
+            if (isArithmeticOperation(candidate)
+                    && areBothOperandTypesKnown(candidate)
+                    && isExpIntAndOrLong(candidate)) {
                 CtTypeReference ctType = getExpectedType(candidate);
                 if (ctType != null) {
                     if (isTypeLongOrDoubleOrFloat(ctType)

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -135,7 +135,7 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
 
     private boolean isExpIntAndOrLong(CtBinaryOperator ctBinaryOperator) {
         return (ctBinaryOperator.getLeftHandOperand().getType() != null
-                && ctBinaryOperator.getRightHandOperand().getType() != null)
+                        && ctBinaryOperator.getRightHandOperand().getType() != null)
                 && (ctBinaryOperator
                                 .getLeftHandOperand()
                                 .getType()

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -134,7 +134,9 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
     }
 
     private boolean isExpIntAndOrLong(CtBinaryOperator ctBinaryOperator) {
-        return (ctBinaryOperator
+        return (ctBinaryOperator.getLeftHandOperand().getType() != null
+                && ctBinaryOperator.getRightHandOperand().getType() != null)
+                && (ctBinaryOperator
                                 .getLeftHandOperand()
                                 .getType()
                                 .getSimpleName()

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_NullOperandType.java
@@ -4,5 +4,6 @@ This test checks that such an exception doesn't happen.
 */
 class NOCOMPILE_NullOperandType {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
-    long var = System.currentTimeMillis() - message.getJMSTimestamp();
+    long rhsUnknown = System.currentTimeMillis() - message.getJMSTimestamp();
+    long lhsUnknown = message.getJMSTimestamp() - System.currentTimeMillis();
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_NullOperandType.java
@@ -4,7 +4,7 @@ This test checks that such an exception doesn't happen.
 */
 import javax.jms.Message;
 
-class NullOperandType {
+class NOCOMPILE_NullOperandType {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
 
     Message message;

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_NullOperandType.java
@@ -2,11 +2,7 @@
 When we cannot resolve the type of the left or right hand operands in a binary operator, we get a NullPointerException.
 This test checks that such an exception doesn't happen.
 */
-import javax.jms.Message;
-
 class NOCOMPILE_NullOperandType {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
-
-    Message message;
     long var = System.currentTimeMillis() - message.getJMSTimestamp();
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
@@ -1,0 +1,4 @@
+class NullOperandType {
+    float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
+    String var = response.statusCode() + " ";
+}

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
@@ -4,5 +4,7 @@ This test checks that such an exception doesn't happen.
 */
 class NullOperandType {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
-    String var = response.statusCode() + " ";
+
+    Message message;
+    long var = System.currentTimeMillis() - message.getJMSTimestamp();
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
@@ -8,3 +8,8 @@ class NullOperandType {
     Message message;
     long var = System.currentTimeMillis() - message.getJMSTimestamp();
 }
+
+
+class Message {
+
+}

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
@@ -1,3 +1,7 @@
+/*
+When we cannot resolve the type of the left or right hand operands in a binary operator, we get a NullPointerException.
+This test checks that such an exception doesn't happen.
+*/
 class NullOperandType {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
     String var = response.statusCode() + " ";

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NullOperandType.java
@@ -2,14 +2,11 @@
 When we cannot resolve the type of the left or right hand operands in a binary operator, we get a NullPointerException.
 This test checks that such an exception doesn't happen.
 */
+import javax.jms.Message;
+
 class NullOperandType {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINE CAN BE ACTUALLY TESTED!
 
     Message message;
     long var = System.currentTimeMillis() - message.getJMSTimestamp();
-}
-
-
-class Message {
-
 }


### PR DESCRIPTION
This PR partially addresses #125.

The thing is: when we cannot resolve the type of the left or right hand operand in a binary operator, we get a `NullPointerException`. This PR adds a test case that triggers that exception and the fix for it.