### PR TITLE
refactor: Fix violations of Sonar rule 3032

### DIFF
--- a/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -28,7 +28,9 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
         Properties props = new Properties();
         try {
             props.load(
-                    Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName));
+                    Thread.currentThread()
+                            .getContextClassLoader()
+                            .getResourceAsStream(resourceName));
         } catch (Exception e) {
             return LOCAL_VERSION;
         }

--- a/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -28,7 +28,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
         Properties props = new Properties();
         try {
             props.load(
-                    SoraldVersionProvider.class.getClassLoader().getResourceAsStream(resourceName));
+                    Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName));
         } catch (Exception e) {
             return LOCAL_VERSION;
         }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 3032: 'JEE applications should not "getClassLoader"'](https://rules.sonarsource.com/java/RSPEC-3032).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 3032](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#jee-applications-should-not-getclassloader-sonar-rule-3032).