### PR TITLE
chore: Move Spoon snapshot repo into a profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,16 +18,6 @@
         </license>
     </licenses>
 
-    <repositories>
-        <repository>
-            <!--This repository is normally unused in the committed version of this pom file, but we use it to quickly
-            test new changes in Spoon, so please leave it in here :) -->
-            <id>ow2.org-snapshot</id>
-            <name>Maven Repository for Spoon Snapshots</name>
-            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>info.picocli</groupId>
@@ -335,6 +325,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>spoonSnapshot</id>
+            <repositories>
+                <repository>
+                    <id>ow2.org-snapshot</id>
+                    <name>Maven Repository for Spoon Snapshots</name>
+                    <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+                    <snapshots><enabled>true</enabled></snapshots>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
 


### PR DESCRIPTION
We shouldn't declare the snapshot repository willy-nilly in the pom-file, see discussion over at inria/spoon#3216. This PR puts the snapshot repo in a profile, such that we can still easily access it when we want like so:

```
$ mvn -P spoonSnapshot ...
```