### PR TITLE
feat: Add classpath resolution for Maven projects to miner

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,15 +203,20 @@ mine --help`).
       --git-repos-list=<reposList>
                              The path to the repos list.
   -h, --help                 Show this help message and exit.
+      --handled-rules        When this argument is used, Sorald only mines
+                               violations of the rules that can be fixed by
+                               Sorald.
       --miner-output-file=<minerOutputFile>
                              The path to the output file.
-      --source=<source>
-                             The path to the file or folder to be analyzed and
-                               possibly repaired.
+      --resolve-classpath    Resolve the classpath of a project for more
+                               accurate scans. Currently only works for Maven
+                               projects.
       --rule-types=<ruleTypes>[,<ruleTypes>...]
                              One or more types of rules to check for (use ','
                                to separate multiple types). Choices: BUG,
                                VULNERABILITY, CODE_SMELL, SECURITY_HOTSPOT
+      --source=<source>      The path to the file or folder to be analyzed and
+                               possibly repaired.
       --stats-on-git-repos   If the stats should be computed on git repos.
       --stats-output-file=<statsOutputFile>
                              Path to a file to store execution statistics in

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
     public static final String ARG_HANDLED_RULES = "--handled-rules";
     public static final String ARG_RULE_VIOLATION_SPECIFIERS = "--violation-specs";
     public static final String ARG_TARGET = "--target";
-    public static final String ARG_RESOLVE_CLASSPATH = "--resolve-classpath";
+    public static final String ARG_RESOLVE_CLASSPATH_FROM = "--resolve-classpath-from";
 
     public static final String VIOLATION_SPECIFIER_SEP = File.pathSeparator;
 

--- a/src/main/java/sorald/Constants.java
+++ b/src/main/java/sorald/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
     public static final String ARG_HANDLED_RULES = "--handled-rules";
     public static final String ARG_RULE_VIOLATION_SPECIFIERS = "--violation-specs";
     public static final String ARG_TARGET = "--target";
+    public static final String ARG_RESOLVE_CLASSPATH = "--resolve-classpath";
 
     public static final String VIOLATION_SPECIFIER_SEP = File.pathSeparator;
 

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -62,10 +62,10 @@ class MineCommand extends BaseCommand {
     private boolean handledRules;
 
     @CommandLine.Option(
-            names = Constants.ARG_RESOLVE_CLASSPATH,
+            names = Constants.ARG_RESOLVE_CLASSPATH_FROM,
             description =
-                    "Resolve the classpath of a project for more accurate scans. Currently only works for Maven projects.")
-    private boolean resolveClasspath;
+                    "Path to the root of a project to resolve the classpath from. Currently only works for Maven projects.")
+    private File resolveClasspathFrom;
 
     @Override
     public Integer call() throws Exception {
@@ -75,7 +75,9 @@ class MineCommand extends BaseCommand {
 
         var statsCollector = new MinerStatisticsCollector();
         List<String> classpath =
-                resolveClasspath ? MavenUtils.resolveClasspath(source.toPath()) : List.of();
+                resolveClasspathFrom != null
+                        ? MavenUtils.resolveClasspath(resolveClasspathFrom.toPath())
+                        : List.of();
 
         var miner =
                 new MineSonarWarnings(
@@ -107,12 +109,13 @@ class MineCommand extends BaseCommand {
 
     /** Perform validation on the parsed arguments. */
     private void validateArgs() {
-        if (resolveClasspath && !MavenUtils.isMavenProjectRoot(source.toPath())) {
+        if (resolveClasspathFrom != null
+                && !MavenUtils.isMavenProjectRoot(resolveClasspathFrom.toPath())) {
             throw new CommandLine.ParameterException(
                     spec.commandLine(),
                     String.format(
-                            "%s is only supported when %s points to the root of a Maven project",
-                            Constants.ARG_RESOLVE_CLASSPATH, Constants.ARG_SOURCE));
+                            "%s is only supported for Maven projects, but %s has no pom.xml",
+                            Constants.ARG_RESOLVE_CLASSPATH_FROM, source));
         }
     }
 

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -69,6 +69,8 @@ class MineCommand extends BaseCommand {
 
     @Override
     public Integer call() throws Exception {
+        validateArgs();
+
         List<? extends JavaFileScanner> checks = inferCheckInstances(ruleTypes, handledRules);
 
         var statsCollector = new MinerStatisticsCollector();
@@ -101,6 +103,17 @@ class MineCommand extends BaseCommand {
         }
 
         return 0;
+    }
+
+    /** Perform validation on the parsed arguments. */
+    private void validateArgs() {
+        if (resolveClasspath && !MavenUtils.isMavenProjectRoot(source.toPath())) {
+            throw new CommandLine.ParameterException(
+                    spec.commandLine(),
+                    String.format(
+                            "%s is only supported when %s points to the root of a Maven project",
+                            Constants.ARG_RESOLVE_CLASSPATH, Constants.ARG_SOURCE));
+        }
     }
 
     /**

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -60,6 +60,12 @@ class MineCommand extends BaseCommand {
                     "When this argument is used, Sorald only mines violations of the rules that can be fixed by Sorald.")
     private boolean handledRules;
 
+    @CommandLine.Option(
+            names = Constants.ARG_RESOLVE_CLASSPATH,
+            description =
+                    "Resolve the classpath of a project for more accurate scans. Currently only works for Maven projects.")
+    private boolean resolveClasspath;
+
     @Override
     public Integer call() throws Exception {
         List<? extends JavaFileScanner> checks = inferCheckInstances(ruleTypes, handledRules);
@@ -69,10 +75,14 @@ class MineCommand extends BaseCommand {
         if (statsOnGitRepos) {
             List<String> reposList = Files.readAllLines(this.reposList.toPath());
 
-            new MineSonarWarnings(statsOutputFile == null ? List.of() : List.of(statsCollector))
+            new MineSonarWarnings(
+                            statsOutputFile == null ? List.of() : List.of(statsCollector),
+                            resolveClasspath)
                     .mineGitRepos(checks, minerOutputFile.getAbsolutePath(), reposList, tempDir);
         } else {
-            new MineSonarWarnings(statsOutputFile == null ? List.of() : List.of(statsCollector))
+            new MineSonarWarnings(
+                            statsOutputFile == null ? List.of() : List.of(statsCollector),
+                            resolveClasspath)
                     .mineLocalProject(
                             checks, source.toPath().normalize().toAbsolutePath().toString());
         }

--- a/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -1,7 +1,6 @@
 package sorald.miner;
 
 import java.io.*;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Consumer;
@@ -16,16 +15,15 @@ import sorald.event.models.miner.MinedViolationEvent;
 import sorald.sonar.Checks;
 import sorald.sonar.RuleVerifier;
 import sorald.sonar.RuleViolation;
-import sorald.util.MavenUtils;
 
 public class MineSonarWarnings {
     final List<SoraldEventHandler> eventHandlers;
-    private final boolean resolveClasspath;
+    private final List<String> classpath;
 
     public MineSonarWarnings(
-            List<? extends SoraldEventHandler> eventHandlers, boolean resolveClasspath) {
+            List<? extends SoraldEventHandler> eventHandlers, List<String> classpath) {
         this.eventHandlers = Collections.unmodifiableList(eventHandlers);
-        this.resolveClasspath = resolveClasspath;
+        this.classpath = classpath;
     }
 
     public void mineGitRepos(
@@ -109,8 +107,6 @@ public class MineSonarWarnings {
                 (checkName) -> warnings.put(checkName, warnings.get(checkName) + 1);
 
         EventHelper.fireEvent(EventType.MINING_START, eventHandlers);
-        List<String> classpath =
-                resolveClasspath ? MavenUtils.resolveClasspath(Path.of(projectPath)) : List.of();
         Set<RuleViolation> analyzeMessages =
                 RuleVerifier.analyze(filesToScan, file, checks, classpath);
         EventHelper.fireEvent(EventType.MINING_END, eventHandlers);

--- a/src/main/java/sorald/util/MavenUtils.java
+++ b/src/main/java/sorald/util/MavenUtils.java
@@ -13,10 +13,20 @@ public class MavenUtils {
      *
      * @param source Path to the root of a Maven project
      * @return The full source classpath
+     * @throws IllegalArgumentException If source does not point to the root of a Maven project
      */
     public static List<String> resolveClasspath(Path source) {
+        if (!isMavenProjectRoot(source)) {
+            throw new IllegalArgumentException(
+                    String.format("'%s' is not a Maven project root", source));
+        }
+
         MavenLauncher launcher =
                 new MavenLauncher(source.toString(), MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
         return List.of(launcher.getEnvironment().getSourceClasspath());
+    }
+
+    private static boolean isMavenProjectRoot(Path source) {
+        return source.resolve("pom.xml").toFile().isFile();
     }
 }

--- a/src/main/java/sorald/util/MavenUtils.java
+++ b/src/main/java/sorald/util/MavenUtils.java
@@ -13,20 +13,20 @@ public class MavenUtils {
      *
      * @param source Path to the root of a Maven project
      * @return The full source classpath
-     * @throws IllegalArgumentException If source does not point to the root of a Maven project
      */
     public static List<String> resolveClasspath(Path source) {
-        if (!isMavenProjectRoot(source)) {
-            throw new IllegalArgumentException(
-                    String.format("'%s' is not a Maven project root", source));
-        }
-
         MavenLauncher launcher =
                 new MavenLauncher(source.toString(), MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
         return List.of(launcher.getEnvironment().getSourceClasspath());
     }
 
-    private static boolean isMavenProjectRoot(Path source) {
+    /**
+     * Test whether or not the given source path points to the root of a Maven project.
+     *
+     * @param source A path
+     * @return true iff the source path points to the root of a Maven project
+     */
+    public static boolean isMavenProjectRoot(Path source) {
         return source.resolve("pom.xml").toFile().isFile();
     }
 }

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -197,18 +197,21 @@ public class WarningMinerTest {
     void canDetectRuleViolation_thatRequiresClasspath_whenResolvingClasspathInMavenProject(
             @TempDir File tempdir) throws Exception {
         Path statsFile = tempdir.toPath().resolve("stats.json");
+        Path projectRoot =
+                TestHelper.PATH_TO_RESOURCES_FOLDER
+                        .resolve("scenario_test_files")
+                        .resolve("classpath-dependent-project");
+        Path source = projectRoot.resolve("src").resolve("main").resolve("java");
 
         String[] args = {
             Constants.MINE_COMMAND_NAME,
             Constants.ARG_STATS_OUTPUT_FILE,
             statsFile.toString(),
             Constants.ARG_SOURCE,
-            TestHelper.PATH_TO_RESOURCES_FOLDER
-                    .resolve("scenario_test_files")
-                    .resolve("classpath-dependent-project")
-                    .toString(),
+            source.toString(),
             Constants.ARG_HANDLED_RULES,
-            Constants.ARG_RESOLVE_CLASSPATH
+            Constants.ARG_RESOLVE_CLASSPATH_FROM,
+            projectRoot.toString()
         };
         Main.main(args);
 
@@ -226,7 +229,8 @@ public class WarningMinerTest {
             Constants.MINE_COMMAND_NAME,
             Constants.ARG_SOURCE,
             TestHelper.PATH_TO_RESOURCES_FOLDER.toString(),
-            Constants.ARG_RESOLVE_CLASSPATH
+            Constants.ARG_RESOLVE_CLASSPATH_FROM,
+            TestHelper.PATH_TO_RESOURCES_FOLDER.toString()
         };
 
         assertThrows(SystemExitHandler.NonZeroExit.class, () -> Main.main(args));

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.io.TempDir;
 import sorald.Constants;
 import sorald.FileUtils;
 import sorald.Main;
+import sorald.SystemExitHandler;
 import sorald.TestHelper;
 import sorald.cli.SoraldVersionProvider;
 import sorald.event.StatsMetadataKeys;
@@ -216,6 +217,19 @@ public class WarningMinerTest {
         assertThat(repairs.length(), equalTo(1));
         JSONObject repair = repairs.getJSONObject(0);
         assertThat(repair.getString(StatsMetadataKeys.REPAIR_RULE_KEY), equalTo("2184"));
+    }
+
+    /** We currently only support resolving the classpath on Maven projects. */
+    @Test
+    void exitsNonZero_whenResolvingClasspathOnNonMavenProject() {
+        String[] args = {
+            Constants.MINE_COMMAND_NAME,
+            Constants.ARG_SOURCE,
+            TestHelper.PATH_TO_RESOURCES_FOLDER.toString(),
+            Constants.ARG_RESOLVE_CLASSPATH
+        };
+
+        assertThrows(SystemExitHandler.NonZeroExit.class, () -> Main.main(args));
     }
 
     private static void runMiner(


### PR DESCRIPTION
Fix #523, related to #533 

This PR implements classpath resolution for Maven projects for the miner. I decided to go with adding a flag `--resolve-classpath-from <path-to-project-root>`, that currently only works for Maven projects (there must be a file `<path-to-project-route>/pom.xml`).

I chose to go this route instead of adding e.g. `--maven` or `--miner-mode MAVEN`, as we can quite easily add support for other build systems and just infer them by looking for build files. For example, to add support for Gradle, and then probably use the `gradle dependencies` command in some way. In other words, we can add support for more build systems without changing the CLI.

Initially I opted for just a `--resolve-classpath` argument that uses the `--source` path as the project route, but as I ran into issues with the repair version of Maven mode, I decided to go with separate source and classpath resolution paths. After this is merged, I will extend the feature to also work for repair mode, see #533.