### PR TITLE
chore: Remove SNAPSHOT from path in memory-constrained test script

### DIFF
--- a/.github/mem-constrained-exec.sh
+++ b/.github/mem-constrained-exec.sh
@@ -9,7 +9,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SORALD_JAR_PATH=$(echo target/sorald-*-SNAPSHOT-jar-with-dependencies.jar)
+SORALD_JAR_PATH=$(echo target/sorald-*-jar-with-dependencies.jar)
 if [[ ! (-f "$SORALD_JAR_PATH") ]]; then
   echo "expected Sorald jar at $SORALD_JAR_PATH"
   exit 1


### PR DESCRIPTION
Another one of those hard-coded SNAPSHOT paths had snuck its way into the CI. It works fine as long as the current version in the repository is a SNAPSHOT version, but blows up on releases.

This PR simply removes `SNAPSHOT-` from the file path.