### PR TITLE
break: Rename --original-files-path arg to --source

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,8 @@ jobs:
         env:
           SORALD_JAR_PATH: "target/sorald-1.1-SNAPSHOT-jar-with-dependencies.jar"
         run: |
-          java -jar "$SORALD_JAR_PATH" repair --original-files-path src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
-          java -jar "$SORALD_JAR_PATH" repair --original-files-path src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
+          java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
+          java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9 # v1.0.15
         with:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and are specified by their key. For example, to repair violations of the rule
 `some/project/path`, one can invoke Sorald like so.
 
 ```bash
-$ sorald repair --original-files-path some/project/path --rule-key 2111
+$ sorald repair --source some/project/path --rule-key 2111
 ```
 
 The full list of options is as follows (and can also be found by running
@@ -80,7 +80,7 @@ Repair Sonar rule violations in a targeted project.
                                segment.
       --max-fixes-per-rule=<maxFixesPerRule>
                              Max number of fixes per rule.
-      --original-files-path=<originalFilesPath>
+      --source=<source>
                              The path to the file or folder to be analyzed and
                                possibly repaired.
       --pretty-printing-strategy=<prettyPrintingStrategy>
@@ -168,7 +168,7 @@ To mine projects for Sonar warnings, use the `mine` command. Its most basic
 usage consists of simply pointing it to a project directory.
 
 ```bash
-$ sorald mine --original-files-path path/to/project
+$ sorald mine --source path/to/project
 ```
 
 It will then output statistics for that project with the Sonar checks available
@@ -194,7 +194,7 @@ mine --help`).
   -h, --help                 Show this help message and exit.
       --miner-output-file=<minerOutputFile>
                              The path to the output file.
-      --original-files-path=<originalFilesPath>
+      --source=<source>
                              The path to the file or folder to be analyzed and
                                possibly repaired.
       --rule-types=<ruleTypes>[,<ruleTypes>...]

--- a/experimentation/tools/README.md
+++ b/experimentation/tools/README.md
@@ -242,7 +242,7 @@ like this:
                     "2755",
                     "--file-output-strategy",
                     "IN_PLACE",
-                    "--original-files-path",
+                    "--source",
                     ".",
                     "--stats-output-file",
                     "stats.json"
@@ -382,7 +382,7 @@ After these three command shave been executed, my `prs.json` looks like this:
                     "2755",
                     "--file-output-strategy",
                     "IN_PLACE",
-                    "--original-files-path",
+                    "--source",
                     ".",
                     "--stats-output-file",
                     "stats.json"

--- a/experimentation/tools/sorald/benchmark.py
+++ b/experimentation/tools/sorald/benchmark.py
@@ -229,7 +229,7 @@ def run_sorald_for_rule(repo: git.Repo, rule_key: str) -> "RepairStats":
     with restore_head_after(repo):
         return_code, *_ = soraldwrapper.sorald(
             "repair",
-            original_files_path=pathlib.Path(repo.working_dir),
+            source=pathlib.Path(repo.working_dir),
             stats_output_file=workdir / stats_file,
             rule_key=rule_key,
             timeout=SINGLE_RUN_TIMEOUT,

--- a/experimentation/tools/sorald/warnings_extractor.py
+++ b/experimentation/tools/sorald/warnings_extractor.py
@@ -253,7 +253,7 @@ def extract_warning_stats_from_dir(
             "-jar",
             str(config.sorald_jar),
             "mine",
-            "--originalFilesPath",
+            "--source",
             str(root_path),
             *extra_args,
         ],

--- a/experimentation/tools/tests/resources/prs_final.json
+++ b/experimentation/tools/tests/resources/prs_final.json
@@ -65,7 +65,7 @@
                     "2755",
                     "--file-output-strategy",
                     "IN_PLACE",
-                    "--original-files-path",
+                    "--source",
                     ".",
                     "--stats-output-file",
                     "stats.json"

--- a/experimentation/tools/tests/resources/prs_initial.json
+++ b/experimentation/tools/tests/resources/prs_initial.json
@@ -65,7 +65,7 @@
                     "2755",
                     "--file-output-strategy",
                     "IN_PLACE",
-                    "--original-files-path",
+                    "--source",
                     ".",
                     "--stats-output-file",
                     "stats.json"

--- a/experimentation/tools/tests/resources/stats.json
+++ b/experimentation/tools/tests/resources/stats.json
@@ -51,7 +51,7 @@
             "2755",
             "--file-output-strategy",
             "IN_PLACE",
-            "--original-files-path",
+            "--source",
             ".",
             "--stats-output-file",
             "stats.json"

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -7,7 +7,7 @@ public class Constants {
     public static final String MINE_COMMAND_NAME = "mine";
 
     public static final String ARG_RULE_KEY = "--rule-key";
-    public static final String ARG_ORIGINAL_FILES_PATH = "--original-files-path";
+    public static final String ARG_SOURCE = "--source";
     public static final String ARG_STATS_ON_GIT_REPOS = "--stats-on-git-repos";
     public static final String ARG_STATS_OUTPUT_FILE = "--stats-output-file";
     public static final String ARG_MINER_OUTPUT_FILE = "--miner-output-file";

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -84,7 +84,7 @@ public class Repair {
         }
 
         String ruleKey = distinctRuleKeys.get(0);
-        Path inputDir = Path.of(config.getOriginalFilesPath());
+        Path inputDir = Path.of(config.getSource());
 
         SoraldAbstractProcessor<?> processor = createProcessor(Integer.parseInt(ruleKey));
         Stream<CtModel> models = repair(inputDir, processor, ruleViolations);

--- a/src/main/java/sorald/SoraldConfig.java
+++ b/src/main/java/sorald/SoraldConfig.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public class SoraldConfig {
     private PrettyPrintingStrategy prettyPrintingStrategy;
     private RepairStrategy repairStrategy;
-    private String originalFilesPath;
+    private String source;
     private int maxFixesPerRule;
     private int maxFilesPerSegment;
     private File statsOutputFile;
@@ -31,13 +31,12 @@ public class SoraldConfig {
         return this.repairStrategy;
     }
 
-    public void setOriginalFilesPath(String originalFilesPath) {
-        this.originalFilesPath =
-                Paths.get(originalFilesPath).normalize().toAbsolutePath().toString();
+    public void setSource(String source) {
+        this.source = Paths.get(source).normalize().toAbsolutePath().toString();
     }
 
-    public String getOriginalFilesPath() {
-        return this.originalFilesPath;
+    public String getSource() {
+        return this.source;
     }
 
     public void setMaxFixesPerRule(int maxFixesPerRule) {

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -23,9 +23,9 @@ import sorald.sonar.Checks;
 class MineCommand extends BaseCommand {
 
     @CommandLine.Option(
-            names = {Constants.ARG_ORIGINAL_FILES_PATH},
+            names = {Constants.ARG_SOURCE},
             description = "The path to the file or folder to be analyzed and possibly repaired.")
-    File originalFilesPath;
+    File source;
 
     @CommandLine.Option(
             names = Constants.ARG_STATS_ON_GIT_REPOS,
@@ -74,8 +74,7 @@ class MineCommand extends BaseCommand {
         } else {
             new MineSonarWarnings(statsOutputFile == null ? List.of() : List.of(statsCollector))
                     .mineLocalProject(
-                            checks,
-                            originalFilesPath.toPath().normalize().toAbsolutePath().toString());
+                            checks, source.toPath().normalize().toAbsolutePath().toString());
         }
 
         if (statsOutputFile != null) {

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -39,10 +39,10 @@ class RepairCommand extends BaseCommand {
     List<RuleViolation> specifiedRuleViolations = List.of();
 
     @CommandLine.Option(
-            names = {Constants.ARG_ORIGINAL_FILES_PATH},
+            names = {Constants.ARG_SOURCE},
             description = "The path to the file or folder to be analyzed and possibly repaired.",
             required = true)
-    File originalFilesPath;
+    File source;
 
     @CommandLine.ArgGroup(multiplicity = "1")
     Rules rules;
@@ -118,21 +118,17 @@ class RepairCommand extends BaseCommand {
 
         if (statsOutputFile != null) {
             // mine violations to trigger stats collection
-            mineViolations(originalFilesPath, ruleKey, eventHandlers);
+            mineViolations(source, ruleKey, eventHandlers);
             writeStatisticsOutput(
                     statsCollector,
-                    FileUtils.getClosestDirectory(originalFilesPath)
-                            .toPath()
-                            .toAbsolutePath()
-                            .normalize());
+                    FileUtils.getClosestDirectory(source).toPath().toAbsolutePath().normalize());
         }
 
         return 0;
     }
 
     private Set<RuleViolation> resolveRuleViolations(List<SoraldEventHandler> eventHandlers) {
-        Set<RuleViolation> minedViolations =
-                mineViolations(originalFilesPath, ruleKey, eventHandlers);
+        Set<RuleViolation> minedViolations = mineViolations(source, ruleKey, eventHandlers);
 
         if (!specifiedRuleViolations.isEmpty()) {
             specifiedRuleViolations.forEach(
@@ -151,7 +147,7 @@ class RepairCommand extends BaseCommand {
             RuleViolation specifiedViolation, Collection<RuleViolation> minedViolations) {
         if (!minedViolations.contains(specifiedViolation)) {
             String violationSpecifier =
-                    specifiedViolation.relativeSpecifier(originalFilesPath.toPath());
+                    specifiedViolation.relativeSpecifier(source.toPath());
             throw new CommandLine.ParameterException(
                     spec.commandLine(),
                     String.format(
@@ -248,14 +244,14 @@ class RepairCommand extends BaseCommand {
         String[] parts = violationSpecifier.split(Constants.VIOLATION_SPECIFIER_SEP);
         String key = parts[0];
         String rawFilename = parts[1];
-        Path absPath = originalFilesPath.toPath().resolve(rawFilename).toAbsolutePath().normalize();
+        Path absPath = source.toPath().resolve(rawFilename).toAbsolutePath().normalize();
 
         if (!absPath.toFile().isFile()) {
             throw new CommandLine.ParameterException(
                     spec.commandLine(),
                     String.format(
                             "Invalid violation ID '%s', no file '%s' in directory '%s'",
-                            violationSpecifier, rawFilename, originalFilesPath));
+                            violationSpecifier, rawFilename, source));
         }
 
         int startLine = Integer.parseInt(parts[2]);
@@ -273,7 +269,7 @@ class RepairCommand extends BaseCommand {
 
     private SoraldConfig createConfig() {
         SoraldConfig config = new SoraldConfig();
-        config.setOriginalFilesPath(originalFilesPath.getAbsolutePath());
+        config.setSource(source.getAbsolutePath());
         config.setPrettyPrintingStrategy(prettyPrintingStrategy);
         config.setMaxFixesPerRule(maxFixesPerRule);
         config.setMaxFilesPerSegment(maxFilesPerSegment);

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -146,8 +146,7 @@ class RepairCommand extends BaseCommand {
     private void checkSpecifiedViolationExists(
             RuleViolation specifiedViolation, Collection<RuleViolation> minedViolations) {
         if (!minedViolations.contains(specifiedViolation)) {
-            String violationSpecifier =
-                    specifiedViolation.relativeSpecifier(source.toPath());
+            String violationSpecifier = specifiedViolation.relativeSpecifier(source.toPath());
             throw new CommandLine.ParameterException(
                     spec.commandLine(),
                     String.format(

--- a/src/test/java/sorald/GatherStatsTest.java
+++ b/src/test/java/sorald/GatherStatsTest.java
@@ -161,7 +161,7 @@ public class GatherStatsTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     project.getAbsolutePath(),
                     Constants.ARG_STATS_OUTPUT_FILE,
                     statsFile.getAbsolutePath(),

--- a/src/test/java/sorald/MavenLauncherTest.java
+++ b/src/test/java/sorald/MavenLauncherTest.java
@@ -29,7 +29,7 @@ public class MavenLauncherTest {
         String[] args =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workdir.getAbsolutePath(),
                     Constants.ARG_RULE_KEY,
                     "1854",

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -45,7 +45,7 @@ public class SegmentStrategyTest {
                     // https://github.com/SpoonLabs/sorald/issues/154
                     Constants.ARG_MAX_FILES_PER_SEGMENT,
                     "1",
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workspace.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",
@@ -71,7 +71,7 @@ public class SegmentStrategyTest {
                     "SEGMENT",
                     Constants.ARG_MAX_FILES_PER_SEGMENT,
                     "0",
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workspace.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",
@@ -137,10 +137,10 @@ public class SegmentStrategyTest {
                 .get();
     }
 
-    private static SoraldConfig createSegmentConfig(Path originalFilesPath) {
+    private static SoraldConfig createSegmentConfig(Path source) {
         var config = new SoraldConfig();
         config.setRepairStrategy(RepairStrategy.SEGMENT);
-        config.setOriginalFilesPath(originalFilesPath.toString());
+        config.setSource(source.toString());
         config.setMaxFixesPerRule(Integer.MAX_VALUE);
         config.setMaxFilesPerSegment(1);
         return config;

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -37,7 +37,7 @@ public class TargetedRepairTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workdirInfo.workdir.getAbsolutePath(),
                     Constants.ARG_RULE_VIOLATION_SPECIFIERS,
                     workdirInfo.targetViolation.relativeSpecifier(workdirInfo.workdir.toPath())
@@ -60,7 +60,7 @@ public class TargetedRepairTest {
         var args =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workdir.getAbsolutePath(),
                     Constants.ARG_RULE_VIOLATION_SPECIFIERS,
                     workdirInfo.targetViolation.relativeSpecifier(workdir.toPath()),
@@ -84,7 +84,7 @@ public class TargetedRepairTest {
         var args =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workdir.getAbsolutePath(),
                     Constants.ARG_RULE_VIOLATION_SPECIFIERS,
                     badViolationId
@@ -110,7 +110,7 @@ public class TargetedRepairTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     workdirInfo.workdir.toString(),
                     Constants.ARG_RULE_VIOLATION_SPECIFIERS,
                     absoluteViolationId
@@ -136,7 +136,7 @@ public class TargetedRepairTest {
 
         String[] args = {
             Constants.REPAIR_COMMAND_NAME,
-            Constants.ARG_ORIGINAL_FILES_PATH,
+            Constants.ARG_SOURCE,
             workdirInfo.workdir.toString(),
             Constants.ARG_RULE_VIOLATION_SPECIFIERS,
             violationSpec

--- a/src/test/java/sorald/event/collectors/CompilationUnitCollectorTest.java
+++ b/src/test/java/sorald/event/collectors/CompilationUnitCollectorTest.java
@@ -21,12 +21,12 @@ class CompilationUnitCollectorTest {
     public void collect_canCollectManyCompilationUnits() {
         // arrange
         Launcher launcher = new Launcher();
-        String originalFilesPath = ProcessorTestHelper.TEST_FILES_ROOT.toAbsolutePath().toString();
+        String source = ProcessorTestHelper.TEST_FILES_ROOT.toAbsolutePath().toString();
         var config = new SoraldConfig();
-        config.setOriginalFilesPath(originalFilesPath);
+        config.setSource(source);
         var cuCollector = new CompilationUnitCollector();
 
-        launcher.addInputResource(originalFilesPath);
+        launcher.addInputResource(source);
         Collection<CtType<?>> types = launcher.buildModel().getAllTypes();
         var expectedCUs = launcher.getFactory().CompilationUnit().getMap().values();
 

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -130,9 +130,7 @@ public class WarningMinerTest {
 
         Main.main(
                 new String[] {
-                    Constants.MINE_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
-                    workdir.toString()
+                    Constants.MINE_COMMAND_NAME, Constants.ARG_SOURCE, workdir.toString()
                 });
 
         assertThat(out.toString(), containsString("MathOnFloatCheck=1"));

--- a/src/test/java/sorald/processor/MaxFixesPerRuleTest.java
+++ b/src/test/java/sorald/processor/MaxFixesPerRuleTest.java
@@ -22,7 +22,7 @@ public class MaxFixesPerRuleTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     pathToBuggyFile.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",

--- a/src/test/java/sorald/processor/NoSonarTest.java
+++ b/src/test/java/sorald/processor/NoSonarTest.java
@@ -19,7 +19,7 @@ public class NoSonarTest {
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     pathToBuggyFile.toString(),
                     Constants.ARG_RULE_KEY,
                     "2116",

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -141,7 +141,7 @@ public class ProcessorTestHelper {
         var coreArgs =
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,
-                    Constants.ARG_ORIGINAL_FILES_PATH,
+                    Constants.ARG_SOURCE,
                     originalFileAbspath,
                     Constants.ARG_RULE_KEY,
                     Checks.getRuleKey(checkClass),


### PR DESCRIPTION
Fix #429 

This PR renames the argument, and also updates all corresponding variable names in the source code, as well as updating docs and scripts.

I swear that I did not mistype the argument in `Rename --origina-files-path arg to --source` on purpose; it's just really error prone! :)