### PR TITLE
wip: chore: Update sonar-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,14 @@
     <description>An automatic repair system for static code analysis warnings from Sonar Java.</description>
     <url>https://github.com/SpoonLabs/sorald</url>
 
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <picocli.version>4.5.2</picocli.version>
+        <sonar.java.version>6.13.0.25138</sonar.java.version>
+    </properties>
+
     <licenses>
         <license>
             <name>MIT License</name>
@@ -82,7 +90,7 @@
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-checks-testkit</artifactId>
-            <version>6.9.0.23563</version>
+            <version>${sonar.java.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- included in stdlib -->
@@ -94,12 +102,12 @@
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-frontend</artifactId>
-            <version>6.9.0.23563</version>
+            <version>${sonar.java.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-checks</artifactId>
-            <version>6.9.0.23563</version>
+            <version>${sonar.java.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- included in stdlib -->
@@ -124,12 +132,6 @@
             <version>2.6</version>
         </dependency>
     </dependencies>
-    <properties>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <picocli.version>4.5.2</picocli.version>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <picocli.version>4.5.2</picocli.version>
-        <sonar.java.version>6.13.0.25138</sonar.java.version>
+        <sonar.java.version>6.12.0.24852</sonar.java.version>
     </properties>
 
     <licenses>

--- a/src/main/java/sorald/event/collectors/MinerStatisticsCollector.java
+++ b/src/main/java/sorald/event/collectors/MinerStatisticsCollector.java
@@ -1,6 +1,5 @@
 package sorald.event.collectors;
 
-import com.google.common.collect.ImmutableList;
 import java.util.*;
 import java.util.stream.Collectors;
 import sorald.event.SoraldEvent;
@@ -66,7 +65,7 @@ public class MinerStatisticsCollector implements SoraldEventHandler {
                                 new MinedRule(
                                         e.getKey().split(RULE_ID_SEPARATOR)[0],
                                         e.getKey().split(RULE_ID_SEPARATOR)[1],
-                                        ImmutableList.copyOf(e.getValue())))
+                                        List.copyOf(e.getValue())))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/sorald/event/models/miner/MinedRule.java
+++ b/src/main/java/sorald/event/models/miner/MinedRule.java
@@ -1,21 +1,20 @@
 package sorald.event.models.miner;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 import sorald.event.models.WarningLocation;
 
 public class MinedRule {
     private final String ruleKey;
     private final String ruleName;
-    private final ImmutableList<WarningLocation> warningLocations;
+    private final List<WarningLocation> warningLocations;
 
-    public MinedRule(
-            String ruleKey, String ruleName, ImmutableList<WarningLocation> warningLocations) {
+    public MinedRule(String ruleKey, String ruleName, List<WarningLocation> warningLocations) {
         this.ruleKey = ruleKey;
         this.ruleName = ruleName;
         this.warningLocations = warningLocations;
     }
 
-    public ImmutableList<WarningLocation> getWarningLocations() {
+    public List<WarningLocation> getWarningLocations() {
         return warningLocations;
     }
 

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -20,8 +20,8 @@ import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.rule.internal.NewActiveRule;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter;
 import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.rule.RuleKey;
@@ -108,7 +108,7 @@ public class RuleVerifier {
 
     @SuppressWarnings("UnstableApiUsage")
     private static void scanFiles(List<InputFile> sourceFiles, SoraldSonarComponents components) {
-        Measurer measurer = new Measurer(components.getContext(), new DefaultNoSonarFilter());
+        Measurer measurer = new Measurer(components.getContext(), new NoSonarFilter());
         JavaSquid squid =
                 new JavaSquid(
                         // TODO set the source version dynamically


### PR DESCRIPTION
#331 

Currently, updating to any recent version of Sonar breaks our handling of `NOSONAR` and `@SuppressWarnings`. Not bothering with it at the moment, see https://github.com/SpoonLabs/sorald/issues/331#issuecomment-802678077

I will periodically update this PR to ensure that we stay somewhat up-to-date with sonar-java, but won't try to fix the issue filtering at this time.