### PR TITLE
chore: Prevent gpg-maven-plugin from using pinentry programs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.6</version>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
#150 

See https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml