### PR TITLE
feat: Add `--resolve-classpath-from` to repair command

### DIFF
--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -54,13 +54,18 @@ public class Repair {
 
     final List<SoraldEventHandler> eventHandlers;
     private final CompilationUnitCollector cuCollector;
+    private final List<String> classpath;
 
-    public Repair(SoraldConfig config, List<? extends SoraldEventHandler> eventHandlers) {
+    public Repair(
+            SoraldConfig config,
+            List<String> classpath,
+            List<? extends SoraldEventHandler> eventHandlers) {
         this.config = config;
         cuCollector = new CompilationUnitCollector();
         List<SoraldEventHandler> eventHandlersCopy = new ArrayList<>(eventHandlers);
         eventHandlersCopy.add(cuCollector);
         this.eventHandlers = Collections.unmodifiableList(eventHandlersCopy);
+        this.classpath = new ArrayList<>(classpath);
     }
 
     /**
@@ -252,6 +257,11 @@ public class Repair {
         Environment env = launcher.getEnvironment();
         env.setIgnoreDuplicateDeclarations(true);
         env.setComplianceLevel(Constants.DEFAULT_COMPLIANCE_LEVEL);
+
+        if (!classpath.isEmpty()) {
+            env.setSourceClasspath(classpath.toArray(String[]::new));
+            env.setNoClasspath(false);
+        }
 
         // this is a workaround for https://github.com/INRIA/spoon/issues/3693
         if (config.getPrettyPrintingStrategy() == PrettyPrintingStrategy.SNIPER) {

--- a/src/main/java/sorald/Repair.java
+++ b/src/main/java/sorald/Repair.java
@@ -260,7 +260,6 @@ public class Repair {
 
         if (!classpath.isEmpty()) {
             env.setSourceClasspath(classpath.toArray(String[]::new));
-            env.setNoClasspath(false);
         }
 
         // this is a workaround for https://github.com/INRIA/spoon/issues/3693

--- a/src/main/java/sorald/cli/BaseCommand.java
+++ b/src/main/java/sorald/cli/BaseCommand.java
@@ -21,4 +21,10 @@ abstract class BaseCommand implements Callable<Integer> {
             description =
                     "Path to a file to store execution statistics in (in JSON format). If left unspecified, Sorald does not gather statistics.")
     File statsOutputFile;
+
+    @CommandLine.Option(
+            names = Constants.ARG_RESOLVE_CLASSPATH_FROM,
+            description =
+                    "Path to the root of a project to resolve the classpath from. Currently only works for Maven projects.")
+    File resolveClasspathFrom;
 }

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -61,12 +61,6 @@ class MineCommand extends BaseCommand {
                     "When this argument is used, Sorald only mines violations of the rules that can be fixed by Sorald.")
     private boolean handledRules;
 
-    @CommandLine.Option(
-            names = Constants.ARG_RESOLVE_CLASSPATH_FROM,
-            description =
-                    "Path to the root of a project to resolve the classpath from. Currently only works for Maven projects.")
-    private File resolveClasspathFrom;
-
     @Override
     public Integer call() throws Exception {
         validateArgs();

--- a/src/main/java/sorald/cli/RepairCommand.java
+++ b/src/main/java/sorald/cli/RepairCommand.java
@@ -108,17 +108,14 @@ class RepairCommand extends BaseCommand {
                 statsOutputFile == null ? List.of() : List.of(statsCollector);
         EventHelper.fireEvent(EventType.EXEC_START, eventHandlers);
 
-        List<String> classpath =
-                repairStrategy == RepairStrategy.MAVEN
-                        ? MavenUtils.resolveClasspath(source.toPath())
-                        : List.of();
+        List<String> classpath = resolveClasspath();
 
         Set<RuleViolation> ruleViolations = resolveRuleViolations(eventHandlers, classpath);
         if (ruleViolations.isEmpty()) {
             System.out.println("No rule violations found, nothing to do ...");
         } else {
             SoraldAbstractProcessor<?> proc =
-                    new Repair(config, eventHandlers).repair(ruleViolations);
+                    new Repair(config, classpath, eventHandlers).repair(ruleViolations);
             printEndProcess(proc);
         }
 
@@ -133,6 +130,16 @@ class RepairCommand extends BaseCommand {
         }
 
         return 0;
+    }
+
+    private List<String> resolveClasspath() {
+        if (resolveClasspathFrom != null) {
+            return MavenUtils.resolveClasspath(resolveClasspathFrom.toPath());
+        } else if (repairStrategy == RepairStrategy.MAVEN) {
+            return MavenUtils.resolveClasspath(source.toPath());
+        } else {
+            return List.of();
+        }
     }
 
     private Set<RuleViolation> resolveRuleViolations(

--- a/src/test/java/sorald/ClasspathModeTest.java
+++ b/src/test/java/sorald/ClasspathModeTest.java
@@ -1,0 +1,56 @@
+package sorald;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import sorald.event.StatsMetadataKeys;
+
+/** Tests for running Sorald in classpath mode. */
+class ClasspathModeTest {
+
+    @Test
+    void resolveClasspathFrom_enablesRepairOfViolation_thatRequiresClasspathToDetect(
+            @TempDir File workdir) throws IOException {
+        // arrange
+        org.apache.commons.io.FileUtils.copyDirectory(
+                TestHelper.PATH_TO_RESOURCES_FOLDER
+                        .resolve("scenario_test_files")
+                        .resolve("classpath-dependent-project")
+                        .toFile(),
+                workdir);
+
+        Path statsFile = workdir.toPath().resolve("stats.json");
+        Path source = workdir.toPath().resolve("src").resolve("main").resolve("java");
+
+        String castArithmOperandKey = "2184";
+        String[] args = {
+            Constants.REPAIR_COMMAND_NAME,
+            Constants.ARG_SOURCE,
+            source.toString(),
+            Constants.ARG_RULE_KEY,
+            castArithmOperandKey,
+            Constants.ARG_STATS_OUTPUT_FILE,
+            statsFile.toString(),
+            Constants.ARG_RESOLVE_CLASSPATH_FROM,
+            workdir.getAbsolutePath()
+        };
+
+        // act
+        Main.main(args);
+
+        // assert
+        JSONObject stats = FileUtils.readJSON(statsFile);
+        JSONArray repairs = stats.getJSONArray(StatsMetadataKeys.REPAIRS);
+        assertThat(repairs.length(), equalTo(1));
+        JSONObject repair = repairs.getJSONObject(0);
+        assertThat(
+                repair.getString(StatsMetadataKeys.REPAIR_RULE_KEY), equalTo(castArithmOperandKey));
+    }
+}

--- a/src/test/java/sorald/RepairTest.java
+++ b/src/test/java/sorald/RepairTest.java
@@ -34,7 +34,7 @@ public class RepairTest {
                         .collect(Collectors.toSet());
 
         // act
-        var repair = new Repair(config, List.of());
+        var repair = new Repair(config, List.of(), List.of());
         try {
             repair.repair(violations);
         } catch (IllegalArgumentException e) {

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -100,7 +100,7 @@ public class SegmentStrategyTest {
         String crashingClass = "DeadStores";
         Path crashingFile = getProcessorTestJavaFilePath(workspace.toFile(), crashingClass);
 
-        Repair repair = new Repair(config, List.of());
+        Repair repair = new Repair(config, List.of(), List.of());
         Function<LinkedList<Node>, CtModel> selectivelyCrashySegmentParser =
                 segment ->
                         segmentContainsFile(segment, crashingFile.toString())


### PR DESCRIPTION
Fix #533 

This PR adds the `--resolve-classpath-from <path-to-project-root>` option to the repair command. It works precisely the same way as for the mine command, and resolves the classpath from the provided directory path. Currently only works for Maven projects.

While this allows us to run Spoon in noclasspath mode in most cases, I chose to disable it for now. The reason is that segment mode won't work in noclasspath mode even with the classpath provided, as this classpath only includes dependencies, and then parts of the project itself would be missing in each segment. A solution would be to require the project to be compiled before-hand, and include the project's own bytecode on the classpath as well, but I feel that's too much to squeeze into this single PR.