### PR TITLE
fix: Fix memory leak from accumulating compilation units across writes

### DIFF
--- a/.github/mem-constrained-exec.sh
+++ b/.github/mem-constrained-exec.sh
@@ -16,7 +16,7 @@ if [[ ! (-f "$SORALD_JAR_PATH") ]]; then
 fi
 
 HEAP_SIZE="128m"
-MAX_FILES_PER_SEGMENT=50
+MAX_FILES_PER_SEGMENT=25
 
 echo "Running memory-constrained test with heap size=$HEAP_SIZE and segment size=$MAX_FILES_PER_SEGMENT"
 

--- a/.github/mem-constrained-exec.sh
+++ b/.github/mem-constrained-exec.sh
@@ -17,12 +17,20 @@ fi
 
 HEAP_SIZE="128m"
 MAX_FILES_PER_SEGMENT=25
+SORALD_STDOUT_FILE="sorald_stdout.txt"
+EXPECTED_NUM_FIXES_LINE="SerializableFieldInSerializableClassProcessor: 170"
 
 echo "Running memory-constrained test with heap size=$HEAP_SIZE and segment size=$MAX_FILES_PER_SEGMENT"
 
 git clone https://github.com/eclipse/eclipse-collections.git --depth 1 --branch 11.0.0.M1 --single-branch
 java -Xmx"$HEAP_SIZE" -jar "$SORALD_JAR_PATH" repair --source eclipse-collections/eclipse-collections --rule-key 1948 \
     --repair-strategy SEGMENT \
-    --max-files-per-segment $MAX_FILES_PER_SEGMENT > /dev/null
+    --max-files-per-segment $MAX_FILES_PER_SEGMENT > "$SORALD_STDOUT_FILE"
+
+grep "$EXPECTED_NUM_FIXES_LINE" "$SORALD_STDOUT_FILE" || {
+  echo "Did not find the expected amount of fixes line: $EXPECTED_NUM_FIXES_LINE"
+  tail -n 10 $SORALD_STDOUT_FILE
+  exit 1
+}
 
 echo "Memory-constrained test passed without error"

--- a/.github/mem-constrained-exec.sh
+++ b/.github/mem-constrained-exec.sh
@@ -1,0 +1,28 @@
+# This script executes Sorald in segment mode with a very limited amount of heap memory in order to verify that there are no
+# memory leaks. As an example, if the CompilationUnitCollector is not cleared after each write, then all segments are
+# held in memory for as long as Sorald executes (see https://github.com/SpoonLabs/sorald/issues/437).
+#
+# This script assumes that Sorald is already packaged to the default location, and that it is executed from the root
+# of the repository.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SORALD_JAR_PATH=$(echo target/sorald-*-SNAPSHOT-jar-with-dependencies.jar)
+if [[ ! (-f "$SORALD_JAR_PATH") ]]; then
+  echo "expected Sorald jar at $SORALD_JAR_PATH"
+  exit 1
+fi
+
+HEAP_SIZE="128m"
+MAX_FILES_PER_SEGMENT=50
+
+echo "Running memory-constrained test with heap size=$HEAP_SIZE and segment size=$MAX_FILES_PER_SEGMENT"
+
+git clone https://github.com/eclipse/eclipse-collections.git --depth 1 --branch 11.0.0.M1 --single-branch
+java -Xmx"$HEAP_SIZE" -jar "$SORALD_JAR_PATH" repair --source eclipse-collections/eclipse-collections --rule-key 1948 \
+    --repair-strategy SEGMENT \
+    --max-files-per-segment $MAX_FILES_PER_SEGMENT > /dev/null
+
+echo "Memory-constrained test passed without error"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,12 +57,9 @@ jobs:
         shell: bash
       - name: Run tests
         run: mvn test
-      - name: Sanity check jarfile
+      - name: Test memory-constrained execution with segment repair
         shell: bash
-        run: |
-          SORALD_JAR_PATH=$(echo target/sorald-*-SNAPSHOT-jar-with-dependencies.jar)
-          java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
-          java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
+        run: .github/mem-constrained-exec.sh
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9 # v1.0.15
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,12 +72,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-      - name: Sanity check jarfile
-        shell: bash
-        run: |
-          SORALD_JAR_PATH=$(echo target/sorald-*-jar-with-dependencies.jar)
-          java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2184
-          java -jar "$SORALD_JAR_PATH" repair --source src/test/resources/ArrayHashCodeAndToString.java --rule-key 2116
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9 # v1.0.15
         with:

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -90,10 +90,12 @@ public class Repair {
         Stream<CtModel> models = repair(inputDir, processor, ruleViolations);
 
         models.forEach(
-                model ->
-                        cuCollector
-                                .getCollectedCompilationUnits()
-                                .forEach(this::overwriteCompilationUnit));
+                model -> {
+                    cuCollector
+                            .getCollectedCompilationUnits()
+                            .forEach(this::overwriteCompilationUnit);
+                    cuCollector.clear();
+                });
 
         return processor;
     }

--- a/src/main/java/sorald/event/collectors/CompilationUnitCollector.java
+++ b/src/main/java/sorald/event/collectors/CompilationUnitCollector.java
@@ -34,6 +34,11 @@ public class CompilationUnitCollector implements SoraldEventHandler {
         return newIdentityHashSet(pathToCu.values());
     }
 
+    /** Clear the collected compilation units. */
+    public void clear() {
+        pathToCu.clear();
+    }
+
     /**
      * Collect the compilation unit that this element belongs to.
      *


### PR DESCRIPTION
Fix #437 

This fixes a memory leak in segment mode caused by the CompilationUnitCollector retaining references to already printed compilation units. Also replaces the JAR sanity check test with a highly memory-constrained test, using the packaged JAR in segment mode. [Here's an example of where it reproduces the memory leak](https://github.com/SpoonLabs/sorald/pull/498/checks?check_run_id=2410450540#step:11:30).

The memory constrained test takes as long to run as all of the unit tests combined, but I think that's fine considering that it adds a real-world test to the test suite. Note that it also asserts the amount of repairs (170) for the given rule, so it's the largest-scale test we have right now.