### PR TITLE
chore: Add daily Maven dependency cache to all jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,18 @@ jobs:
           java-version: 11
           java-package: jdk
           architecture: x64
+
+      - name: Get date for cache # see https://github.com/actions/cache README
+        id: get-date
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+      - name: Use Maven dependency cache
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
       - name: Check formatting with spotless
         run: mvn spotless:check
       - name: Build project
@@ -54,6 +66,18 @@ jobs:
           java-version: 11
           java-package: jdk
           architecture: x64
+
+      - name: Get date for cache # see https://github.com/actions/cache README
+        id: get-date
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+      - name: Use Maven dependency cache
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
       - name: Package Sorald
         run: mvn package -DskipTests
       - name: Test support scripts
@@ -73,6 +97,18 @@ jobs:
           java-version: 11
           java-package: jdk
           architecture: x64
+
+      - name: Get date for cache # see https://github.com/actions/cache README
+        id: get-date
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+      - name: Use Maven dependency cache
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
       - name: Test that generated code is up-to-date
         run: |
           mvn clean compile dependency:build-classpath -Dmdep.outputFile=cp.txt


### PR DESCRIPTION
Fix #424 

This PR adds caching of Maven dependencies to the GitHub Actions workflows. The cache is used for at most 24 hours as the cache key is tied to the date. Unfortunately, the caching steps must be duplicated across jobs, as there is no way to reuse steps in Actions at the moment.

I recently introduced this in Spoon as well: inria/spoon#3842

Before and after times should speak for themselves:

* [Before](https://github.com/SpoonLabs/sorald/actions/runs/660335885): total = 4m57s
* [After](https://github.com/SpoonLabs/sorald/actions/runs/660347955): total = 2m48s