### PR TITLE
fix: Handle symlinks in input (add macOS support)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -16,14 +16,21 @@ import org.json.JSONObject;
 public class FileUtils {
 
     /**
-     * Compare the two given paths as absolute, normalized paths.
+     * Compare the two given paths as real paths, resolving any symbolic links.
+     *
+     * <p>Note that this method returns false if either path does not exist, even if the paths are
+     * otherwise equal!
      *
      * @param lhs A path.
      * @param rhs A path.
-     * @return Whether or not the paths are equal as absolute, normalized paths.
+     * @return true iff both paths exist and point to the same real file
      */
-    public static boolean pathAbsNormEqual(Path lhs, Path rhs) {
-        return lhs.toAbsolutePath().normalize().equals(rhs.toAbsolutePath().normalize());
+    public static boolean realPathEquals(Path lhs, Path rhs) {
+        try {
+            return lhs.toRealPath().equals(rhs.toRealPath());
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/sorald/cli/RealFileConverter.java
+++ b/src/main/java/sorald/cli/RealFileConverter.java
@@ -1,0 +1,13 @@
+package sorald.cli;
+
+import java.io.File;
+import java.nio.file.Paths;
+import picocli.CommandLine;
+
+/** Converter that converts a String to a real file that's validated to exist in the file system. */
+public class RealFileConverter implements CommandLine.ITypeConverter<File> {
+    @Override
+    public File convert(String s) throws Exception {
+        return Paths.get(s).normalize().toRealPath().toFile();
+    }
+}

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -3,6 +3,7 @@ package sorald.cli;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -213,15 +214,17 @@ class RepairCommand extends BaseCommand {
     }
 
     /** Perform further processing of raw command line args. */
-    private void postprocessArgs() {
+    private void postprocessArgs() throws IOException {
         specifiedRuleViolations = parseRuleViolations(rules);
         ruleKey = parseRuleKey(rules, specifiedRuleViolations);
     }
 
-    private List<RuleViolation> parseRuleViolations(Rules rules) {
-        return rules.ruleViolationSpecifiers.stream()
-                .map(this::parseRuleViolation)
-                .collect(Collectors.toUnmodifiableList());
+    private List<RuleViolation> parseRuleViolations(Rules rules) throws IOException {
+        List<RuleViolation> violations = new ArrayList<>();
+        for (var spec : rules.ruleViolationSpecifiers) {
+            violations.add(parseRuleViolation(spec));
+        }
+        return violations;
     }
 
     private String parseRuleKey(Rules rules, List<RuleViolation> ruleViolations) {
@@ -240,20 +243,11 @@ class RepairCommand extends BaseCommand {
         }
     }
 
-    private RuleViolation parseRuleViolation(String violationSpecifier) {
+    private RuleViolation parseRuleViolation(String violationSpecifier) throws IOException {
         String[] parts = violationSpecifier.split(Constants.VIOLATION_SPECIFIER_SEP);
         String key = parts[0];
         String rawFilename = parts[1];
-        Path absPath = source.toPath().resolve(rawFilename).toAbsolutePath().normalize();
-
-        if (!absPath.toFile().isFile()) {
-            throw new CommandLine.ParameterException(
-                    spec.commandLine(),
-                    String.format(
-                            "Invalid violation ID '%s', no file '%s' in directory '%s'",
-                            violationSpecifier, rawFilename, source));
-        }
-
+        Path absPath = source.toPath().resolve(rawFilename).toRealPath();
         int startLine = Integer.parseInt(parts[2]);
         int startCol = Integer.parseInt(parts[3]);
         int endLine = Integer.parseInt(parts[4]);

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -41,7 +41,8 @@ class RepairCommand extends BaseCommand {
     @CommandLine.Option(
             names = {Constants.ARG_SOURCE},
             description = "The path to the file or folder to be analyzed and possibly repaired.",
-            required = true)
+            required = true,
+            converter = RealFileConverter.class)
     File source;
 
     @CommandLine.ArgGroup(multiplicity = "1")

--- a/src/main/java/sorald/sonar/BestFitScanner.java
+++ b/src/main/java/sorald/sonar/BestFitScanner.java
@@ -93,7 +93,13 @@ public class BestFitScanner<E extends CtElement> extends CtScanner {
 
     private boolean isTypeInFileWithoutViolations(CtElement element) {
         return element instanceof CtType
-                && !filesWithViolations.contains(element.getPosition().getFile());
+                && element.getPosition().isValidPosition()
+                && filesWithViolations.stream()
+                        .noneMatch(
+                                fileWithViolation ->
+                                        FileUtils.realPathEquals(
+                                                fileWithViolation.toPath(),
+                                                element.getPosition().getFile().toPath()));
     }
 
     @Override
@@ -253,7 +259,7 @@ public class BestFitScanner<E extends CtElement> extends CtScanner {
 
     private static boolean inSameFile(CtElement element, RuleViolation violation) {
         return element.getPosition().isValidPosition()
-                && FileUtils.pathAbsNormEqual(
+                && FileUtils.realPathEquals(
                         violation.getAbsolutePath(), element.getPosition().getFile().toPath());
     }
 

--- a/src/test/java/sorald/FileUtilsTest.java
+++ b/src/test/java/sorald/FileUtilsTest.java
@@ -1,5 +1,7 @@
 package sorald;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,5 +64,17 @@ public class FileUtilsTest {
     public void getExtension_returnsEmptyString_whenFileLacksExtension() {
         File fileWithoutExtension = new File("path/to/some/file");
         assertEquals("", FileUtils.getExtension(fileWithoutExtension));
+    }
+
+    /**
+     * This is an unintuitive part of the method: if two paths are precisely equal, but they don't
+     * exist in the file system, the method returns false!
+     */
+    @Test
+    void realPathEquals_returnsFalse_whenEqualPathsDoNotExist() {
+        Path lhs = Path.of("/a/path/that/certainly/does/not/exist");
+        Path rhs = Path.of(lhs.toString());
+
+        assertThat(FileUtils.realPathEquals(lhs, rhs), equalTo(false));
     }
 }


### PR DESCRIPTION
Fix #416
Fix #428

This PR adds a macOS build and fixes all test errors on macOS. They're all related to symbolic links. When creating a temporary directory on macOS (which we do e.g. in `TestHelper.createTemporaryTestResourceWorkspace()`), it's created in the `/var` directory. However, that's actually a symlink to `/private/var`, but the path you get back starts with `/var`. This causes problems, as Spoon always fully resolves symlinks while Sorald otherwise does not.

In order to debug and test this on a non-macOS system, I also added a hidden part to the test suite: if you set the environment variable `SORALD_TEST_SYMLINK_WORKSPACE=true`, then `TestHelper` returns a symlink to the temporary workspaces it creates, rather than a real path to the workspace. This does not however need to be active in tests, as it's covered by the new macOS build.