### PR TITLE
refactor: Replace RuleViolation.getFileName() with RuleViolation.getAbsolutePath()

### DIFF
--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -231,10 +231,9 @@ class RepairCommand extends BaseCommand {
         String[] parts = violationSpecifier.split(Constants.VIOLATION_SPECIFIER_SEP);
         String key = parts[0];
         String rawFilename = parts[1];
-        String fileName =
-                originalFilesPath.toPath().resolve(rawFilename).toAbsolutePath().toString();
+        Path absPath = originalFilesPath.toPath().resolve(rawFilename).toAbsolutePath().normalize();
 
-        if (!new File(fileName).isFile()) {
+        if (!absPath.toFile().isFile()) {
             throw new CommandLine.ParameterException(
                     spec.commandLine(),
                     String.format(
@@ -246,7 +245,7 @@ class RepairCommand extends BaseCommand {
         int startCol = Integer.parseInt(parts[3]);
         int endLine = Integer.parseInt(parts[4]);
         int endCol = Integer.parseInt(parts[5]);
-        return new SpecifiedViolation(key, fileName, startLine, startCol, endLine, endCol);
+        return new SpecifiedViolation(key, absPath, startLine, startCol, endLine, endCol);
     }
 
     private SoraldConfig createConfig() {

--- a/src/main/java/sorald/cli/SpecifiedViolation.java
+++ b/src/main/java/sorald/cli/SpecifiedViolation.java
@@ -1,5 +1,6 @@
 package sorald.cli;
 
+import java.nio.file.Path;
 import sorald.sonar.Checks;
 import sorald.sonar.RuleViolation;
 
@@ -7,17 +8,17 @@ import sorald.sonar.RuleViolation;
 class SpecifiedViolation extends RuleViolation {
     private final String ruleKey;
     private final String checkName;
-    private final String fileName;
+    private final Path absPath;
     private final int startLine;
     private final int startCol;
     private final int endLine;
     private final int endCol;
 
     SpecifiedViolation(
-            String ruleKey, String fileName, int startLine, int startCol, int endLine, int endCol) {
+            String ruleKey, Path absPath, int startLine, int startCol, int endLine, int endCol) {
         this.ruleKey = ruleKey;
         checkName = Checks.getCheck(ruleKey).getSimpleName();
-        this.fileName = fileName;
+        this.absPath = absPath;
         this.startLine = startLine;
         this.endLine = endLine;
         this.startCol = startCol;
@@ -45,8 +46,8 @@ class SpecifiedViolation extends RuleViolation {
     }
 
     @Override
-    public String getFileName() {
-        return fileName;
+    public Path getAbsolutePath() {
+        return absPath;
     }
 
     @Override

--- a/src/main/java/sorald/event/models/WarningLocation.java
+++ b/src/main/java/sorald/event/models/WarningLocation.java
@@ -1,7 +1,6 @@
 package sorald.event.models;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import sorald.sonar.RuleViolation;
 
 public class WarningLocation {
@@ -13,7 +12,7 @@ public class WarningLocation {
     private final String violationSpecifier;
 
     public WarningLocation(RuleViolation violation, Path projectPath) {
-        this.filePath = projectPath.relativize(Paths.get(violation.getFileName())).toString();
+        this.filePath = projectPath.relativize(violation.getAbsolutePath()).toString();
         this.startLine = violation.getStartLine();
         this.endLine = violation.getEndLine();
         this.startColumn = violation.getStartCol();

--- a/src/main/java/sorald/sonar/GreedyBestFitScanner.java
+++ b/src/main/java/sorald/sonar/GreedyBestFitScanner.java
@@ -1,6 +1,7 @@
 package sorald.sonar;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,8 +75,8 @@ public class GreedyBestFitScanner<E extends CtElement> extends CtScanner {
         intersecting = new HashMap<>();
         filesWithViolations =
                 violations.stream()
-                        .map(RuleViolation::getFileName)
-                        .map(File::new)
+                        .map(RuleViolation::getAbsolutePath)
+                        .map(Path::toFile)
                         .collect(Collectors.toSet());
     }
 
@@ -173,7 +174,7 @@ public class GreedyBestFitScanner<E extends CtElement> extends CtScanner {
     private static boolean inSameFile(CtElement element, RuleViolation violation) {
         return element.getPosition().isValidPosition()
                 && FileUtils.pathAbsNormEqual(
-                        violation.getFileName(), element.getPosition().getFile().getAbsolutePath());
+                        violation.getAbsolutePath(), element.getPosition().getFile().toPath());
     }
 
     /** All rule violations must concern the same rule as the processor. */

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -1,7 +1,6 @@
 package sorald.sonar;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,8 +21,8 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
     /** @return The column the element that violates the rule ends on. */
     public abstract int getEndCol();
 
-    /** @return The name of the file that was analyzed. */
-    public abstract String getFileName();
+    /** @return Absolute and normalized path to the analyzed file. */
+    public abstract Path getAbsolutePath();
 
     /** @return The name of the check class that generated this warning. */
     public abstract String getCheckName();
@@ -36,7 +35,7 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
      * @return A violation specifier that is unique relative to the given project path.
      */
     public String relativeSpecifier(Path projectPath) {
-        Path absPath = Paths.get(getFileName()).toAbsolutePath().normalize();
+        Path absPath = getAbsolutePath();
         Path normalizedProjectPath = projectPath.toAbsolutePath().normalize();
         Path idPath = normalizedProjectPath.relativize(absPath);
         return Stream.of(
@@ -56,7 +55,7 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
             return false;
         }
         var other = (RuleViolation) obj;
-        return getFileName().equals(other.getFileName())
+        return getAbsolutePath().equals(other.getAbsolutePath())
                 && getCheckName().equals(other.getCheckName())
                 && getRuleKey().equals(other.getRuleKey())
                 && getStartLine() == other.getStartLine()
@@ -68,7 +67,7 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
     @Override
     public int hashCode() {
         return Objects.hash(
-                getFileName(),
+                getAbsolutePath(),
                 getCheckName(),
                 getRuleKey(),
                 getStartLine(),
@@ -79,7 +78,7 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
 
     @Override
     public int compareTo(RuleViolation violation) {
-        int fileCmp = getFileName().compareTo(violation.getFileName());
+        int fileCmp = getAbsolutePath().compareTo(violation.getAbsolutePath());
         int ruleCmp = getRuleKey().compareTo(violation.getRuleKey());
         int startLineCmp = Integer.compare(getStartLine(), violation.getStartLine());
         int startColCmp = Integer.compare(getStartCol(), violation.getStartCol());

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -1,5 +1,7 @@
 package sorald.sonar;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.sonar.java.AnalyzerMessage;
 import org.sonar.plugins.java.api.JavaCheck;
 
@@ -40,8 +42,10 @@ class ScannedViolation extends RuleViolation {
     }
 
     @Override
-    public String getFileName() {
-        return message.getInputComponent().key().replace(":", "");
+    public Path getAbsolutePath() {
+        return Paths.get(message.getInputComponent().key().replace(":", ""))
+                .toAbsolutePath()
+                .normalize();
     }
 
     @Override


### PR DESCRIPTION
#166 

Replaces `RuleViolation.getFileName` (which returns `String`) with `RuleViolation.getAbsolutePath` (which returns an absolute and normalized `Path`)