### PR TITLE
fix: Fix violations of Sonar rule 1854

### DIFF
--- a/src/main/java/sorald/GitPatchGenerator.java
+++ b/src/main/java/sorald/GitPatchGenerator.java
@@ -34,8 +34,6 @@ public class GitPatchGenerator {
         try {
 
             FileOutputStream out = new FileOutputStream(pathToPatch + Constants.PATCH_EXT);
-
-            PrintWriter printer = new PrintWriter(out);
             String relativeOriginalFilePath =
                     new File(this.gitProjectRootDir)
                             .toURI()

--- a/src/main/java/sorald/GitPatchGenerator.java
+++ b/src/main/java/sorald/GitPatchGenerator.java
@@ -3,7 +3,6 @@ package sorald;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.EditList;
 import org.eclipse.jgit.diff.HistogramDiff;


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 1854: 'Unused assignments should be removed'](https://rules.sonarsource.com/java/RSPEC-1854).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 1854](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#unused-assignments-should-be-removed-sonar-rule-1854).

9521a51 was applied with Spotless.