### PR TITLE
chore: Only run Sonar step on the main repository

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: .github/mem-constrained-exec.sh
       - name: Run Sonar
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && github.repository == 'SpoonLabs/sorald' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Fix #506 

This prevents failing the workflow when a PR comes in from a fork.