### PR TITLE
feat(2142): Add type check when catch clause contains multiple types

### DIFF
--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -1,15 +1,19 @@
 package sorald.processor;
 
 import sorald.annotations.ProcessorAnnotation;
+import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtThrow;
 import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.factory.Factory;
 
 @ProcessorAnnotation(key = 2142, description = "\"InterruptedException\" should not be ignored")
@@ -27,7 +31,13 @@ public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCat
         CtInvocation<?> secondInvocation =
                 factory.createInvocation(firstInvocation, interruptMethod.getReference());
 
-        element.getBody().addStatement(lastSafeInterruptIndex(element.getBody()), secondInvocation);
+        CtStatement statementToInsert =
+                mustTypeCheckCatchVariable(element)
+                        ? wrapInTypeCheck(element.getParameter(), secondInvocation)
+                        : secondInvocation;
+
+        element.getBody()
+                .addStatement(lastSafeInterruptIndex(element.getBody()), statementToInsert);
     }
 
     /**
@@ -56,5 +66,24 @@ public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCat
                 .filterChildren(e -> e instanceof CtReturn || e instanceof CtThrow)
                 .list()
                 .isEmpty();
+    }
+
+    private static boolean mustTypeCheckCatchVariable(CtCatch ctCatch) {
+        return ctCatch.getParameter().getMultiTypes().size() != 1;
+    }
+
+    private static CtIf wrapInTypeCheck(CtVariable<?> varToCheck, CtStatement statementToWrap) {
+        Factory fact = varToCheck.getFactory();
+        CtVariableAccess<?> varRead = fact.createVariableRead(varToCheck.getReference(), false);
+        CtTypeAccess<?> interruptedExcAccess =
+                fact.createTypeAccess(fact.Type().get(InterruptedException.class).getReference());
+
+        CtIf ctIf = fact.createIf();
+        ctIf.setCondition(
+                fact.createBinaryOperator(
+                        varRead, interruptedExcAccess, BinaryOperatorKind.INSTANCEOF));
+        ctIf.setThenStatement(statementToWrap);
+
+        return ctIf;
     }
 }

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java
@@ -1,0 +1,20 @@
+import java.util.concurrent.ExecutionException;
+
+/**
+ We should only set the interrupted flag if an interrupt actually occurred, so when a catch has
+ multiple types in the catch clause, we need to do a type check.
+ */
+
+public class CatchMultipleTypes {
+    public static void method() {
+        try {
+            if (1 < 2) {
+                throw new ExecutionException(new RuntimeException());
+            } else {
+                throw new InterruptedException();
+            }
+        } catch (InterruptedException | ExecutionException e) { // Noncompliant
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java
@@ -1,9 +1,8 @@
-import java.util.concurrent.ExecutionException;
-
-/**
- We should only set the interrupted flag if an interrupt actually occurred, so when a catch has
- multiple types in the catch clause, we need to do a type check.
+/*
+We should only set the interrupted flag if an interrupt actually occurred, so when a catch has
+multiple types in the catch clause, we need to do a type check.
  */
+import java.util.concurrent.ExecutionException;
 
 public class CatchMultipleTypes {
     public static void method() {

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java.expected
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java.expected
@@ -1,0 +1,23 @@
+import java.util.concurrent.ExecutionException;
+
+/**
+ We should only set the interrupted flag if an interrupt actually occurred, so when a catch has
+ multiple types in the catch clause, we need to do a type check.
+ */
+
+public class CatchMultipleTypes {
+    public static void method() {
+        try {
+            if (1 < 2) {
+                throw new ExecutionException(new RuntimeException());
+            } else {
+                throw new InterruptedException();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java.expected
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java.expected
@@ -1,9 +1,8 @@
-import java.util.concurrent.ExecutionException;
-
-/**
- We should only set the interrupted flag if an interrupt actually occurred, so when a catch has
- multiple types in the catch clause, we need to do a type check.
+/*
+We should only set the interrupted flag if an interrupt actually occurred, so when a catch has
+multiple types in the catch clause, we need to do a type check.
  */
+import java.util.concurrent.ExecutionException;
 
 public class CatchMultipleTypes {
     public static void method() {

--- a/src/test/resources/processor_test_files/2142_InterruptedException/InterruptedExceptionForTesting.java.expected
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/InterruptedExceptionForTesting.java.expected
@@ -48,7 +48,9 @@ class InterruptedExceptionForTesting {
 				throw new IOException();
 			}
 		} catch (InterruptedException | IOException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
-			Thread.currentThread().interrupt();
+			if (e instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix #459 

This PR makes the `InterruptedExceptionProcessor` insert a type check when a catch clause catches more than just an `InterruptedException`. This is to avoid setting the interrupt flag when something other that `InterruptedException` was actually caught. Here's an example transformation:

```diff

public class CatchMultipleTypes {
    public static void method() {
        try {
            if (1 < 2) {
                throw new ExecutionException(new RuntimeException());
            } else {
                throw new InterruptedException();
            }
        } catch (InterruptedException | ExecutionException e) { // Noncompliant
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
            throw new RuntimeException(e);
        }
    }
}
```

I need this to fix a [violation in Spoon](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&issues=AXh4mEuvLwoiZThdxVl5&open=AXh4mEuvLwoiZThdxVl5&q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) that I'm not super proud to say that I introduced myself :). Let's say I planted it there for an excuse to improve this processor ...