### PR TITLE
chore: Set log level to WARNING in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,17 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>
+                <!--Enabled for tests to make it possible to silence INFO log output from SonarJava-->
+                test
+            </scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/fr.inria.gforge.spoon/spoon-core -->
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <root level="WARNING"/>
+</configuration>


### PR DESCRIPTION
Fix #427 

It's super hard to read test failures because of the massive amounts of INFO log output from SonarJava. This PR sets the log output to WARNING for tests, such that all of that redundant output is hidden.