### PR TITLE
chore: Set version to 0.1.0-SNAPSHOT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,8 @@ jobs:
         run: mvn test
       - name: Sanity check jarfile
         env:
-          SORALD_JAR_PATH: "target/sorald-1.1-SNAPSHOT-jar-with-dependencies.jar"
+          SORALD_JAR_PATH: "target/sorald-*-SNAPSHOT-jar-with-dependencies.jar"
+        shell: bash
         run: |
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Sanity check jarfile
         shell: bash
         run: |
-          SORALD_JAR_PATH=target/sorald-*-SNAPSHOT-jar-with-dependencies.jar
+          SORALD_JAR_PATH=$(echo target/sorald-*-SNAPSHOT-jar-with-dependencies.jar)
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
       - name: Upload coverage report to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,10 +54,9 @@ jobs:
       - name: Run tests
         run: mvn test
       - name: Sanity check jarfile
-        env:
-          SORALD_JAR_PATH: "target/sorald-*-SNAPSHOT-jar-with-dependencies.jar"
         shell: bash
         run: |
+          SORALD_JAR_PATH=target/sorald-*-SNAPSHOT-jar-with-dependencies.jar
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
       - name: Upload coverage report to Codecov

--- a/experimentation/tools/sorald/_helpers/soraldwrapper.py
+++ b/experimentation/tools/sorald/_helpers/soraldwrapper.py
@@ -8,11 +8,24 @@ import sys
 from typing import List, Optional, Tuple
 
 
-DEFAULT_SORALD_JAR_PATH = (
-    pathlib.Path(__file__).absolute().parent.parent.parent.parent.parent
-    / "target"
-    / "sorald-1.1-SNAPSHOT-jar-with-dependencies.jar"
-).resolve(strict=False)
+def _find_default_sorald_jar() -> pathlib.Path:
+    target_dir = (
+        pathlib.Path(__file__).absolute().parent.parent.parent.parent.parent / "target"
+    )
+    sorald_jar_matches = list(
+        target_dir.glob("sorald-*-SNAPSHOT-jar-with-dependencies.jar")
+    )
+
+    if len(sorald_jar_matches) != 1:
+        raise RuntimeError(
+            f"expected precisely one Sorald jar in the target directory, "
+            f"but found: {sorald_jar_matches}"
+        )
+
+    return sorald_jar_matches[0].resolve(strict=True)
+
+
+DEFAULT_SORALD_JAR_PATH = _find_default_sorald_jar()
 
 
 def sorald(

--- a/experimentation/tools/sorald/warnings_extractor.py
+++ b/experimentation/tools/sorald/warnings_extractor.py
@@ -23,12 +23,7 @@ import pandas as pd
 
 from typing import Tuple, List, Mapping, Iterable, Optional
 
-
-SORALD_JAR_PATH = (
-    pathlib.Path(__file__).absolute().parent.parent.parent.parent
-    / "target"
-    / "sorald-1.1-SNAPSHOT-jar-with-dependencies.jar"
-).resolve(strict=False)
+from sorald._helpers import soraldwrapper
 
 WARNING_STATS_OUTPUT_DIR = (
     pathlib.Path(__file__).parent / "warning_stats_output"
@@ -116,7 +111,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         "--sorald-jar",
         help="path to the Sorald jarfile with dependencies",
         type=pathlib.Path,
-        default=SORALD_JAR_PATH,
+        default=soraldwrapper.DEFAULT_SORALD_JAR_PATH,
     )
     parser.add_argument(
         "--num-cpus",

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.kth.castor</groupId>
     <artifactId>sorald</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <name>Sorald</name>
     <description>An automatic repair system for static code analysis warnings from Sonar Java.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.kth.castor</groupId>
     <artifactId>sorald</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>0.1-SNAPSHOT</version>
 
     <name>Sorald</name>
     <description>An automatic repair system for static code analysis warnings from Sonar Java.</description>


### PR DESCRIPTION
#150 

This PR sets the version number to 0.1.0-SNAPSHOT and updates support scripts that had the old version number hard coded.