### PR TITLE
chore: Only run non-SNAPSHOT publish step on publish of release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
           gpg-passphrase: SORALD_GPG_PASSPHRASE
 
       - name: Publish to Maven Central
-        if: ${{ contains(steps.get-sorald-version.version, 'SNAPSHOT') || github.event_name == 'release' }}
+        if: ${{ contains(steps.get-sorald-version.outputs.version, 'SNAPSHOT') || github.event_name == 'release' }}
         run: mvn -Prelease deploy
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ name: deploy
 on:
   push:
     branches: [ master ]
+  release:
+    types: [ published ]
 
 env:
   JAVA_DISTRIBUTION: 'adopt'
@@ -34,6 +36,13 @@ jobs:
       - name: Build
         run: mvn -B package
 
+      - name: Get Sorald version
+        id: get-sorald-version
+        shell: bash
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "::set-output name=version::$VERSION"
+
       - name: Setup Java for deploy
         uses: actions/setup-java@8764a52df183aa0ccea74521dfd9d506ffc7a19a # v2.0.0
         with: # running setup-java again overwrites the settings.xml
@@ -49,6 +58,7 @@ jobs:
           gpg-passphrase: SORALD_GPG_PASSPHRASE
 
       - name: Publish to Maven Central
+        if: ${{ contains(steps.get-sorald-version.version, 'SNAPSHOT') || github.event_name == 'release' }}
         run: mvn -Prelease deploy
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
Related to #482 

This adjusts the deploy workflow such that it only deploys non-snapshot versions once a GitHub release is published. This makes the release process a bit more predictable than when deploying from master, as GitHub Actions typically only builds the very latest commit, which when pushing a release is in fact the "next iteration" commit, and not the release commit.

I had an awkward workaround for this (push the release commit, then wait until the action starts, then push the next iteration commit). By deploying only on a published release, that workaround is no longer necessary, and it also allows us to release _before_ merging into master. That's good if there's trouble in the publish step.