### PR TITLE
feat(2095): Handle multiple unclosed closeables in same try

### DIFF
--- a/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
@@ -49,7 +49,11 @@ public class UnclosedResourcesProcessor extends SoraldAbstractProcessor<CtConstr
 
         CtBlock parentCtBlock = parent.getParent(CtBlock.class);
         boolean isInTry = parentCtBlock.getParent() instanceof CtTry;
-        if (isInTry) {
+        boolean isInTryWithResource = parentCtBlock.getParent() instanceof CtTryWithResource;
+        if (isInTryWithResource) {
+            ((CtTryWithResource) parentCtBlock.getParent()).addResource(variable);
+            parent.delete();
+        } else if (isInTry) {
             parent.delete();
             tryWithResource.setCatchers(((CtTry) parentCtBlock.getParent()).getCatchers());
             parentCtBlock.getParent().replace(tryWithResource);

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/MultipleCloseablesInSingleTry.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/MultipleCloseablesInSingleTry.java
@@ -1,0 +1,24 @@
+/*
+Tests that the processor can handle multiple closeables in the same try, when none of them are
+closed initially.
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class MultipleCloseablesInSingleTry {
+    public void readAndWrite() {
+
+        try {
+            FileInputStream is = new FileInputStream(new File("random/file/path")); // Noncompliant
+            FileOutputStream os = new FileOutputStream(new File("some/other/file")); // Noncompliant
+
+            byte[] bytes = is.readAllBytes();
+            os.write(bytes);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/MultipleCloseablesInSingleTry.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/MultipleCloseablesInSingleTry.java.expected
@@ -1,0 +1,17 @@
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class MultipleCloseablesInSingleTry {
+    public void readAndWrite() {
+
+        try (FileInputStream is = new FileInputStream(new File("random/file/path"));
+                FileOutputStream os = new FileOutputStream(new File("some/other/file"))) {
+            byte[] bytes = is.readAllBytes();
+            os.write(bytes);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java
@@ -7,7 +7,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-public class MultipleCloseablesInSingleTry {
+public class UnclosedResourceWithinTryWithResources {
     public void readAndWrite() {
 
         try (FileInputStream is = new FileInputStream(new File("random/file/path"))) {

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java
@@ -1,0 +1,22 @@
+/*
+Tests that the processor can handle an unclosed resource within a try-with-resources.
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class MultipleCloseablesInSingleTry {
+    public void readAndWrite() {
+
+        try (FileInputStream is = new FileInputStream(new File("random/file/path"))) {
+            FileOutputStream os = new FileOutputStream(new File("some/other/file")); // Noncompliant
+
+            byte[] bytes = is.readAllBytes();
+            os.write(bytes);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
@@ -7,7 +7,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-public class MultipleCloseablesInSingleTry {
+public class UnclosedResourceWithinTryWithResources {
     public void readAndWrite() {
 
         try (FileInputStream is = new FileInputStream(new File("random/file/path"));

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
@@ -1,0 +1,22 @@
+/*
+Tests that the processor can handle an unclosed resource within a try-with-resources.
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class MultipleCloseablesInSingleTry {
+    public void readAndWrite() {
+
+        try (FileInputStream is = new FileInputStream(new File("random/file/path"));
+                FileOutputStream os = new FileOutputStream(new File("some/other/file"))) {
+
+            byte[] bytes = is.readAllBytes();
+            os.write(bytes);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Fix #386 

This PR is a minor extension to the `UnclosedResourcesProcessor` that simply makes it respect an existing try-with-resources, and add resources to it rather than delete it and create a new one (which would cause resources to be lost; only the very last resource processed would ever appear in the resource block of the try). By extension, this allows the processor to deal with multiple unclosed resources in the same try-block. Here's how that works:

1. There's one violation for each unclosed resource
2. The first violation is fixed first (due to iteration order of the AST), and creates a try-with-resources block, with any remaining violating elements being placed within it
3. Any further violations are fixed simply by deleting the violating element and adding it the the (now existing) try-with-resources
    - This is the code that corresponds to the patch in this PR.

There are a gazillion corner cases which this does not cover. I will keep improving this processor with tiny PRs every once in a while. Next up is #540.