### PR TITLE
refactor: Avoid explicitly accessing getClassLoader()

### DIFF
--- a/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -27,7 +27,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
     public static String getVersionFromPropertiesResource(String resourceName) {
         Properties props = new Properties();
         try {
-            props.load(SoraldVersionProvider.class.getResourceAsStream(resourceName));
+            props.load(SoraldVersionProvider.class.getResourceAsStream("/" + resourceName));
         } catch (Exception e) {
             return LOCAL_VERSION;
         }

--- a/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -27,8 +27,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
     public static String getVersionFromPropertiesResource(String resourceName) {
         Properties props = new Properties();
         try {
-            props.load(
-                    SoraldVersionProvider.class.getClassLoader().getResourceAsStream(resourceName));
+            props.load(SoraldVersionProvider.class.getResourceAsStream(resourceName));
         } catch (Exception e) {
             return LOCAL_VERSION;
         }


### PR DESCRIPTION
This avoids a false positive for rule 3032 discussed in #470.