### PR TITLE
doc: Fix outdated release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For building Sorald from source, you need a Java 11+ JDK, Maven and Git.
 
 To run Sorald, you need to first get your hands on the program. You can do this
 either by [building from source](#build), or going to the [latest
-release](https://github.com/spoonlabs/sorald/releases/tag/sorald-0.1.0) and
+release](https://github.com/spoonlabs/sorald/releases/latest) and
 downloading the file called `sorald-<VERSION>-jar-with-dependencies.jar` listed
 under `Assets`. Unless you keep multiple versions of Sorald, we recommend
 renaming the JAR to `sorald.jar` for the sake of simplicity.


### PR DESCRIPTION
The link in the README that points to the release is hard-coded to 0.1.0. This PR points it to the `latest` endpoint instead, which updates automatically with each new release.