### PR TITLE
feat: Utilize classpath when repairing in Maven mode

### DIFF
--- a/src/test/java/sorald/MavenLauncherTest.java
+++ b/src/test/java/sorald/MavenLauncherTest.java
@@ -1,11 +1,17 @@
 package sorald;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.java.checks.DeadStoreCheck;
+import sorald.event.StatsMetadataKeys;
 import sorald.sonar.RuleVerifier;
 
 public class MavenLauncherTest {
@@ -43,5 +49,47 @@ public class MavenLauncherTest {
         // assert
         RuleVerifier.verifyNoIssue(productionFile.toString(), new DeadStoreCheck());
         RuleVerifier.verifyNoIssue(testFile.toString(), new DeadStoreCheck());
+    }
+
+    /**
+     * Test that Sorald can repair a rule violation for which Sonar requires the full classpath to
+     * detect.
+     */
+    @Test
+    void sorald_repairsRuleViolation_thatRequiresClasspathToDetect(@TempDir File workdir)
+            throws IOException {
+        // arrange
+        org.apache.commons.io.FileUtils.copyDirectory(
+                TestHelper.PATH_TO_RESOURCES_FOLDER
+                        .resolve("scenario_test_files")
+                        .resolve("classpath-dependent-project")
+                        .toFile(),
+                workdir);
+
+        Path statsFile = workdir.toPath().resolve("stats.json");
+
+        String castArithmOperandKey = "2184";
+        String[] args = {
+            Constants.REPAIR_COMMAND_NAME,
+            Constants.ARG_SOURCE,
+            workdir.getAbsolutePath(),
+            Constants.ARG_RULE_KEY,
+            castArithmOperandKey,
+            Constants.ARG_REPAIR_STRATEGY,
+            RepairStrategy.MAVEN.name(),
+            Constants.ARG_STATS_OUTPUT_FILE,
+            statsFile.toString()
+        };
+
+        // act
+        Main.main(args);
+
+        // assert
+        JSONObject stats = FileUtils.readJSON(statsFile);
+        JSONArray repairs = stats.getJSONArray(StatsMetadataKeys.REPAIRS);
+        assertThat(repairs.length(), equalTo(1));
+        JSONObject repair = repairs.getJSONObject(0);
+        assertThat(
+                repair.getString(StatsMetadataKeys.REPAIR_RULE_KEY), equalTo(castArithmOperandKey));
     }
 }

--- a/src/test/resources/scenario_test_files/classpath-dependent-project/pom.xml
+++ b/src/test/resources/scenario_test_files/classpath-dependent-project/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>sorald.test</groupId>
+  <artifactId>sorald.test.project</artifactId>
+  <properties>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>sorald.test.project</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>fr.inria.gforge.spoon.labs</groupId>
+      <artifactId>gumtree-spoon-ast-diff</artifactId>
+      <version>1.24</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/scenario_test_files/classpath-dependent-project/src/main/java/sorald/test/App.java
+++ b/src/test/resources/scenario_test_files/classpath-dependent-project/src/main/java/sorald/test/App.java
@@ -1,0 +1,12 @@
+package sorald.test;
+
+/**
+ * App that computes the ratio of root operations to all opertions with gumtree-spoon!
+ */
+public class App {
+    public static void main(String[] args) {
+        Diff diff = new AstComparator().compare(leftPath.toFile(), rightPath.toFile());
+        double ratio = diff.getRootOperations().size() / diff.getAllOperations().size(); // Noncompliant; rule 2184 (cast arithmetic operator)
+        System.out.println(ratio);
+    }
+}


### PR DESCRIPTION
Fix #205 

Currently, this is just a test case that demonstrates the need to run in classpath mode.