### PR TITLE
chore: Use Spoon 9.1.0-beta-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>8.4.0-beta-18</version>
+            <version>9.1.0-beta-2</version>
             <exclusions>
                 <exclusion>
                     <!-- must be excluded as it is signed, which causes problems with unsigned version from sonar -->


### PR DESCRIPTION
Fix #445 

Updates to Spoon 9.1.0-beta-2.

This version includes a bugfix for the sniper printer, where it failed to print a newline when adding elements to the beginning of a statement list/method list. Where previously some of our patches that add to the beginning of a class body or statement list would look like this:

```diff
-public class CtLineElementComparator implements Comparator<CtElement>, Serializable {
+public class CtLineElementComparator implements Comparator<CtElement>, Serializable {static final long serialVersionUID = 1L;
```

They now look like this:

```diff
 public class CtLineElementComparator implements Comparator<CtElement>, Serializable {
+       static final long serialVersionUID = 1L;
```