### PR TITLE
chore: Bump Spoon version to 8.4.0-beta-15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>8.4.0-beta-14</version>
+            <version>8.4.0-beta-15</version>
             <exclusions>
                 <exclusion>
                     <!-- must be excluded as it is signed, which causes problems with unsigned version from sonar -->


### PR DESCRIPTION
Just bumps the Spoon version to the latest beta. This PR literally changes one digit, so I'll merge it myself as soon as it passes CI.