### PR TITLE
fix(1854): Avoid merging declaration with another dead store

### DIFF
--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -57,11 +57,7 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
      */
     private boolean isDeadStore(CtVariableAccess<?> varAccess) {
         CtStatement parentStatement = varAccess.getParent(CtStatement.class);
-        if (parentStatement == null) {
-            return false;
-        } else {
-            return getBestFits().containsKey(parentStatement);
-        }
+        return getBestFits().containsKey(parentStatement);
     }
 
     /**

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -43,11 +43,11 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
      */
     private void retainDeclarationOnVariableUse(CtLocalVariable<?> localVar) {
         CtStatementList statementList = localVar.getParent(CtStatementList.class);
-        List<CtVariableAccess<?>> varAccesses = statementList.getElements(accessFilter(localVar));
+        List<CtVariableAccess<?>> liveVarAccesses =
+                statementList.getElements(liveAccessFilter(localVar));
 
-        boolean isDeadVariable = varAccesses.stream().allMatch(this::isDeadStore);
-        if (!varAccesses.isEmpty() && !isDeadVariable) {
-            createNewDeclaration(statementList, varAccesses, localVar);
+        if (!liveVarAccesses.isEmpty()) {
+            createNewDeclaration(statementList, liveVarAccesses, localVar);
         }
     }
 
@@ -70,15 +70,15 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
      * declaration with a variable write if possible.
      *
      * @param statementList The statement list in which the variable declaration appears.
-     * @param varAccesses All accesses to the variable.
+     * @param liveVarAccesses All non-dead-store accesses to the variable.
      * @param localVar The variable declaration itself.
      */
     private void createNewDeclaration(
             CtStatementList statementList,
-            List<CtVariableAccess<?>> varAccesses,
+            List<CtVariableAccess<?>> liveVarAccesses,
             CtLocalVariable<?> localVar) {
         List<CtStatementList> statementListsWithVarAccess =
-                varAccesses.stream()
+                liveVarAccesses.stream()
                         .map(access -> access.getParent(CtStatementList.class))
                         .distinct() // TODO optimize, this uses taxing equality comparison
                         .collect(Collectors.toList());
@@ -93,7 +93,7 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
         int firstStatementAccessingVarIdx =
                 findFirstStatementAccessingVarIdx(deepestCommonParent, localVar);
         findDeclarationMergeableWrite(
-                        varAccesses, deepestCommonParent, firstStatementAccessingVarIdx)
+                        liveVarAccesses, deepestCommonParent, firstStatementAccessingVarIdx)
                 .ifPresentOrElse(
                         this::makeDeclaration,
                         () -> {
@@ -109,7 +109,7 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
      * statement in the common parent list, and is the first access to the processed variable that
      * appears in the common parent list.
      *
-     * @param varAccesses All variable accesses to the considered variable.
+     * @param liveVarAccesses All non-dead-store variable accesses to the considered variable.
      * @param commonParentList The common parent list.
      * @param firstStatementAccessingVarIdx Index of the first statement that accesses the
      *     considered variable (possibly nested access).
@@ -117,11 +117,11 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
      *     is found.
      */
     private Optional<CtVariableWrite<?>> findDeclarationMergeableWrite(
-            List<CtVariableAccess<?>> varAccesses,
+            List<CtVariableAccess<?>> liveVarAccesses,
             CtStatementList commonParentList,
             int firstStatementAccessingVarIdx) {
         Optional<CtVariableAccess<?>> firstNonNestedVarAccessOpt =
-                varAccesses.stream()
+                liveVarAccesses.stream()
                         .filter(
                                 access ->
                                         access.getParent(CtStatementList.class) == commonParentList)
@@ -153,7 +153,7 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
             CtStatementList statementList, CtLocalVariable<?> localVar) {
         for (int i = 0; i < statementList.getStatements().size(); i++) {
             var statement = statementList.getStatement(i);
-            if (!statement.getElements(accessFilter(localVar)).isEmpty()) {
+            if (!statement.getElements(liveAccessFilter(localVar)).isEmpty()) {
                 return i;
             }
         }
@@ -226,10 +226,14 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
         return depth;
     }
 
-    private static Filter<CtVariableAccess<?>> accessFilter(CtLocalVariable<?> localVar) {
-        return (varRead) -> {
-            CtVariableReference<?> ref = varRead.getVariable();
-            return ref != null && ref.getDeclaration() == localVar;
+    /**
+     * Predicate that says "yes" only to live accesses to the given variable. That is to say, dead
+     * stores are not included.
+     */
+    private Filter<CtVariableAccess<?>> liveAccessFilter(CtLocalVariable<?> localVar) {
+        return (varAccess) -> {
+            CtVariableReference<?> ref = varAccess.getVariable();
+            return !isDeadStore(varAccess) && ref != null && ref.getDeclaration() == localVar;
         };
     }
 }

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -52,6 +52,17 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
     }
 
     /**
+     * Predicate that says "yes" only to live accesses to the given variable. That is to say, dead
+     * stores are not included.
+     */
+    private Filter<CtVariableAccess<?>> liveAccessFilter(CtLocalVariable<?> localVar) {
+        return (varAccess) -> {
+            CtVariableReference<?> ref = varAccess.getVariable();
+            return !isDeadStore(varAccess) && ref != null && ref.getDeclaration() == localVar;
+        };
+    }
+
+    /**
      * @param varAccess Access to a variable.
      * @return true if the variable access is a dead store (according to the best fits mapping).
      */
@@ -220,16 +231,5 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
             depth++;
         }
         return depth;
-    }
-
-    /**
-     * Predicate that says "yes" only to live accesses to the given variable. That is to say, dead
-     * stores are not included.
-     */
-    private Filter<CtVariableAccess<?>> liveAccessFilter(CtLocalVariable<?> localVar) {
-        return (varAccess) -> {
-            CtVariableReference<?> ref = varAccess.getVariable();
-            return !isDeadStore(varAccess) && ref != null && ref.getDeclaration() == localVar;
-        };
     }
 }

--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -45,8 +45,22 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
         CtStatementList statementList = localVar.getParent(CtStatementList.class);
         List<CtVariableAccess<?>> varAccesses = statementList.getElements(accessFilter(localVar));
 
-        if (!varAccesses.isEmpty()) {
+        boolean isDeadVariable = varAccesses.stream().allMatch(this::isDeadStore);
+        if (!varAccesses.isEmpty() && !isDeadVariable) {
             createNewDeclaration(statementList, varAccesses, localVar);
+        }
+    }
+
+    /**
+     * @param varAccess Access to a variable.
+     * @return true if the variable access is a dead store (according to the best fits mapping).
+     */
+    private boolean isDeadStore(CtVariableAccess<?> varAccess) {
+        CtStatement parentStatement = varAccess.getParent(CtStatement.class);
+        if (parentStatement == null) {
+            return false;
+        } else {
+            return getBestFits().containsKey(parentStatement);
         }
     }
 

--- a/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -136,6 +136,10 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         return this;
     }
 
+    public Map<CtElement, RuleViolation> getBestFits() {
+        return bestFits;
+    }
+
     public SoraldAbstractProcessor setMaxFixes(int maxFixes) {
         this.maxFixes = maxFixes;
         return this;

--- a/src/test/resources/processor_test_files/1854_DeadStore/DeadVariableWithMultipleDeadStores.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/DeadVariableWithMultipleDeadStores.java
@@ -1,0 +1,16 @@
+/*
+When a variable declaration is entirely dead AND has dead stores, we expect the variable to be
+removed entirely.
+ */
+
+public class DeadVariableWithMultipleDeadStores {
+    public static void main(String[] args) {
+        int a = 2; // Noncompliant
+        a = 3; // Noncompliant
+        a = 4; // Noncompliant
+        if (true) {
+            System.out.println("Hello, world!");
+        }
+        a = 5; // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/DeadVariableWithMultipleDeadStores.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/DeadVariableWithMultipleDeadStores.java.expected
@@ -1,0 +1,12 @@
+/*
+When a variable declaration is entirely dead AND has dead stores, we expect the variable to be
+removed entirely.
+ */
+
+public class DeadVariableWithMultipleDeadStores {
+    public static void main(String[] args) {
+        if (true) {
+            System.out.println("Hello, world!");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/MultipleDeadStoresInARow.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/MultipleDeadStoresInARow.java
@@ -1,0 +1,14 @@
+/*
+When there are multiple dead stores in a row, and the first one is a dead initializer, we expect
+the declaration to be merged with the first non-dead store. Any intermediate dead stores are then
+removed as well.
+ */
+
+public class MultipleDeadStoresInARow {
+    public static void main(String[] args){
+        int a = 2; // Noncompliant
+        a = 3; // Noncompliant
+        a = 4;
+        System.out.println(a);
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/MultipleDeadStoresInARow.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/MultipleDeadStoresInARow.java.expected
@@ -1,0 +1,12 @@
+/*
+When there are multiple dead stores in a row, and the first one is a dead initializer, we expect
+the declaration to be merged with the first non-dead store. Any intermediate dead stores are then
+removed as well.
+ */
+
+public class MultipleDeadStoresInARow {
+    public static void main(String[] args){
+        int a = 4;
+        System.out.println(a);
+    }
+}


### PR DESCRIPTION
Fix #418 

This PR fixes a problem where the `DeadStoreProcessor` would merge a declaration with a dead initializer, with _another_ dead store (/facepalm). The fix is pretty simple: don't do that.

Here's an example of how moving the declaration without considering dead stores can go wrong:

```diff
public class MultipleDeadStoresInARow {
    public static void main(String[] args){
-       int a = 2; // Noncompliant
-       a = 3; // Noncompliant
+       int a = 3;
        a = 4;
        System.out.println(a);
    }
} 
```

Note that the initializer for `a` is still a dead store. The problem is that the dead store that's mapped to `a = 3` will simply disappear, as that element is replaced with the declaration.

Here's the same fix after the patch in this PR:

```diff
public class MultipleDeadStoresInARow {
    public static void main(String[] args){
-       int a = 2; // Noncompliant
-       a = 3; // Noncompliant
-       a = 4;
+       int a = 4;
        System.out.println(a);
    }
} 
```

**How does this work?** When repairing the violation on `int a = 2;` by moving the declaration to another store, it simply skips over all dead stores and finds the first non-dead store. The skipped-over dead stores are then deleted by further invocations of the processor, on those particular elements. Note that if there is _no_ non-dead store, the declaration is simply deleted.

**Why this much work for such a simple repair?** This presents a good stepping stone for making Sorald's repairs more sophisticated. It's a simple repair in principle that's complicated by our choice of moving the declaration to create a better-looking patch.

For this to be possible, the `DeadStoreProcessor` must be able to access the best-fits mapping between Spoon elements and rule violations. As it turns out, this was trivial: just add a getter to `SoraldAbstractProcessor`. Therefore, this PR _also_ fixes part of #359, in that `repair` now has access to said mapping. It's not however accessible to `canRepair`, as that method is in fact used to compute the mapping. If we want `canRepair` to have access to the rule violation for an element, a position-matched rule violation and Spoon element pair must be passed in to `canRepair`.