### PR TITLE
DONTMERGE: Disable Sonar on PRs from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: .github/mem-constrained-exec.sh
       - name: Run Sonar
-        if: ${{ matrix.os == 'ubuntu-latest' && github.repository == 'SpoonLabs/sorald' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'SpoonLabs/sorald') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This is just to show that Sonar is in fact disabled on forks.