### PR TITLE
fix: Add exact-match search on variable name in joint declarations

### DIFF
--- a/src/main/java/sorald/sonar/BestFitScanner.java
+++ b/src/main/java/sorald/sonar/BestFitScanner.java
@@ -196,8 +196,9 @@ public class BestFitScanner<E extends CtElement> extends CtScanner {
                         violation.getStartLine(),
                         violation.getStartCol(),
                         cu.getLineSeparatorPositions());
-        int symbolEndPos = reverseSearch(cuSource, searchStartPos, c -> !Character.isWhitespace(c));
-        int symbolStartPos = reverseSearch(cuSource, symbolEndPos, Character::isWhitespace) + 1;
+        int symbolEndPos = reverseSearch(cuSource, searchStartPos, Character::isJavaIdentifierPart);
+        int symbolStartPos =
+                reverseSearch(cuSource, symbolEndPos, c -> !Character.isJavaIdentifierPart(c)) + 1;
         return cuSource.substring(symbolStartPos, symbolEndPos + 1);
     }
 

--- a/src/main/java/sorald/sonar/BestFitScanner.java
+++ b/src/main/java/sorald/sonar/BestFitScanner.java
@@ -178,7 +178,7 @@ public class BestFitScanner<E extends CtElement> extends CtScanner {
     private boolean candidatePostFilter(E element, RuleViolation violation) {
         if (element instanceof CtVariable && ((CtVariable<?>) element).isPartOfJointDeclaration()) {
             String ident =
-                    getPrecedingSymbol(violation, element.getPosition().getCompilationUnit());
+                    getPrecedingIdentifier(violation, element.getPosition().getCompilationUnit());
             return ident.equals(((CtVariable<?>) element).getSimpleName());
         } else {
             return true;
@@ -186,20 +186,20 @@ public class BestFitScanner<E extends CtElement> extends CtScanner {
     }
 
     /**
-     * Get the first non-whitespace symbol preceding the source position of the given rule
+     * Get the first identifier-like symbol preceding the source position of the given rule
      * violation.
      */
-    private static String getPrecedingSymbol(RuleViolation violation, CtCompilationUnit cu) {
+    private static String getPrecedingIdentifier(RuleViolation violation, CtCompilationUnit cu) {
         String cuSource = cu.getOriginalSourceCode();
         int searchStartPos =
                 calculateSourcePos(
                         violation.getStartLine(),
                         violation.getStartCol(),
                         cu.getLineSeparatorPositions());
-        int symbolEndPos = reverseSearch(cuSource, searchStartPos, Character::isJavaIdentifierPart);
-        int symbolStartPos =
-                reverseSearch(cuSource, symbolEndPos, c -> !Character.isJavaIdentifierPart(c)) + 1;
-        return cuSource.substring(symbolStartPos, symbolEndPos + 1);
+        int identEndPos = reverseSearch(cuSource, searchStartPos, Character::isJavaIdentifierPart);
+        int identStartPos =
+                reverseSearch(cuSource, identEndPos, c -> !Character.isJavaIdentifierPart(c)) + 1;
+        return cuSource.substring(identStartPos, identEndPos + 1);
     }
 
     private static int reverseSearch(String s, int startIdx, Predicate<Character> predicate) {

--- a/src/main/java/sorald/sonar/BestFitScanner.java
+++ b/src/main/java/sorald/sonar/BestFitScanner.java
@@ -196,13 +196,13 @@ public class BestFitScanner<E extends CtElement> extends CtScanner {
                         violation.getStartLine(),
                         violation.getStartCol(),
                         cu.getLineSeparatorPositions());
-        int identEndPos = reverseSearch(cuSource, searchStartPos, Character::isJavaIdentifierPart);
+        int identEndPos = reverseFind(cuSource, searchStartPos, Character::isJavaIdentifierPart);
         int identStartPos =
-                reverseSearch(cuSource, identEndPos, c -> !Character.isJavaIdentifierPart(c)) + 1;
+                reverseFind(cuSource, identEndPos, c -> !Character.isJavaIdentifierPart(c)) + 1;
         return cuSource.substring(identStartPos, identEndPos + 1);
     }
 
-    private static int reverseSearch(String s, int startIdx, Predicate<Character> predicate) {
+    private static int reverseFind(String s, int startIdx, Predicate<Character> predicate) {
         int searchPos = startIdx;
         while (searchPos > 0 && !predicate.test(s.charAt(searchPos))) {
             --searchPos;

--- a/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java
@@ -26,4 +26,11 @@ public class JointLocalVarDeclaration {
         System.out.println(x);
         System.out.println(y);
     }
+
+    // no whitespace to delimit the identifiers
+    public void noWhitespaceBetweenIdentAndComma() {
+        int x=2,y=3,z=4; // Noncompliant
+        System.out.println(x);
+        System.out.println(z);
+    }
 }

--- a/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java
@@ -1,0 +1,29 @@
+/*
+Joint declarations are tricky in Spoon as they are modelede as separate elements with the same
+source position. This test case tests that Sorald can find the correct local variable in a few
+different configurations of joint declarations.
+ */
+
+public class JointLocalVarDeclaration {
+
+    // the first variable in a joint declaration is a dead store
+    public void firstIsDeadStore() {
+        int x = 2, y = 3, z = 4; // Noncompliant
+        System.out.println(y);
+        System.out.println(z);
+    }
+
+    // the second variable in a joint declaration is a dead store
+    public void secondIsDeadStore() {
+        int x = 2, y = 3, z = 4; // Noncompliant
+        System.out.println(x);
+        System.out.println(z);
+    }
+
+    // the third variable in a joint declaration is a dead store
+    public void thirdIsDeadStore() {
+        int x = 2, y = 3, z = 4; // Noncompliant
+        System.out.println(x);
+        System.out.println(y);
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java
@@ -1,5 +1,5 @@
 /*
-Joint declarations are tricky in Spoon as they are modelede as separate elements with the same
+Joint declarations are tricky in Spoon as they are modeled as separate elements with the same
 source position. This test case tests that Sorald can find the correct local variable in a few
 different configurations of joint declarations.
  */

--- a/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java.expected
@@ -29,4 +29,12 @@ public class JointLocalVarDeclaration {
         System.out.println(x);
         System.out.println(y);
     }
+
+    // no whitespace to delimit the identifiers
+    public void noWhitespaceBetweenIdentAndComma() {
+        int x = 2;
+        int z = 4;
+        System.out.println(x);
+        System.out.println(z);
+    }
 }

--- a/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java.expected
@@ -1,5 +1,5 @@
 /*
-Joint declarations are tricky in Spoon as they are modelede as separate elements with the same
+Joint declarations are tricky in Spoon as they are modeled as separate elements with the same
 source position. This test case tests that Sorald can find the correct local variable in a few
 different configurations of joint declarations.
  */

--- a/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/JointLocalVarDeclaration.java.expected
@@ -1,0 +1,32 @@
+/*
+Joint declarations are tricky in Spoon as they are modelede as separate elements with the same
+source position. This test case tests that Sorald can find the correct local variable in a few
+different configurations of joint declarations.
+ */
+
+public class JointLocalVarDeclaration {
+
+    // the first variable in a joint declaration is a dead store
+    public void firstIsDeadStore() {
+        int y = 3;
+        int z = 4;
+        System.out.println(y);
+        System.out.println(z);
+    }
+
+    // the second variable in a joint declaration is a dead store
+    public void secondIsDeadStore() {
+        int x = 2;
+        int z = 4;
+        System.out.println(x);
+        System.out.println(z);
+    }
+
+    // the third variable in a joint declaration is a dead store
+    public void thirdIsDeadStore() {
+        int x = 2;
+        int y = 3;
+        System.out.println(x);
+        System.out.println(y);
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/MultiLineJointLocalVariableDeclarations.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/MultiLineJointLocalVariableDeclarations.java
@@ -1,0 +1,23 @@
+/*
+An assortment of multiline joint local variable declarations.
+ */
+
+public class MultiLineJointLocalVariableDeclarations {
+
+    public void multiLineJointDeclarationWithDeadStore() {
+        int veryLongVariableName = 1,
+            otherLongVariableName = 2,
+            finalLongVariableName = 3; // Noncompliant
+        System.out.println(veryLongVariableName);
+        System.out.println(otherLongVariableName);
+    }
+
+    public void multiLineJointDeclarationWithMissingInitializer() {
+        int veryLongVariableName = 1,
+                otherLongVariableName,
+                finalLongVariableName = 3; // Noncompliant
+        System.out.println(veryLongVariableName);
+        otherLongVariableName = 2;
+        System.out.println(otherLongVariableName);
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/MultiLineJointLocalVariableDeclarations.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/MultiLineJointLocalVariableDeclarations.java.expected
@@ -1,0 +1,21 @@
+/*
+An assortment of multiline joint local variable declarations.
+ */
+
+public class MultiLineJointLocalVariableDeclarations {
+
+    public void multiLineJointDeclarationWithDeadStore() {
+        int veryLongVariableName = 1;
+        int otherLongVariableName = 2;
+        System.out.println(veryLongVariableName);
+        System.out.println(otherLongVariableName);
+    }
+
+    public void multiLineJointDeclarationWithMissingInitializer() {
+        int veryLongVariableName = 1;
+        int otherLongVariableName;
+        System.out.println(veryLongVariableName);
+        otherLongVariableName = 2;
+        System.out.println(otherLongVariableName);
+    }
+}


### PR DESCRIPTION
Fix #522 

This PR extends the best fits scanner with a post filter that runs on all position-matched candidates. Currently, this post filter is only used to improve matching between rule violations and jointly declared variables.

@lyxell I know we discussed hamming distance, but I figured an exact match should be equally viable here. It may be that we find corner cases where the entire identifier can't be extracted, but I couldn't come up with one. Feel free to suggest more test cases and comment on the implementation!