### PR TITLE
chore: Use github-actions bot user as committer for ACHIEVEMENTS update

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -26,8 +26,8 @@ jobs:
         run: python -m sorald.achievements -p experimentation/prs.json -o docs/ACHIEVEMENTS.md
       - name: Create pull request
         run: |
-          git config --local user.email noreply@github.com
-          git config --local user.name GitHub
+          git config --local user.email github-actions[bot]@users.noreply.github.com
+          git config --local user.name github-actions[bot]
 
           branch_name=achievements-update-${{ github.sha }}
           git switch -c "$branch_name"


### PR DESCRIPTION
I'm not sure if anyone's noticed, but we have a `GitHub Web Flow` contributor. That's because of this commit: https://github.com/SpoonLabs/sorald/commit/cfc009279b03b63cb2ceca0ad355fcc55dc525fa

Which lists it as a co-author for the ACHIEVEMENTS file update. That's automatically put there because the auto-updater commits with that user.

This PR makes the support workflow commit with the github-actions bot user instead. It will still generate a "co-authored by", but it will be with an alias of the actions bot, which does not count as a contributor.