### PR TITLE
refactor: Move PATH_TO_RESOURCES_FOLDER to TestHelper

### DIFF
--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -1,8 +1,6 @@
 package sorald;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -33,8 +31,6 @@ public class Constants {
     public static final String VIOLATION_SPECIFIER_SEP = File.pathSeparator;
 
     public static final String SORALD_WORKSPACE = "sorald-workspace";
-    public static final Path PATH_TO_RESOURCES_FOLDER =
-            Paths.get("src").resolve("test").resolve("resources").toAbsolutePath();
 
     public static final String JAVA_EXT = ".java";
 

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -18,7 +18,7 @@ public class FileOutputStrategyTest {
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
                     Constants.ARG_ORIGINAL_FILES_PATH,
-                    Constants.PATH_TO_RESOURCES_FOLDER.toString(),
+                    TestHelper.PATH_TO_RESOURCES_FOLDER.toString(),
                     Constants.ARG_RULE_KEY,
                     "4973",
                     Constants.ARG_FILE_OUTPUT_STRATEGY,
@@ -37,7 +37,7 @@ public class FileOutputStrategyTest {
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
                     Constants.ARG_ORIGINAL_FILES_PATH,
-                    Constants.PATH_TO_RESOURCES_FOLDER.toString(),
+                    TestHelper.PATH_TO_RESOURCES_FOLDER.toString(),
                     Constants.ARG_RULE_KEY,
                     "4973",
                     Constants.ARG_FILE_OUTPUT_STRATEGY,

--- a/src/test/java/sorald/FileUtilsTest.java
+++ b/src/test/java/sorald/FileUtilsTest.java
@@ -21,7 +21,7 @@ public class FileUtilsTest {
             @TempDir File workdir) throws Exception {
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
-                Constants.PATH_TO_RESOURCES_FOLDER.toFile(), workdir);
+                TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(), workdir);
         Path javaExtDirpath = workdir.toPath().resolve("randomdir.java");
         Path javaFileInJavaExtDirpath = javaExtDirpath.resolve("SomeClass.java");
         Files.createDirectory(workdir.toPath().resolve("randomdir.java"));
@@ -41,7 +41,7 @@ public class FileUtilsTest {
         // act
         List<File> files =
                 FileUtils.findFilesByExtension(
-                        Constants.PATH_TO_RESOURCES_FOLDER.toFile(), Constants.JAVA_EXT);
+                        TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(), Constants.JAVA_EXT);
 
         // assert
         Predicate<File> isJavaFile =

--- a/src/test/java/sorald/MavenHelper.java
+++ b/src/test/java/sorald/MavenHelper.java
@@ -15,7 +15,7 @@ import sorald.processor.ProcessorTestHelper;
 /** A class for helping with Maven in testing. */
 public class MavenHelper {
     private static final File POM_FILE =
-            Constants.PATH_TO_RESOURCES_FOLDER
+            TestHelper.PATH_TO_RESOURCES_FOLDER
                     .resolve("scenario_test_files")
                     .resolve("maven_converter_pom.xml")
                     .toFile();

--- a/src/test/java/sorald/MavenLauncherTest.java
+++ b/src/test/java/sorald/MavenLauncherTest.java
@@ -15,7 +15,7 @@ public class MavenLauncherTest {
             throws IOException {
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
-                Constants.PATH_TO_RESOURCES_FOLDER
+                TestHelper.PATH_TO_RESOURCES_FOLDER
                         .resolve("scenario_test_files/simple-java8-maven-project")
                         .toFile(),
                 workdir);

--- a/src/test/java/sorald/RepairTest.java
+++ b/src/test/java/sorald/RepairTest.java
@@ -21,7 +21,7 @@ public class RepairTest {
     public void repair_doesNotAllowMultipleRules(@TempDir File workdir) throws IOException {
         // arrange
         File origFile =
-                Constants.PATH_TO_RESOURCES_FOLDER.resolve("MultipleProcessors.java").toFile();
+                TestHelper.PATH_TO_RESOURCES_FOLDER.resolve("MultipleProcessors.java").toFile();
         File targetFile = workdir.toPath().resolve(origFile.getName()).toFile();
         org.apache.commons.io.FileUtils.copyFile(origFile, targetFile);
         SoraldConfig config = new SoraldConfig();

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -32,7 +32,7 @@ public class SegmentStrategyTest {
     @Test
     public void arrayToStringProcessor_success_Test() throws Exception {
         String fileName = "ArrayHashCodeAndToString.java";
-        Path pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
+        Path pathToBuggyFile = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
         String pathToRepairedFile =
                 Constants.SORALD_WORKSPACE + "/SEGMENT/" + Constants.SPOONED + "/" + fileName;
 
@@ -48,7 +48,7 @@ public class SegmentStrategyTest {
                     Constants.ARG_MAX_FILES_PER_SEGMENT,
                     "1",
                     Constants.ARG_ORIGINAL_FILES_PATH,
-                    Constants.PATH_TO_RESOURCES_FOLDER.toString(),
+                    TestHelper.PATH_TO_RESOURCES_FOLDER.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",
                     Constants.ARG_PRETTY_PRINTING_STRATEGY,
@@ -63,7 +63,7 @@ public class SegmentStrategyTest {
     @Test
     public void arrayToStringProcessor_fail_Test() throws Exception {
         String fileName = "ArrayHashCodeAndToString.java";
-        Path pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
+        Path pathToBuggyFile = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
 
         RuleVerifier.verifyHasIssue(
                 pathToBuggyFile.toString(), new ArrayHashCodeAndToStringCheck());
@@ -75,7 +75,7 @@ public class SegmentStrategyTest {
                     Constants.ARG_MAX_FILES_PER_SEGMENT,
                     "0",
                     Constants.ARG_ORIGINAL_FILES_PATH,
-                    Constants.PATH_TO_RESOURCES_FOLDER.toString(),
+                    TestHelper.PATH_TO_RESOURCES_FOLDER.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",
                     Constants.ARG_PRETTY_PRINTING_STRATEGY,
@@ -91,7 +91,7 @@ public class SegmentStrategyTest {
             throws IOException {
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
-                Constants.PATH_TO_RESOURCES_FOLDER.toFile(), tempDir);
+                TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(), tempDir);
 
         SoraldConfig config = createSegmentConfig(tempDir.getAbsolutePath());
 

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -125,7 +125,7 @@ public class TargetedRepairTest {
     /** Setup the workdir with a specific target violation. */
     private static TargetedRepairWorkdirInfo setupWorkdir(File workdir) throws IOException {
         org.apache.commons.io.FileUtils.copyDirectory(
-                Constants.PATH_TO_RESOURCES_FOLDER.toFile(), workdir);
+                TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(), workdir);
 
         String ruleKey = "2111";
         JavaFileScanner check = Checks.getCheckInstance(ruleKey);

--- a/src/test/java/sorald/TestHelper.java
+++ b/src/test/java/sorald/TestHelper.java
@@ -3,8 +3,13 @@ package sorald;
 import java.io.BufferedReader;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class TestHelper {
+
+    public static final Path PATH_TO_RESOURCES_FOLDER =
+            Paths.get("src").resolve("test").resolve("resources").toAbsolutePath();
 
     /**
      * Simple helper method that removes the mandatory // Noncompliant comments from test files,

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.io.TempDir;
 import sorald.Constants;
 import sorald.FileUtils;
 import sorald.Main;
+import sorald.TestHelper;
 import sorald.cli.SoraldVersionProvider;
 import sorald.event.StatsMetadataKeys;
 import sorald.sonar.Checks;
@@ -30,9 +31,11 @@ import sorald.sonar.Checks;
 public class WarningMinerTest {
 
     private static final Path REPOS_TXT =
-            Constants.PATH_TO_RESOURCES_FOLDER.resolve("warning_miner").resolve("test_repos.txt");
+            TestHelper.PATH_TO_RESOURCES_FOLDER.resolve("warning_miner").resolve("test_repos.txt");
     private static final Path EXPECTED_OUTPUT_TXT =
-            Constants.PATH_TO_RESOURCES_FOLDER.resolve("warning_miner").resolve("test_results.txt");
+            TestHelper.PATH_TO_RESOURCES_FOLDER
+                    .resolve("warning_miner")
+                    .resolve("test_results.txt");
 
     @Test
     public void test_warningMiner() throws Exception {

--- a/src/test/java/sorald/processor/BestFitScannerTest.java
+++ b/src/test/java/sorald/processor/BestFitScannerTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import sorald.Constants;
+import sorald.TestHelper;
 import sorald.sonar.BestFitScanner;
 import sorald.sonar.Checks;
 import sorald.sonar.ProjectScanner;
@@ -27,7 +28,7 @@ public class BestFitScannerTest {
 
     @Test
     public void calculateBestFits_throws_whenProcessorConcernsDifferentRuleThanViolations() {
-        File projectBaseDir = Constants.PATH_TO_RESOURCES_FOLDER.toFile();
+        File projectBaseDir = TestHelper.PATH_TO_RESOURCES_FOLDER.toFile();
         Set<RuleViolation> xxeProcessingViolations =
                 ProjectScanner.scanProject(
                         projectBaseDir,

--- a/src/test/java/sorald/processor/MaxFixesPerRuleTest.java
+++ b/src/test/java/sorald/processor/MaxFixesPerRuleTest.java
@@ -12,7 +12,7 @@ public class MaxFixesPerRuleTest {
     @Test
     public void arrayToStringProcessorTest() throws Exception {
         String fileName = "ArrayHashCodeAndToString.java";
-        Path pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
+        Path pathToBuggyFile = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
         String pathToRepairedFile =
                 Constants.SORALD_WORKSPACE + "/" + Constants.SPOONED + "/" + fileName;
 

--- a/src/test/java/sorald/processor/NoSonarTest.java
+++ b/src/test/java/sorald/processor/NoSonarTest.java
@@ -12,7 +12,7 @@ public class NoSonarTest {
     @Test
     public void noSonarTesting() throws Exception {
         String fileName = "NOSONARCommentTest.java";
-        Path pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
+        Path pathToBuggyFile = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
         String pathToRepairedFile =
                 Constants.SORALD_WORKSPACE + "/" + Constants.SPOONED + "/" + fileName;
 

--- a/src/test/java/sorald/processor/ProcessorTest.java
+++ b/src/test/java/sorald/processor/ProcessorTest.java
@@ -141,7 +141,7 @@ public class ProcessorTest {
             throws Exception {
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
-                Constants.PATH_TO_RESOURCES_FOLDER.toFile(), workdir);
+                TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(), workdir);
         File dirWithJavaExtension = workdir.listFiles(File::isDirectory)[0];
         org.apache.commons.io.FileUtils.moveDirectory(
                 dirWithJavaExtension,
@@ -184,7 +184,7 @@ public class ProcessorTest {
     public void sorald_canProcessProject_withModuleInfo() throws Exception {
         // act
         ProcessorTestHelper.runSorald(
-                Constants.PATH_TO_RESOURCES_FOLDER
+                TestHelper.PATH_TO_RESOURCES_FOLDER
                         .resolve("scenario_test_files")
                         .resolve("project.with.module")
                         .toFile(),

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -17,13 +17,14 @@ import org.sonar.plugins.java.api.JavaFileScanner;
 import sorald.Constants;
 import sorald.Main;
 import sorald.PrettyPrintingStrategy;
+import sorald.TestHelper;
 import sorald.sonar.Checks;
 import sorald.sonar.RuleVerifier;
 
 /** Helper functions for {@link ProcessorTest}. */
 public class ProcessorTestHelper {
     public static final Path TEST_FILES_ROOT =
-            Constants.PATH_TO_RESOURCES_FOLDER.resolve("processor_test_files");
+            TestHelper.PATH_TO_RESOURCES_FOLDER.resolve("processor_test_files");
 
     static final String EXPECTED_FILE_SUFFIX = ".expected";
     // The processors related to these checks currently cause problems with the sniper printer

--- a/src/test/java/sorald/segment/FirstFitSegmentationAlgorithmTest.java
+++ b/src/test/java/sorald/segment/FirstFitSegmentationAlgorithmTest.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import sorald.Constants;
+import sorald.TestHelper;
 
 public class FirstFitSegmentationAlgorithmTest {
 
@@ -28,7 +28,7 @@ public class FirstFitSegmentationAlgorithmTest {
 
     @Test
     public void segmentationTest() throws Exception {
-        Path folder = Constants.PATH_TO_RESOURCES_FOLDER.resolve("DummyTreeDir");
+        Path folder = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve("DummyTreeDir");
         Node rootNode = SoraldTreeBuilderAlgorithm.buildTree(folder.toString());
 
         LinkedList<LinkedList<Node>> segments = FirstFitSegmentationAlgorithm.segment(rootNode, 2);

--- a/src/test/java/sorald/segment/SoraldTreeBuilderAlgorithmTest.java
+++ b/src/test/java/sorald/segment/SoraldTreeBuilderAlgorithmTest.java
@@ -9,13 +9,13 @@ import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import sorald.Constants;
+import sorald.TestHelper;
 
 public class SoraldTreeBuilderAlgorithmTest {
 
     @Test
     public void treeBuildTest() {
-        Path folder = Constants.PATH_TO_RESOURCES_FOLDER.resolve("DummyTreeDir");
+        Path folder = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve("DummyTreeDir");
         Node rootNode = SoraldTreeBuilderAlgorithm.buildTree(folder.toString());
         File rootFolder = folder.toFile();
         Assertions.assertEquals("DummyTreeDir", rootFolder.getName());

--- a/src/test/java/sorald/sonar/RuleVerifierTest.java
+++ b/src/test/java/sorald/sonar/RuleVerifierTest.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.DefaultPackageCheck;
-import sorald.Constants;
+import sorald.TestHelper;
 
 class RuleVerifierTest {
 
@@ -26,14 +26,14 @@ class RuleVerifierTest {
         String suppressedRuleKey = "2116";
         String nonSuppressedRuleKey = "2164";
         String testFile =
-                Constants.PATH_TO_RESOURCES_FOLDER
+                TestHelper.PATH_TO_RESOURCES_FOLDER
                         .resolve("WithMethodSuppressedS" + suppressedRuleKey + ".java")
                         .toString();
 
         var violations =
                 RuleVerifier.analyze(
                         List.of(testFile),
-                        Constants.PATH_TO_RESOURCES_FOLDER.toFile(),
+                        TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(),
                         List.of(
                                 Checks.getCheckInstance(suppressedRuleKey),
                                 Checks.getCheckInstance(nonSuppressedRuleKey)));
@@ -50,13 +50,13 @@ class RuleVerifierTest {
         var checkWithNoLocation = new DefaultPackageCheck();
 
         String testFile =
-                Constants.PATH_TO_RESOURCES_FOLDER
+                TestHelper.PATH_TO_RESOURCES_FOLDER
                         .resolve("ArrayHashCodeAndToString.java")
                         .toString();
         var violations =
                 RuleVerifier.analyze(
                         List.of(testFile),
-                        Constants.PATH_TO_RESOURCES_FOLDER.toFile(),
+                        TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(),
                         checkWithNoLocation);
 
         assertThat(violations, is(empty()));
@@ -65,7 +65,7 @@ class RuleVerifierTest {
     @Test
     public void analyze_doesNotReturnViolation_fromNosonarLine() throws IOException {
         // arrange
-        Path testFile = Constants.PATH_TO_RESOURCES_FOLDER.resolve("NOSONARCommentTest.java");
+        Path testFile = TestHelper.PATH_TO_RESOURCES_FOLDER.resolve("NOSONARCommentTest.java");
         int nosonarLine = 7;
         int violationLine = 8;
         List<String> lines = Files.readAllLines(testFile);
@@ -76,7 +76,7 @@ class RuleVerifierTest {
         var violations =
                 RuleVerifier.analyze(
                         List.of(testFile.toString()),
-                        Constants.PATH_TO_RESOURCES_FOLDER.toFile(),
+                        TestHelper.PATH_TO_RESOURCES_FOLDER.toFile(),
                         List.of(Checks.getCheckInstance("S2116")));
 
         // assert

--- a/src/test/java/sorald/sonar/RuleViolationTest.java
+++ b/src/test/java/sorald/sonar/RuleViolationTest.java
@@ -5,12 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.se.checks.XxeProcessingCheck;
-import sorald.Constants;
+import sorald.TestHelper;
 
 public class RuleViolationTest {
     @Test
     public void equals_onNonRuleViolationType_returnsFalse() {
-        File resources = Constants.PATH_TO_RESOURCES_FOLDER.toFile();
+        File resources = TestHelper.PATH_TO_RESOURCES_FOLDER.toFile();
         RuleViolation violation =
                 ProjectScanner.scanProject(resources, resources, new XxeProcessingCheck()).stream()
                         .findFirst()


### PR DESCRIPTION
The PATH_TO_RESOURCES_FOLDER constant should not be available in production, as it's only used for tests. This PR moves it into an appropriate position.