### PR TITLE
chore: Use Spoon 8.4.0-beta-18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>8.4.0-beta-15</version>
+            <version>8.4.0-beta-18</version>
             <exclusions>
                 <exclusion>
                     <!-- must be excluded as it is signed, which causes problems with unsigned version from sonar -->


### PR DESCRIPTION
This PR just updates Spoon to the latest beta. Notably, this includes my patch for parenthesis minimization in arithmetic expressions. As an example, here's what a `CastArithmeticOperand` repair in Verificatum looked like before the patch:

```diff
-                ((double) (widthExp + (2 - 1 / widthExp) * bitLength)) / width;
+                ( (double) (widthExp + ((2 - (1D / widthExp)) * bitLength))) / width;
```

And here's what it now looks like:

```diff
-                ((double) (widthExp + (2 - 1 / widthExp) * bitLength)) / width;
+                ( (double) (widthExp + (2 - 1D / widthExp) * bitLength)) / width;
```

Not that the redundant parentheses around `1D / widthExp` are now gone.

There's still a rogue space at the start, but that's just the sniper printer mismatching one of the initial parentheses. At least now we have the correct amount of parentheses!