### PR TITLE
feat(2184): Use upper case letter for literal suffixes

### DIFF
--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -124,7 +124,8 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
         CtCodeSnippetExpression<?> literalWithSuffix =
                 literalInt
                         .getFactory()
-                        .createCodeSnippetExpression(value + getLiteralSuffix(typeForSuffix));
+                        .createCodeSnippetExpression(
+                                value + getLiteralSuffix(typeForSuffix).toUpperCase());
         literalInt.replace(literalWithSuffix);
     }
 


### PR DESCRIPTION
Fix #379 

There's no test to verify that this is the case, as we currently don't have support for testing literal output in the test suite, but I've verified it manually. I've opened an issue about augmenting the test suite to allow for testing that arbitrary text is present in the output file, see #393.