### PR TITLE
break: Remove --workspace argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,16 @@ The full list of options is as follows (and can also be found by running
 `sorald repair --help`):
 
 ```bash
+Repair Sonar rule violations in a targeted project.
       --file-output-strategy=<fileOutputStrategy>
-                          Mode for outputting files: 'CHANGED_ONLY', which
-                            means that only changed files will be created in
-                            the workspace. 'ALL', which means that all files,
-                            including the unchanged ones, will be created in
-                            the workspace. 'IN_PLACE', which means that results
-                            are written directly to source files.
-  -h, --help              Show this help message and exit.
+                             Mode for outputting files: 'CHANGED_ONLY', which
+                               means that only changed files will be created in
+                               the workspace. 'ALL', which means that all
+                               files, including the unchanged ones, will be
+                               created in the workspace. 'IN_PLACE', which
+                               means that results are written directly to
+                               source files.
+  -h, --help                 Show this help message and exit.
       --max-files-per-segment=<maxFilesPerSegment>
                              Max number of files per loaded segment for
                                segmented repair. It should be >= 3000 files per
@@ -149,10 +151,6 @@ The full list of options is as follows (and can also be found by running
                              One or more rule violation specifiers. Specifiers
                                can be gathered with the 'mine' command using
                                the --stats-output-file option.
-      --workspace=<soraldWorkspace>
-                             The path to a folder that will be used as
-                               workspace by Sorald, i.e. the path for the
-                               output.
 ```
 
 > **Note:** Some rules (e.g. 1444) are marked as "incomplete". This means that

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -19,7 +19,6 @@ public class Constants {
     public static final String ARG_MINER_OUTPUT_FILE = "--miner-output-file";
     public static final String ARG_GIT_REPOS_LIST = "--git-repos-list";
     public static final String ARG_TEMP_DIR = "--temp-dir";
-    public static final String ARG_WORKSPACE = "--workspace";
     public static final String ARG_PRETTY_PRINTING_STRATEGY = "--pretty-printing-strategy";
     public static final String ARG_FILE_OUTPUT_STRATEGY = "--file-output-strategy";
     public static final String ARG_MAX_FIXES_PER_RULE = "--max-fixes-per-rule";

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -62,7 +62,7 @@ public class Repair {
 
     public Repair(SoraldConfig config, List<? extends SoraldEventHandler> eventHandlers) {
         this.config = config;
-        spoonedPath = Paths.get(config.getWorkspace()).resolve(Constants.SPOONED);
+        spoonedPath = Paths.get(Constants.SORALD_WORKSPACE).resolve(Constants.SPOONED);
 
         cuCollector = new CompilationUnitCollector();
         List<SoraldEventHandler> eventHandlersCopy = new ArrayList<>(eventHandlers);

--- a/src/main/java/sorald/SoraldConfig.java
+++ b/src/main/java/sorald/SoraldConfig.java
@@ -10,7 +10,6 @@ public class SoraldConfig {
     private FileOutputStrategy fileOutputStrategy;
     private RepairStrategy repairStrategy;
     private String originalFilesPath;
-    private String workspace;
     private String gitRepoPath;
     private int maxFixesPerRule;
     private int maxFilesPerSegment;
@@ -49,14 +48,6 @@ public class SoraldConfig {
 
     public String getOriginalFilesPath() {
         return this.originalFilesPath;
-    }
-
-    public void setWorkspace(String workspace) {
-        this.workspace = workspace;
-    }
-
-    public String getWorkspace() {
-        return this.workspace;
     }
 
     public void setMaxFixesPerRule(int maxFixesPerRule) {

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -265,7 +265,6 @@ class RepairCommand extends BaseCommand {
     private SoraldConfig createConfig() {
         SoraldConfig config = new SoraldConfig();
         config.setOriginalFilesPath(originalFilesPath.getAbsolutePath());
-        config.setWorkspace(Constants.SORALD_WORKSPACE);
         config.setPrettyPrintingStrategy(prettyPrintingStrategy);
         config.setFileOutputStrategy(fileOutputStrategy);
         config.setMaxFixesPerRule(maxFixesPerRule);

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -71,13 +71,6 @@ class RepairCommand extends BaseCommand {
     }
 
     @CommandLine.Option(
-            names = {Constants.ARG_WORKSPACE},
-            description =
-                    "The path to a folder that will be used as workspace by Sorald, i.e. the path for the output.",
-            defaultValue = Constants.SORALD_WORKSPACE)
-    File soraldWorkspace;
-
-    @CommandLine.Option(
             names = {Constants.ARG_PRETTY_PRINTING_STRATEGY},
             description =
                     "Mode for pretty printing the source code: 'NORMAL', which means that all source code will be printed and its formatting might change (such as indentation), and 'SNIPER', which means that only statements changed towards the repair of Sonar rule violations will be printed.")
@@ -272,7 +265,7 @@ class RepairCommand extends BaseCommand {
     private SoraldConfig createConfig() {
         SoraldConfig config = new SoraldConfig();
         config.setOriginalFilesPath(originalFilesPath.getAbsolutePath());
-        config.setWorkspace(soraldWorkspace.getAbsolutePath());
+        config.setWorkspace(Constants.SORALD_WORKSPACE);
         config.setPrettyPrintingStrategy(prettyPrintingStrategy);
         config.setFileOutputStrategy(fileOutputStrategy);
         config.setMaxFixesPerRule(maxFixesPerRule);

--- a/src/test/java/sorald/FileOutputStrategyTest.java
+++ b/src/test/java/sorald/FileOutputStrategyTest.java
@@ -22,9 +22,7 @@ public class FileOutputStrategyTest {
                     Constants.ARG_RULE_KEY,
                     "4973",
                     Constants.ARG_FILE_OUTPUT_STRATEGY,
-                    FileOutputStrategy.CHANGED_ONLY.name(),
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE
+                    FileOutputStrategy.CHANGED_ONLY.name()
                 });
 
         File spooned = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.SPOONED);
@@ -43,9 +41,7 @@ public class FileOutputStrategyTest {
                     Constants.ARG_FILE_OUTPUT_STRATEGY,
                     FileOutputStrategy.ALL.name(),
                     Constants.ARG_PRETTY_PRINTING_STRATEGY,
-                    PrettyPrintingStrategy.NORMAL.name(),
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE
+                    PrettyPrintingStrategy.NORMAL.name()
                 });
 
         File spooned = new File(Constants.SORALD_WORKSPACE + File.separator + Constants.SPOONED);

--- a/src/test/java/sorald/RepairTest.java
+++ b/src/test/java/sorald/RepairTest.java
@@ -25,7 +25,6 @@ public class RepairTest {
         File targetFile = workdir.toPath().resolve(origFile.getName()).toFile();
         org.apache.commons.io.FileUtils.copyFile(origFile, targetFile);
         SoraldConfig config = new SoraldConfig();
-        config.setWorkspace(Constants.SORALD_WORKSPACE);
 
         Set<RuleViolation> violations =
                 Set.of("2111", "2184").stream()

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -146,7 +146,6 @@ public class SegmentStrategyTest {
         var config = new SoraldConfig();
         config.setRepairStrategy(RepairStrategy.SEGMENT);
         config.setOriginalFilesPath(originalFilesPath);
-        config.setWorkspace(Constants.SORALD_WORKSPACE);
         config.setFileOutputStrategy(FileOutputStrategy.CHANGED_ONLY);
         config.setMaxFixesPerRule(Integer.MAX_VALUE);
         config.setMaxFilesPerSegment(1);

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -34,7 +34,7 @@ public class SegmentStrategyTest {
         String fileName = "ArrayHashCodeAndToString.java";
         Path pathToBuggyFile = Constants.PATH_TO_RESOURCES_FOLDER.resolve(fileName);
         String pathToRepairedFile =
-                Constants.SORALD_WORKSPACE + "/SEGMENT/" + Constants.SPOONED + "/" + fileName;
+                Constants.SORALD_WORKSPACE + "/" + Constants.SPOONED + "/" + fileName;
 
         RuleVerifier.verifyHasIssue(
                 pathToBuggyFile.toString(), new ArrayHashCodeAndToStringCheck());
@@ -52,9 +52,7 @@ public class SegmentStrategyTest {
                     Constants.ARG_RULE_KEY,
                     "2116",
                     Constants.ARG_PRETTY_PRINTING_STRATEGY,
-                    PrettyPrintingStrategy.NORMAL.name(),
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE + "/SEGMENT/"
+                    PrettyPrintingStrategy.NORMAL.name()
                 });
         TestHelper.removeComplianceComments(pathToRepairedFile);
         RuleVerifier.verifyNoIssue(pathToRepairedFile, new ArrayHashCodeAndToStringCheck());
@@ -79,9 +77,7 @@ public class SegmentStrategyTest {
                     Constants.ARG_RULE_KEY,
                     "2116",
                     Constants.ARG_PRETTY_PRINTING_STRATEGY,
-                    PrettyPrintingStrategy.NORMAL.name(),
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE + "/SEGMENT/"
+                    PrettyPrintingStrategy.NORMAL.name()
                 };
         assertThrows(SystemExitHandler.NonZeroExit.class, () -> Main.main(args));
     }

--- a/src/test/java/sorald/processor/MaxFixesPerRuleTest.java
+++ b/src/test/java/sorald/processor/MaxFixesPerRuleTest.java
@@ -25,8 +25,6 @@ public class MaxFixesPerRuleTest {
                     pathToBuggyFile.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE,
                     Constants.ARG_MAX_FIXES_PER_RULE,
                     "3"
                 });

--- a/src/test/java/sorald/processor/NoSonarTest.java
+++ b/src/test/java/sorald/processor/NoSonarTest.java
@@ -25,8 +25,6 @@ public class NoSonarTest {
                     pathToBuggyFile.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE,
                     Constants.ARG_MAX_FIXES_PER_RULE,
                     "3"
                 });

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -144,8 +144,6 @@ public class ProcessorTestHelper {
                     originalFileAbspath,
                     Constants.ARG_RULE_KEY,
                     Checks.getRuleKey(checkClass),
-                    Constants.ARG_WORKSPACE,
-                    Constants.SORALD_WORKSPACE,
                     Constants.ARG_PRETTY_PRINTING_STRATEGY,
                     brokenWithSniper
                             ? PrettyPrintingStrategy.NORMAL.name()


### PR DESCRIPTION
#409 

This is in preparation of removing out-of-place repair. With that gone, there is no need for a separate workspace directory, and consequently there is no need for a CLI argument to specify it.

Note that this PR only removes the workspace argument, the workspace is still used for out-of-place repair but is hard-coded to `sorald-workspace`. I will follow up on this PR with a couple more such that, in the end, out-of-place repair is gone. See #432 for the complete (but pretty messy) vision.