### PR TITLE
chore: Only run deploy job in SpoonLabs/sorald

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'SpoonLabs/sorald' }}
     runs-on: ubuntu-latest
 
     environment: Deploy


### PR DESCRIPTION
Fix #477 

This PR edits the deploy job to only run if the repository is called `SpoonLabs/sorald` (i.e. does not run on forks, where it will always fail!)