### PR TITLE
feat(2142): Put curly brackets around inserted if-statement

### DIFF
--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.java
@@ -82,7 +82,11 @@ public class InterruptedExceptionProcessor extends SoraldAbstractProcessor<CtCat
         ctIf.setCondition(
                 fact.createBinaryOperator(
                         varRead, interruptedExcAccess, BinaryOperatorKind.INSTANCEOF));
-        ctIf.setThenStatement(statementToWrap);
+
+        // We add a block instead of just the naked statement here to force printing of curly
+        // brackets
+        CtBlock<?> thenBranch = fact.createCtBlock(statementToWrap);
+        ctIf.setThenStatement(thenBranch);
 
         return ctIf;
     }

--- a/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java.exact
+++ b/src/test/resources/processor_test_files/2142_InterruptedException/CatchMultipleTypes.java.exact
@@ -1,0 +1,3 @@
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }


### PR DESCRIPTION
Fix #526 

This PR amends the `InterruptedExceptionProcessor` to put curly brackets around inserted if-statements. Previously, it would look like so:

```diff
                        try {
                                job.get();
                        } catch (InterruptedException | ExecutionException e) {
+                               if (e instanceof InterruptedException)
+                                       Thread.currentThread().interrupt();
+
                                throw new SpoonException("failed to wait for parallel processor to finish", e);
                        }
                }
```

but with this patch it looks like so:

```diff
                        try {
                                job.get();
                        } catch (InterruptedException | ExecutionException e) {
+                               if (e instanceof InterruptedException) {
+                                       Thread.currentThread().interrupt();
+                               }
+
                                throw new SpoonException("failed to wait for parallel processor to finish", e);
                        }
                }