### PR TITLE
feat: Add message to rule violation

### DIFF
--- a/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sorald/processor/CastArithmeticOperandProcessor.java
@@ -66,6 +66,19 @@ public class CastArithmeticOperandProcessor extends SoraldAbstractProcessor<CtBi
         literalInt.replace(literalWithSuffix);
     }
 
+    /**
+     * Parse the message of a SonarJava rule violation to get the operation kind and type.
+     *
+     * <p>As of SonarJava 6.9.0.23563, the message can be on two forms.<br>
+     * <code>"Cast one of the operands of this integer division to a \"double\"."</code><br>
+     * <code>
+     * "Cast one of the operands of this " + OPERATION_BY_KIND.get(expr.kind()) + " operation to a \"" + varType.name() + "\"."
+     * </code><br>
+     *
+     * @param violation A rule violation
+     * @return The operator kind and type of the expression
+     * @see org.sonar.java.checks.CastArithmeticOperandCheck
+     */
     private Pair<BinaryOperatorKind, CtTypeReference<?>> getOpKindAndType(RuleViolation violation) {
         String message = violation.getMessage();
         Pattern p = Pattern.compile(".*?(\\w+)( operation)? to a \"(\\w+)\".*");

--- a/src/main/java/sorald/sonar/RuleViolation.java
+++ b/src/main/java/sorald/sonar/RuleViolation.java
@@ -30,6 +30,12 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
     /** @return The key of the violated rule. */
     public abstract String getRuleKey();
 
+    /** @return A message describing the problem. */
+    public String getMessage() {
+        throw new UnsupportedOperationException(
+                "getMessage() should not be called on this instance");
+    }
+
     /**
      * @param projectPath The root directory of the current project.
      * @return A violation specifier that is unique relative to the given project path.
@@ -55,6 +61,9 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
             return false;
         }
         var other = (RuleViolation) obj;
+
+        // IMPORTANT: The message is intentionally not part of the equality check to allow for
+        // comparing message-less implementations with those that do carry messages
         return getAbsolutePath().equals(other.getAbsolutePath())
                 && getCheckName().equals(other.getCheckName())
                 && getRuleKey().equals(other.getRuleKey())
@@ -66,6 +75,8 @@ public abstract class RuleViolation implements Comparable<RuleViolation> {
 
     @Override
     public int hashCode() {
+        // IMPORTANT: The message is intentionally not part of the hash code to allow for
+        // comparing message-less implementations with those that do carry messages
         return Objects.hash(
                 getAbsolutePath(),
                 getCheckName(),

--- a/src/main/java/sorald/sonar/ScannedViolation.java
+++ b/src/main/java/sorald/sonar/ScannedViolation.java
@@ -58,6 +58,11 @@ class ScannedViolation extends RuleViolation {
         return Checks.getRuleKey(message.getCheck().getClass());
     }
 
+    @Override
+    public String getMessage() {
+        return message.getMessage();
+    }
+
     private static String getCheckName(JavaCheck check) {
         return check.getClass().getSimpleName();
     }


### PR DESCRIPTION
Fix #358 

This adds a method `RuleViolation.getMessage()` that can be used to fetch the message emitted by Sonar. The reason we want this message is that it sometimes contains useful information. As a driver for the implementation and to illustrate that it's useful, I've refactored `CastArithmeticOperandProcessor` to use the message to parse the expected type.

See #375 for why it's proven inconvenient to try to get the type ourselves. Unfortunately, the test case provided there no longer causes a failure, as SonarJava does not flag a violation of rule 2184 inside method calls, it's only for assignments. The new, better position matching thus makes it impossible to trigger the bug, but it's still guaranteed to be gone as the method in which it was triggered `getExpectedtype()` has been removed.