### PR TITLE
chore: Add developer information to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
             <id>slarse</id>
             <name>Simon Larsén</name>
             <email>slarse@kth.se</email>
+            <organization>KTH Royal Institute of Technology</organization>
+            <organizationUrl>https://www.kth.se</organizationUrl>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,14 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <id>slarse</id>
+            <name>Simon Larsén</name>
+            <email>slarse@kth.se</email>
+        </developer>
+    </developers>
+
     <dependencies>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
             <organization>KTH Royal Institute of Technology</organization>
             <organizationUrl>https://www.kth.se</organizationUrl>
         </developer>
+        <developer>
+            <id>fermadeiral</id>
+            <name>Fernanda Madeiral</name>
+            <email>fer.madeiral@gmail.com</email>
+            <organization>KTH Royal Institute of Technology</organization>
+            <organizationUrl>https://www.kth.se</organizationUrl>
+        </developer>
     </developers>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,13 @@
             <organization>KTH Royal Institute of Technology</organization>
             <organizationUrl>https://www.kth.se</organizationUrl>
         </developer>
+        <developer>
+            <id>khaes-kth</id>
+            <name>Khashayar Etemadi</name>
+            <email>khaes@kth.se</email>
+            <organization>KTH Royal Institute of Technology</organization>
+            <organizationUrl>https://www.kth.se</organizationUrl>
+        </developer>
     </developers>
 
     <dependencies>


### PR DESCRIPTION
Sonatype requires that the pom file contains [developer information](https://central.sonatype.org/pages/requirements.html#developer-information). Here's for example the corresponding entry in Depclean: https://github.com/castor-software/depclean/blob/add262810f6d1b93b44d31431d69c7d14cad1cd6/pom.xml#L62-L70

I figured we'll just put the currently active developers, which would be at least myself, and then possibly @fermadeiral and @khaes-kth. @fermadeiral @khaes-kth would you like to be added, and if so, with what details (email, organization etc)?

What should we put as organization? Since we're publishing under Castor's group id, I suppose we put Castor there? Perhaps it doesn't really matter, we could just put "KTH" for everyone.