### PR TITLE
fix: Fix violations of Sonar rule 1118

### DIFF
--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -3,8 +3,8 @@ package sorald;
 import java.io.File;
 
 public class Constants {
-    private Constants() {
-    }
+    private Constants() {}
+
     public static final String REPAIR_COMMAND_NAME = "repair";
     public static final String MINE_COMMAND_NAME = "mine";
 

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -3,6 +3,8 @@ package sorald;
 import java.io.File;
 
 public class Constants {
+    private Constants() {
+    }
     public static final String REPAIR_COMMAND_NAME = "repair";
     public static final String MINE_COMMAND_NAME = "mine";
 

--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -14,8 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class FileUtils {
-    private FileUtils() {
-    }
+    private FileUtils() {}
 
     /**
      * Compare the two given paths as real paths, resolving any symbolic links.

--- a/src/main/java/sorald/FileUtils.java
+++ b/src/main/java/sorald/FileUtils.java
@@ -14,6 +14,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class FileUtils {
+    private FileUtils() {
+    }
 
     /**
      * Compare the two given paths as real paths, resolving any symbolic links.

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -8,6 +8,8 @@ import sorald.processor.*;
  * change any of the generated fields unless you know precisely what you are doing.
  */
 public class Processors {
+    private Processors() {
+    }
     // GENERATED FIELD
     private static final Map<Integer, Class<? extends SoraldAbstractProcessor<?>>>
             RULE_KEY_TO_PROCESSOR =

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -9,6 +9,7 @@ import sorald.processor.*;
  */
 public class Processors {
     private Processors() {}
+
     // GENERATED FIELD
     private static final Map<Integer, Class<? extends SoraldAbstractProcessor<?>>>
             RULE_KEY_TO_PROCESSOR =

--- a/src/main/java/sorald/Processors.java
+++ b/src/main/java/sorald/Processors.java
@@ -8,8 +8,7 @@ import sorald.processor.*;
  * change any of the generated fields unless you know precisely what you are doing.
  */
 public class Processors {
-    private Processors() {
-    }
+    private Processors() {}
     // GENERATED FIELD
     private static final Map<Integer, Class<? extends SoraldAbstractProcessor<?>>>
             RULE_KEY_TO_PROCESSOR =

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -5,8 +5,7 @@ import picocli.CommandLine;
 
 /** Class containing the CLI for Sorald. */
 public class Cli {
-    private Cli() {
-    }
+    private Cli() {}
 
     /** @return Sorald's command line interface. */
     public static CommandLine createCli() {

--- a/src/main/java/sorald/cli/Cli.java
+++ b/src/main/java/sorald/cli/Cli.java
@@ -5,6 +5,8 @@ import picocli.CommandLine;
 
 /** Class containing the CLI for Sorald. */
 public class Cli {
+    private Cli() {
+    }
 
     /** @return Sorald's command line interface. */
     public static CommandLine createCli() {

--- a/src/main/java/sorald/event/EventHelper.java
+++ b/src/main/java/sorald/event/EventHelper.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 
 /** Helper methods for firing off events. */
 public class EventHelper {
+    private EventHelper() {
+    }
 
     /**
      * Register an event with the given type with all handlers.

--- a/src/main/java/sorald/event/EventHelper.java
+++ b/src/main/java/sorald/event/EventHelper.java
@@ -4,8 +4,7 @@ import java.util.Collection;
 
 /** Helper methods for firing off events. */
 public class EventHelper {
-    private EventHelper() {
-    }
+    private EventHelper() {}
 
     /**
      * Register an event with the given type with all handlers.

--- a/src/main/java/sorald/event/StatsMetadataKeys.java
+++ b/src/main/java/sorald/event/StatsMetadataKeys.java
@@ -2,8 +2,7 @@ package sorald.event;
 
 /** Metadata keys used for the stats JSON file. */
 public class StatsMetadataKeys {
-    private StatsMetadataKeys() {
-    }
+    private StatsMetadataKeys() {}
     // General data
     public static final String REPAIRS = "repairs";
     public static final String ORIGINAL_ARGS = "originalArgs";

--- a/src/main/java/sorald/event/StatsMetadataKeys.java
+++ b/src/main/java/sorald/event/StatsMetadataKeys.java
@@ -2,6 +2,8 @@ package sorald.event;
 
 /** Metadata keys used for the stats JSON file. */
 public class StatsMetadataKeys {
+    private StatsMetadataKeys() {
+    }
     // General data
     public static final String REPAIRS = "repairs";
     public static final String ORIGINAL_ARGS = "originalArgs";

--- a/src/main/java/sorald/segment/FirstFitSegmentationAlgorithm.java
+++ b/src/main/java/sorald/segment/FirstFitSegmentationAlgorithm.java
@@ -4,6 +4,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class FirstFitSegmentationAlgorithm {
+    private FirstFitSegmentationAlgorithm() {
+    }
 
     public static LinkedList<LinkedList<Node>> segment(Node startNode, int maxFiles) {
         LinkedList<Node> resources4Repair = new LinkedList<Node>();

--- a/src/main/java/sorald/segment/FirstFitSegmentationAlgorithm.java
+++ b/src/main/java/sorald/segment/FirstFitSegmentationAlgorithm.java
@@ -4,8 +4,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class FirstFitSegmentationAlgorithm {
-    private FirstFitSegmentationAlgorithm() {
-    }
+    private FirstFitSegmentationAlgorithm() {}
 
     public static LinkedList<LinkedList<Node>> segment(Node startNode, int maxFiles) {
         LinkedList<Node> resources4Repair = new LinkedList<Node>();

--- a/src/main/java/sorald/segment/SoraldTreeBuilderAlgorithm.java
+++ b/src/main/java/sorald/segment/SoraldTreeBuilderAlgorithm.java
@@ -4,6 +4,8 @@ import java.io.File;
 import sorald.Constants;
 
 public class SoraldTreeBuilderAlgorithm {
+    private SoraldTreeBuilderAlgorithm() {
+    }
 
     public static Node buildTree(String dirPathAbsolutePath) {
         Node startNode = new Node(dirPathAbsolutePath);

--- a/src/main/java/sorald/segment/SoraldTreeBuilderAlgorithm.java
+++ b/src/main/java/sorald/segment/SoraldTreeBuilderAlgorithm.java
@@ -4,8 +4,7 @@ import java.io.File;
 import sorald.Constants;
 
 public class SoraldTreeBuilderAlgorithm {
-    private SoraldTreeBuilderAlgorithm() {
-    }
+    private SoraldTreeBuilderAlgorithm() {}
 
     public static Node buildTree(String dirPathAbsolutePath) {
         Node startNode = new Node(dirPathAbsolutePath);

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -12,6 +12,8 @@ import sorald.FileUtils;
 
 /** Helper class that uses Sonar to scan projects for rule violations. */
 public class ProjectScanner {
+    private ProjectScanner() {
+    }
 
     /**
      * Scan a project for rule violations.

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -12,8 +12,7 @@ import sorald.FileUtils;
 
 /** Helper class that uses Sonar to scan projects for rule violations. */
 public class ProjectScanner {
-    private ProjectScanner() {
-    }
+    private ProjectScanner() {}
 
     /**
      * Scan a project for rule violations.

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -42,6 +42,8 @@ import sorald.Constants;
 
 /** Adapter class for interfacing with sonar-java's verification and analysis facilities. */
 public class RuleVerifier {
+    private RuleVerifier() {
+    }
 
     /**
      * Verify that the given file has at least one issue according to check.

--- a/src/main/java/sorald/sonar/RuleVerifier.java
+++ b/src/main/java/sorald/sonar/RuleVerifier.java
@@ -42,8 +42,7 @@ import sorald.Constants;
 
 /** Adapter class for interfacing with sonar-java's verification and analysis facilities. */
 public class RuleVerifier {
-    private RuleVerifier() {
-    }
+    private RuleVerifier() {}
 
     /**
      * Verify that the given file has at least one issue according to check.

--- a/src/main/java/sorald/support/IdentityHashSet.java
+++ b/src/main/java/sorald/support/IdentityHashSet.java
@@ -10,8 +10,7 @@ import java.util.Set;
  * operate on object identity rather than equality).
  */
 public class IdentityHashSet {
-    private IdentityHashSet() {
-    }
+    private IdentityHashSet() {}
 
     /**
      * Create an identity hash set and add all elements from the given collection to it.

--- a/src/main/java/sorald/support/IdentityHashSet.java
+++ b/src/main/java/sorald/support/IdentityHashSet.java
@@ -10,6 +10,8 @@ import java.util.Set;
  * operate on object identity rather than equality).
  */
 public class IdentityHashSet {
+    private IdentityHashSet() {
+    }
 
     /**
      * Create an identity hash set and add all elements from the given collection to it.


### PR DESCRIPTION
Hi,

This PR fixes 11 violations of [Sonar Rule 1118: 'Utility classes should not have public constructors'](https://rules.sonarsource.com/java/RSPEC-1118).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 1118](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#utility-classes-should-not-have-public-constructors-sonar-rule-1118).