### PR TITLE
chore: Use codecov-action v1.5.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9 # v1.0.15
+        uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27 # v1.5.0
         with:
           fail_ci_if_error: true
 


### PR DESCRIPTION
This PR bumps codecov-action to v1.5.0. The big difference is that the bash uploader (which was the cause of the security breach mentioned in #485) is integrated into the action rather than being fetched from a remote source, making it much more secure. 