### PR TITLE
fix: Make support scripts/CI workflows find any version of the Sorald JAR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Sanity check jarfile
         shell: bash
         run: |
-          SORALD_JAR_PATH=$(echo target/sorald-*-SNAPSHOT-jar-with-dependencies.jar)
+          SORALD_JAR_PATH=$(echo target/sorald-*-jar-with-dependencies.jar)
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
           java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
       - name: Upload coverage report to Codecov

--- a/experimentation/tools/sorald/_helpers/soraldwrapper.py
+++ b/experimentation/tools/sorald/_helpers/soraldwrapper.py
@@ -13,7 +13,7 @@ def _find_default_sorald_jar() -> pathlib.Path:
         pathlib.Path(__file__).absolute().parent.parent.parent.parent.parent / "target"
     )
     sorald_jar_matches = list(
-        target_dir.glob("sorald-*-SNAPSHOT-jar-with-dependencies.jar")
+        target_dir.glob("sorald-*-jar-with-dependencies.jar")
     )
 
     if len(sorald_jar_matches) != 1:


### PR DESCRIPTION
Fix #483 

This PR simply removes the expectation that the compiled JAR file is a SNAPSHOT version, which is important for release commits.