### PR TITLE
feat: Validate violation specs

### DIFF
--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -137,7 +137,11 @@ class RepairCommand extends BaseCommand {
             specifiedRuleViolations.forEach(
                     specifiedViolation -> {
                         if (!minedViolations.contains(specifiedViolation)) {
-                            throw new IllegalStateException();
+                            throw new CommandLine.ParameterException(
+                                    spec.commandLine(),
+                                    "No actual violation matching violation spec: "
+                                            + specifiedViolation.relativeSpecifier(
+                                                    originalFilesPath.toPath()));
                         }
                     });
 

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -3,6 +3,7 @@ package sorald.cli;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,21 +136,27 @@ class RepairCommand extends BaseCommand {
 
         if (!specifiedRuleViolations.isEmpty()) {
             specifiedRuleViolations.forEach(
-                    specifiedViolation -> {
-                        if (!minedViolations.contains(specifiedViolation)) {
-                            throw new CommandLine.ParameterException(
-                                    spec.commandLine(),
-                                    "No actual violation matching violation spec: "
-                                            + specifiedViolation.relativeSpecifier(
-                                                    originalFilesPath.toPath()));
-                        }
-                    });
+                    specifiedViolation ->
+                            checkSpecifiedViolationExists(specifiedViolation, minedViolations));
 
             return minedViolations.stream()
                     .filter(specifiedRuleViolations::contains)
                     .collect(Collectors.toSet());
         } else {
             return minedViolations;
+        }
+    }
+
+    private void checkSpecifiedViolationExists(
+            RuleViolation specifiedViolation, Collection<RuleViolation> minedViolations) {
+        if (!minedViolations.contains(specifiedViolation)) {
+            String violationSpecifier =
+                    specifiedViolation.relativeSpecifier(originalFilesPath.toPath());
+            throw new CommandLine.ParameterException(
+                    spec.commandLine(),
+                    String.format(
+                            "No actual violation matching violation spec: '%s'",
+                            violationSpecifier));
         }
     }
 

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -3,7 +3,6 @@ package sorald.cli;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +35,7 @@ import sorald.sonar.RuleViolation;
         description = "Repair Sonar rule violations in a targeted project.")
 class RepairCommand extends BaseCommand {
     String ruleKey;
-    List<RuleViolation> ruleViolations = List.of();
+    List<RuleViolation> specifiedRuleViolations = List.of();
 
     @CommandLine.Option(
             names = {Constants.ARG_ORIGINAL_FILES_PATH},
@@ -131,17 +130,23 @@ class RepairCommand extends BaseCommand {
     }
 
     private Set<RuleViolation> resolveRuleViolations(List<SoraldEventHandler> eventHandlers) {
-        Set<RuleViolation> violations = null;
-        if (!eventHandlers.isEmpty() || ruleViolations.isEmpty()) {
-            // if there are event handlers, we must mine violations regardless of them being
-            // specified in the config or not in order to trigger the mined violation events
-            violations = mineViolations(originalFilesPath, ruleKey, eventHandlers);
-        }
-        if (!ruleViolations.isEmpty()) {
-            violations = new HashSet<>(ruleViolations);
-        }
+        Set<RuleViolation> minedViolations =
+                mineViolations(originalFilesPath, ruleKey, eventHandlers);
 
-        return violations;
+        if (!specifiedRuleViolations.isEmpty()) {
+            specifiedRuleViolations.forEach(
+                    specifiedViolation -> {
+                        if (!minedViolations.contains(specifiedViolation)) {
+                            throw new IllegalStateException();
+                        }
+                    });
+
+            return minedViolations.stream()
+                    .filter(specifiedRuleViolations::contains)
+                    .collect(Collectors.toSet());
+        } else {
+            return minedViolations;
+        }
     }
 
     /**
@@ -202,8 +207,8 @@ class RepairCommand extends BaseCommand {
 
     /** Perform further processing of raw command line args. */
     private void postprocessArgs() {
-        ruleViolations = parseRuleViolations(rules);
-        ruleKey = parseRuleKey(rules, ruleViolations);
+        specifiedRuleViolations = parseRuleViolations(rules);
+        ruleKey = parseRuleKey(rules, specifiedRuleViolations);
     }
 
     private List<RuleViolation> parseRuleViolations(Rules rules) {

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -1,6 +1,7 @@
 package sorald;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -148,7 +149,9 @@ public class TargetedRepairTest {
         assertThrows(SystemExitHandler.NonZeroExit.class, () -> Main.main(args));
         assertThat(
                 err.toString(),
-                containsString("No actual violation matching violation spec: " + violationSpec));
+                allOf(
+                        containsString("No actual violation matching violation spec:"),
+                        containsString(violationSpec)));
     }
 
     /** Setup the workdir with a specific target violation. */


### PR DESCRIPTION
Fix #395 

Adds validation to user-specified rule violations by checking that the precise violations specified actually exist. To be clear, it validates that violations specified like so exist:

```
$ sorald repair --violation-specs 2111:2111_BigDecimalDoubleConstructor/BigDecimalDoubleConstructor.java:21:25:21:45 [...]
```

 Previously, this was limited to the specified file existing. This new behavior is made possible by _always_ mining violations, which is something we'll need to do to implement #358 as well.

A downside is that this adds a performance overhead to specifying rule violations, as it requires a scan with Sonar that would otherwise not be necessary as we'd just assume that they are real. But, I think I'm pretty much the only one who currently uses targeted repair (I use it when developing), and I always run with stats output, which also requires a scan with Sonar, and so it doesn't matter to my use case.

The error message looks like so:

```
No actual violation matching violation spec: '2111:2111_BigDecimalDoubleConstructor/BigDecimalDoubleConstructor.java:21:25:21:45'
```