### PR TITLE
chore: Use Spoon version 9.1.0-beta-9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>9.1.0-beta-2</version>
+            <version>9.1.0-beta-9</version>
             <exclusions>
                 <exclusion>
                     <!-- must be excluded as it is signed, which causes problems with unsigned version from sonar -->


### PR DESCRIPTION
Bumps the version of Spoon to 9.1.0-beta-9. This includes a fix for a bug that caused simply qualified names in catchers with union types to become fully qualified (see inria/spoon#3918).

Here's an example of the bug in action in repairing a violation of rule 2142:

```diff
                        try {
                                job.get();
-                       } catch (InterruptedException | ExecutionException e) {
+                       } catch (java.lang.InterruptedException | java.util.concurrent.ExecutionException e) {
+                               if (e instanceof InterruptedException) {
+                                       Thread.currentThread().interrupt();
+                               }
                                throw new SpoonException("failed to wait for parallel processor to finish", e);
                        }
                }
```

And here's the same repair where the bug is fixed:

```diff
                        try {
                                job.get();
                        } catch (InterruptedException | ExecutionException e) {
+                               if (e instanceof InterruptedException) {
+                                       Thread.currentThread().interrupt();
+                               }
                                throw new SpoonException("failed to wait for parallel processor to finish", e);
                        }
                }
```