### PR TITLE
chore: Separate building and testing into different steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,10 @@ jobs:
         run: |
           mvn -B package -DskipTests
           mvn -B test-compile
+      - name: Fetch final dependencies
+        # this is a hack to fetch some test runtime dependencies
+        run: timeout 10 mvn -B test || "Done fetching dependencies"
+        shell: bash
       - name: Run tests
         run: mvn test
       - name: Sanity check jarfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           mvn -B test-compile
       - name: Fetch final dependencies
         # this is a hack to fetch some test runtime dependencies
-        run: timeout 10 mvn -B test || "Done fetching dependencies"
+        run: timeout 10 mvn -B test || echo "Done fetching dependencies"
         shell: bash
       - name: Run tests
         run: mvn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,11 @@ jobs:
       - name: Check formatting with spotless
         run: mvn spotless:check
       - name: Build project
-        run: mvn -B package
+        run: |
+          mvn -B package -DskipTests
+          mvn -B test-compile
+      - name: Run tests
+        run: mvn test
       - name: Sanity check jarfile
         env:
           SORALD_JAR_PATH: "target/sorald-1.1-SNAPSHOT-jar-with-dependencies.jar"


### PR DESCRIPTION
Fix #423 

This cleans up the CI output by separating building the project and running tests into separate steps. Thus, the "Run tests" step is not polluted by thousands of lines of "Downloading some dependency".

Previously, the "Build project" step both fetched dependencies and ran tests. Now, the new "Run tests" step only runs tests, which makes it easier to find the test output. Arguably, we should also turn off the logger or set it to warnings only, but that's for another PR.

* [See this build for a "before"](https://github.com/SpoonLabs/sorald/actions/runs/659434600)
* [See this build for an "after"](https://github.com/SpoonLabs/sorald/runs/2128668398)