### PR TITLE
test: Add test case for doing targeted repair of specific file

### DIFF
--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -154,6 +154,31 @@ public class TargetedRepairTest {
                         containsString(violationSpec)));
     }
 
+    /** Test that targeted repair works when --source points to a file rather than a directory. */
+    @Test
+    void targetedRepair_canTargetSpecificFile() throws Exception {
+        // arrange
+        TargetedRepairWorkdirInfo workdirInfo = setupWorkdir();
+        Path target = workdirInfo.targetViolation.getAbsolutePath();
+        String violationSpec = workdirInfo.targetViolation.relativeSpecifier(target);
+
+        // act
+        Main.main(
+                new String[] {
+                    Constants.REPAIR_COMMAND_NAME,
+                    Constants.ARG_SOURCE,
+                    target.toString(),
+                    Constants.ARG_RULE_VIOLATION_SPECIFIERS,
+                    violationSpec
+                });
+
+        // assert
+        Set<RuleViolation> violationsAfter =
+                ProjectScanner.scanProject(
+                        workdirInfo.workdir, workdirInfo.workdir, workdirInfo.check);
+        assertThat(violationsAfter.size(), equalTo(workdirInfo.numViolationsBefore - 1));
+    }
+
     /** Setup the workdir with a specific target violation. */
     private static TargetedRepairWorkdirInfo setupWorkdir() throws IOException {
         Path workdir = TestHelper.createTemporaryProcessorTestFilesWorkspace();


### PR DESCRIPTION
Fix #480 

The problem described in #480 turned out to not be reproducible. Perhaps I was using an old version, or there were some very specific circumstances I failed to record.

Anyway, I'll just add a single test case that performs the task I had trouble with (doing targeted repair when `--source` points to a file) to see that we don't get any regressions.