### PR TITLE
chore: Disable PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 codecov:
   require_ci_to_pass: yes
 
+comment: false
+
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
Fix #497 

The Codecov PR comment is large and in the way, let's get rid of it. We're really only interested in the check, if we want the report we can go to codecov.io.

I think that the change only takes effect once merged into master.