### PR TITLE
feat(2057): Make newly added serialVersionUID field private

### DIFF
--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -480,7 +480,7 @@ The repair consists of add a serialVersionUID to classes implementing Serializab
 Example:
 ```diff
 public class NoUID implements Serializable {
-+  static final long serialVersionUID = 1L;
++  private static final long serialVersionUID = 1L;
 }
 ```
 

--- a/src/main/java/sorald/processor/SerialVersionUidProcessor.java
+++ b/src/main/java/sorald/processor/SerialVersionUidProcessor.java
@@ -67,6 +67,9 @@ public class SerialVersionUidProcessor extends SoraldAbstractProcessor<CtClass<?
             }
             serialVersionUIDField.replace(replacement);
         } else {
+            // We add a new field, and it makes most sense to make it private as it is definitely
+            // not used in the project
+            replacement.addModifier(ModifierKind.PRIVATE);
             element.addFieldAtTop(replacement);
         }
     }

--- a/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NestedInAbstract.java.expected
+++ b/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NestedInAbstract.java.expected
@@ -7,6 +7,6 @@ import java.io.Serializable;
 
 public abstract class NestedInAbstract implements Serializable {
     public static class Serial implements Serializable { // Noncompliant
-        static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NestedInNestedGuiClass.java.expected
+++ b/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NestedInNestedGuiClass.java.expected
@@ -11,7 +11,7 @@ import java.io.Serializable;
 public class NestedInNestedGuiClass {
     public static class GuiClass extends java.awt.Canvas implements Serializable {
         public static class Serial implements Serializable { // Noncompliant
-            static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
         }
     }
 }

--- a/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NestedInThrowable.expected
+++ b/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NestedInThrowable.expected
@@ -7,6 +7,6 @@ import java.io.Serializable;
 
 public class NestedInThrowable extends Throwable implements Serializable {
     public static class Serial implements Serializable { // Noncompliant
-        static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NonSerial.java.expected
+++ b/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/NonSerial.java.expected
@@ -1,6 +1,6 @@
 import java.io.Serializable;
 public class NonSerial {
     public static class Serial implements Serializable { // Noncompliant
-      static final long serialVersionUID = 1L;
+      private static final long serialVersionUID = 1L;
     }
 }

--- a/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/SupertypeImplementsSerializable.java.expected
+++ b/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/SupertypeImplementsSerializable.java.expected
@@ -7,5 +7,5 @@ import java.io.Serializable;
 import java.util.ArrayList; // implements serializable
 
 public class SupertypeImplementsSerializable extends ArrayList<Integer> {
-    static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/UpperClass.java.expected
+++ b/src/test/resources/processor_test_files/2057_SerialVersionUidCheck/UpperClass.java.expected
@@ -2,5 +2,5 @@
 import java.io.Serializable;
 
 class UpperClass implements Serializable { // Noncompliant
-  static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 }


### PR DESCRIPTION
Fix #457 

Adds the `private` visibility to a `serialVersionUID` field if the field is _created_ by the processor, rather than the processor modifying an existing field. It makes most sense to make new fields private, as they're guaranteed not to be accessed anywhere else in the project (as they didn't exist prior to the repair!).