### PR TITLE
fix: fix another IndexOutOfBoundsException in CastArithmeticOperandProcessor

### DIFF
--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -60,40 +60,7 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
         CtTypeReference ctTypeReference = null;
 
         if (ctBinaryOperator.getParent(CtAbstractInvocation.class) != null) {
-
-            CtAbstractInvocation ctAbstractInvocation =
-                    ctBinaryOperator.getParent(CtAbstractInvocation.class);
-            List<CtExpression> arguments = ctAbstractInvocation.getArguments();
-
-            CtElement argToBeFound = ctBinaryOperator;
-            while (argToBeFound.getParent() != ctAbstractInvocation) {
-                argToBeFound = argToBeFound.getParent();
-            }
-
-            int indexInInvocation = -1;
-            for (int i = 0; i < arguments.size(); i++) {
-                if (arguments.get(i) == argToBeFound) {
-                    indexInInvocation = i;
-                    break;
-                }
-            }
-
-            CtExecutableReference ctExecutableReference = ctAbstractInvocation.getExecutable();
-            if (ctExecutableReference != null && ctExecutableReference.getParameters() != null) {
-                List<CtTypeReference> parameters = ctExecutableReference.getParameters();
-
-                if (indexInInvocation > parameters.size()
-                        && parameters.get(parameters.size() - 1).isArray()) {
-                    ctTypeReference =
-                            ((CtArrayTypeReferenceImpl) parameters.get(parameters.size() - 1))
-                                    .getComponentType();
-                } else {
-                    ctTypeReference =
-                            (CtTypeReference)
-                                    ctExecutableReference.getParameters().get(indexInInvocation);
-                }
-            }
-
+            ctTypeReference = getExpectedTypeOfMethodCallArgument(ctBinaryOperator);
         } else if (ctBinaryOperator.getParent(CtField.class) != null
                 || ctBinaryOperator.getParent(CtLocalVariable.class) != null) {
             CtField ctField = ctBinaryOperator.getParent(CtField.class);
@@ -109,6 +76,44 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
             ctTypeReference = ctReturn.getParent(CtMethod.class).getType();
         }
 
+        return ctTypeReference;
+    }
+
+    private CtTypeReference getExpectedTypeOfMethodCallArgument(CtBinaryOperator ctBinaryOperator) {
+        CtTypeReference ctTypeReference = null;
+
+        CtAbstractInvocation ctAbstractInvocation =
+                ctBinaryOperator.getParent(CtAbstractInvocation.class);
+        List<CtExpression> arguments = ctAbstractInvocation.getArguments();
+
+        CtElement argToBeFound = ctBinaryOperator;
+        while (argToBeFound.getParent() != ctAbstractInvocation) {
+            argToBeFound = argToBeFound.getParent();
+        }
+
+        int indexInInvocation = -1;
+        for (int i = 0; i < arguments.size(); i++) {
+            if (arguments.get(i) == argToBeFound) {
+                indexInInvocation = i;
+                break;
+            }
+        }
+
+        CtExecutableReference ctExecutableReference = ctAbstractInvocation.getExecutable();
+        if (ctExecutableReference != null && ctExecutableReference.getParameters() != null) {
+            List<CtTypeReference> parameters = ctExecutableReference.getParameters();
+
+            if (indexInInvocation > parameters.size()
+                    && parameters.get(parameters.size() - 1).isArray()) {
+                ctTypeReference =
+                        ((CtArrayTypeReferenceImpl) parameters.get(parameters.size() - 1))
+                                .getComponentType();
+            } else {
+                ctTypeReference =
+                        (CtTypeReference)
+                                ctExecutableReference.getParameters().get(indexInInvocation);
+            }
+        }
         return ctTypeReference;
     }
 

--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -11,6 +11,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.reflect.reference.CtArrayTypeReferenceImpl;
 
 @ProcessorAnnotation(key = 2184, description = "Math operands should be cast before assignment")
 public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBinaryOperator> {
@@ -79,9 +80,18 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
 
             CtExecutableReference ctExecutableReference = ctAbstractInvocation.getExecutable();
             if (ctExecutableReference != null && ctExecutableReference.getParameters() != null) {
-                ctTypeReference =
-                        (CtTypeReference)
-                                ctExecutableReference.getParameters().get(indexInInvocation);
+                List<CtTypeReference> parameters = ctExecutableReference.getParameters();
+
+                if (indexInInvocation > parameters.size()
+                        && parameters.get(parameters.size() - 1).isArray()) {
+                    ctTypeReference =
+                            ((CtArrayTypeReferenceImpl) parameters.get(parameters.size() - 1))
+                                    .getComponentType();
+                } else {
+                    ctTypeReference =
+                            (CtTypeReference)
+                                    ctExecutableReference.getParameters().get(indexInInvocation);
+                }
             }
 
         } else if (ctBinaryOperator.getParent(CtField.class) != null

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
@@ -1,0 +1,19 @@
+/*
+When a binary operator is in a method call that can receive different number of paraments, we can get an IndexOutOfBoundsException
+when trying to find the type expected for the argument (i.e., the binary operator in this case).
+This test checks that such an exception doesn't happen.
+*/
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters {
+    float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINES CAN BE ACTUALLY TESTED!
+
+    Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    void method() {
+        LOGGER.info("{} {}", 1, 1 + 1); // This is ok, see the method signature: void info(String var1, Object var2, Object var3);
+        LOGGER.info("{} {} {}", 1, 2, 1 + 2); // This can cause an IndexOutOfBoundsException, see the method signature: void info(String var1, Object... var2);
+    }
+}

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
@@ -1,19 +1,17 @@
 /*
-When a binary operator is in a method call that can receive different number of parameters (e.g., `void info(String var1, Object... var2);`),
+When a binary operator is in a method call that can receive different number of parameters (e.g., `void methodX(String var1, Object... var2)`),
 we can get an IndexOutOfBoundsException when trying to find the type expected for the argument (i.e., the binary operator in this case).
 This test checks that such an exception doesn't happen.
 */
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 class NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINES CAN BE ACTUALLY TESTED!
 
-    Logger LOGGER = LoggerFactory.getLogger(getClass());
-
     void method() {
-        LOGGER.info("{} {}", 1, 1 + 1); // This is ok, see the method signature: void info(String var1, Object var2, Object var3);
-        LOGGER.info("{} {} {}", 1, 2, 1 + 2); // This can cause an IndexOutOfBoundsException, see the method signature: void info(String var1, Object... var2);
+        methodX("{} {}", 1, 1 + 1); // This is ok
+        methodX("{} {} {}", 1, 2, 1 + 2); // This can cause an IndexOutOfBoundsException
     }
+
+    static void methodX(String var1, Object var2, Object var3) {}
+
+    static void methodX(String var1, Object... var2) {}
 }

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
@@ -7,7 +7,7 @@ This test checks that such an exception doesn't happen.
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters {
+class NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters {
     float twoThirds = 2/3; // Noncompliant; THIS LINE WAS ONLY ADDED TO MAKE THE TEST FIND A VIOLATION IN THIS FILE SO THE NEXT LINES CAN BE ACTUALLY TESTED!
 
     Logger LOGGER = LoggerFactory.getLogger(getClass());

--- a/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
+++ b/src/test/resources/processor_test_files/2184_CastArithmeticOperand/NOCOMPILE_BinaryOperatorInMethodCallThatCanReceiveDifferentNumberOfParameters.java
@@ -1,6 +1,6 @@
 /*
-When a binary operator is in a method call that can receive different number of paraments, we can get an IndexOutOfBoundsException
-when trying to find the type expected for the argument (i.e., the binary operator in this case).
+When a binary operator is in a method call that can receive different number of parameters (e.g., `void info(String var1, Object... var2);`),
+we can get an IndexOutOfBoundsException when trying to find the type expected for the argument (i.e., the binary operator in this case).
 This test checks that such an exception doesn't happen.
 */
 


### PR DESCRIPTION
This PR partially addresses #125.

When a binary operator is in a method call that can receive different number of parameters (e.g., `void info(String var1, Object... var2);`), we can get an `IndexOutOfBoundsException` when trying to find the type expected for the argument (i.e., the binary operator in this case). This PR adds a test case that triggers that exception and the fix for it.