### PR TITLE
feat(2142): Add thread interrupt before first throw or return

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -94,6 +94,8 @@ Example:
     }
 ```
 
+Sorald places the interrupt as late as possible in the catch block, but before any throws or returns.
+
 -----
 
 #### "Iterator.next()" methods should throw "NoSuchElementException" ([Sonar Rule 2272](https://rules.sonarsource.com/java/RSPEC-2272))

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -1,8 +1,12 @@
 package sorald.processor;
 
 import sorald.annotations.ProcessorAnnotation;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtReturn;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtThrow;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
@@ -23,11 +27,39 @@ public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCat
         CtTypeAccess<?> threadClassAccess = factory.createTypeAccess(threadClass.getReference());
         CtMethod<?> currentThreadMethod = threadClass.getMethodsByName("currentThread").get(0);
         CtMethod<?> interruptMethod = threadClass.getMethodsByName("interrupt").get(0);
-        CtInvocation firstInvocation =
+        CtInvocation<?> firstInvocation =
                 factory.createInvocation(threadClassAccess, currentThreadMethod.getReference());
-        CtInvocation secondInvocation =
+        CtInvocation<?> secondInvocation =
                 factory.createInvocation(firstInvocation, interruptMethod.getReference());
 
-        element.getBody().addStatement(0, secondInvocation);
+        element.getBody().addStatement(lastSafeInterruptIndex(element.getBody()), secondInvocation);
+    }
+
+    /**
+     * Return the last index that is safe to insert at, safe meaning that the interrupt is certain
+     * to actually be invoked.
+     *
+     * <p>This is either the first index at which a return statement or throw is found, or the index
+     * past the last index if no returns or throws are found.
+     */
+    private static int lastSafeInterruptIndex(CtBlock<?> block) {
+        for (int i = 0; i < block.getStatements().size(); i++) {
+            if (containsReturnOrThrow(block.getStatement(i))) {
+                return i;
+            }
+        }
+        return block.getStatements().size();
+    }
+
+    /**
+     * Check if the given statement contains a return or throw.
+     *
+     * <p>TODO recursively check method declarations if there are method calls.
+     */
+    private static boolean containsReturnOrThrow(CtStatement statement) {
+        return !statement
+                .filterChildren(e -> e instanceof CtReturn || e instanceof CtThrow)
+                .list()
+                .isEmpty();
     }
 }

--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -28,6 +28,6 @@ public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCat
         CtInvocation secondInvocation =
                 factory.createInvocation(firstInvocation, interruptMethod.getReference());
 
-        element.getBody().addStatement(element.getBody().getStatements().size(), secondInvocation);
+        element.getBody().addStatement(0, secondInvocation);
     }
 }

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchesWithNestedExits.java
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchesWithNestedExits.java
@@ -1,0 +1,36 @@
+/*
+This file contains catches of InterruptedException with nested exits (throws and return statements).
+The point here is to verify that the interrupt is added before the method is exited.
+ */
+
+public class CatchesWithNestedExits {
+    public int valueForBranching;
+
+    public CatchesWithNestedExits(int valueForBranching) {
+        this.valueForBranching = valueForBranching;
+    }
+
+    public void catchWithNestedReturn() {
+        try {
+            throw new InterruptedException();
+        } catch (InterruptedException e) { // Noncompliant
+            System.out.println("Oh no, interrupt!");
+            if (valueForBranching < 2) {
+                return;
+            }
+            System.out.println("End of catch");
+        }
+    }
+
+    public void catchWithNestedThrow() {
+        try {
+            throw new InterruptedException();
+        } catch (InterruptedException e) { // Noncompliant
+            System.out.println("Oh no, interrupt!");
+            if (valueForBranching > 32) {
+                throw new RuntimeException();
+            }
+            System.out.println("End of catch");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchesWithNestedExits.java.expected
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchesWithNestedExits.java.expected
@@ -1,0 +1,38 @@
+/*
+This file contains catches of InterruptedException with nested exits (throws and return statements).
+The point here is to verify that the interrupt is added before the method is exited.
+ */
+
+public class CatchesWithNestedExits {
+    public int valueForBranching;
+
+    public CatchesWithNestedExits(int valueForBranching) {
+        this.valueForBranching = valueForBranching;
+    }
+
+    public void catchWithNestedReturn() {
+        try {
+            throw new InterruptedException();
+        } catch (InterruptedException e) { // Noncompliant
+            System.out.println("Oh no, interrupt!");
+            Thread.currentThread().interrupt();
+            if (valueForBranching < 2) {
+                return;
+            }
+            System.out.println("End of catch");
+        }
+    }
+
+    public void catchWithNestedThrow() {
+        try {
+            throw new InterruptedException();
+        } catch (InterruptedException e) { // Noncompliant
+            System.out.println("Oh no, interrupt!");
+            Thread.currentThread().interrupt();
+            if (valueForBranching > 32) {
+                throw new RuntimeException();
+            }
+            System.out.println("End of catch");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2142_InterruptedException/InterruptedExceptionForTesting.java.expected
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/InterruptedExceptionForTesting.java.expected
@@ -21,8 +21,8 @@ class InterruptedExceptionForTesting {
 				throw new InterruptedException();
 			}
 		}catch (InterruptedException e) { // Noncompliant; logging is not enough
-		    Thread.currentThread().interrupt();
 			LOGGER.log(Level.WARN, "Interrupted!", e);
+			Thread.currentThread().interrupt();
 		}
 	}
 
@@ -85,10 +85,10 @@ class InterruptedExceptionForTesting {
 				throw new InterruptedException();
 			}
 		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
-			Thread.currentThread().interrupt();
 			LOGGER.log(Level.WARN, "Interrupted!", e);
 			// clean up state...
 			new Foo().interrupt();
+			Thread.currentThread().interrupt();
 		}
 	}
 

--- a/src/test/resources/processor_test_files/2142_InterruptedException/InterruptedExceptionForTesting.java.expected
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/InterruptedExceptionForTesting.java.expected
@@ -1,0 +1,116 @@
+// Test for rule s2142
+// From https://github.com/SonarSource/sonar-java/blob/971eeaf972d8112aa4b7dd9cbf0ed577b397d6a7/java-checks/src/test/files/checks/InterruptedExceptionCheck.java
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.FutureTask;
+
+enum Level {
+	WARN;
+}
+interface Log {
+	void log(Level level, String s, Exception e);
+}
+
+class InterruptedExceptionForTesting {
+	static final Log LOGGER = null;
+
+	public void run () {
+		try {
+			while (true) {
+				// do stuff
+				throw new InterruptedException();
+			}
+		}catch (InterruptedException e) { // Noncompliant; logging is not enough
+		    Thread.currentThread().interrupt();
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+		}
+	}
+
+	public void runUnknownSymbol () {
+		try {
+			if (1 < 2) {
+				throw new InterruptedException();
+			} else {
+				throw new IOException();
+			}
+		}catch (IOException e) {
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+		}catch (InterruptedException e) { // Noncompliant
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	public void catchUnionType () {
+		try {
+			if (1 < 2) {
+				throw new InterruptedException();
+			} else {
+				throw new IOException();
+			}
+		} catch (InterruptedException | IOException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	public void run2 () throws InterruptedException, IOException {
+		try {
+			while (true) {
+				// do stuff
+				throw new InterruptedException();
+			}
+		} catch (InterruptedException e) {
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			// clean up state...
+			throw e;
+		} catch (ThreadDeath threadDeath) { // Noncompliant {{Either re-interrupt this method or rethrow the "ThreadDeath".}}
+			Thread.currentThread().interrupt();
+			throw new IOException();
+		}
+	}
+
+	public void run3 () {
+		try {
+			while (true) {
+				// do stuff
+				throw new InterruptedException();
+			}
+		} catch (InterruptedException e) {
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			// clean up state...
+			Thread.currentThread().interrupt();
+		}
+		try {
+			while (true) {
+				// do stuff
+				throw new InterruptedException();
+			}
+		} catch (InterruptedException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+			Thread.currentThread().interrupt();
+			LOGGER.log(Level.WARN, "Interrupted!", e);
+			// clean up state...
+			new Foo().interrupt();
+		}
+	}
+
+	public FutureTask getNextTask(BlockingQueue<FutureTask> queue) {
+		boolean interrupted = false;
+		try {
+			while (true) {
+				try {
+					return queue.take();
+				} catch (InterruptedException e) {
+					interrupted = true;
+					// fall through and retry
+				}
+			}
+		} finally {
+			if (interrupted)
+				Thread.currentThread().interrupt();
+		}
+	}
+
+}
+
+class Foo {
+	void interrupt() {};
+}


### PR DESCRIPTION
Fix #384 

This PR modifies the processor for rule 2142 to place the interrupt as late as possible in the catch block, but before any throw or return statement. See #384 for why this is necessary.