### PR TITLE
chore: Disable Sonar on PRs from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: .github/mem-constrained-exec.sh
       - name: Run Sonar
-        if: ${{ matrix.os == 'ubuntu-latest' && github.repository == 'SpoonLabs/sorald' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'SpoonLabs/sorald') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Fix #512 

There was a bit of a bug in skipping Sonar on PRs from fork (read: it didn't skip Sonar on PRs from forks). With this PR, that's fixed.

* You can see here that with this PR running from a fork, [the Sonar step doesn't run](https://github.com/SpoonLabs/sorald/pull/520/checks?check_run_id=2508555655)
* And in this PR (which originates from within this repo), [the Sonar step does run](https://github.com/SpoonLabs/sorald/pull/519/checks?check_run_id=2508557275#step:12:1)