### PR TITLE
fix(3984): Retain simply qualified name of throwable type

### DIFF
--- a/src/main/java/sorald/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sorald/processor/UnusedThrowableProcessor.java
@@ -1,17 +1,24 @@
 package sorald.processor;
 
 import sorald.annotations.ProcessorAnnotation;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConstructorCall;
-import spoon.reflect.code.CtThrow;
 
 @ProcessorAnnotation(
         key = 3984,
         description = "Exception should not be created without being thrown")
-public class UnusedThrowableProcessor extends SoraldAbstractProcessor<CtConstructorCall> {
+public class UnusedThrowableProcessor
+        extends SoraldAbstractProcessor<CtConstructorCall<? extends Throwable>> {
 
     @Override
-    protected void repairInternal(CtConstructorCall element) {
-        CtThrow ctThrow = getFactory().createCtThrow(element.toString());
+    protected void repairInternal(CtConstructorCall<? extends Throwable> element) {
+        var ctThrow = getFactory().createThrow();
+        var thrownExpr = element.clone();
+        for (CtComment comment : thrownExpr.getComments()) {
+            comment.delete();
+            ctThrow.addComment(comment);
+        }
+        ctThrow.setThrownExpression(thrownExpr);
         element.replace(ctThrow);
     }
 }

--- a/src/test/resources/processor_test_files/3984_UnusedThrowable/SingleUnusedThrowable.java
+++ b/src/test/resources/processor_test_files/3984_UnusedThrowable/SingleUnusedThrowable.java
@@ -1,0 +1,9 @@
+/*
+Test case to repair a single unused throwable.
+ */
+
+public class SingleUnusedThrowable {
+    public void unusedThrowable() {
+        new IllegalArgumentException(); // Noncompliant
+    }
+}

--- a/src/test/resources/processor_test_files/3984_UnusedThrowable/SingleUnusedThrowable.java.exact
+++ b/src/test/resources/processor_test_files/3984_UnusedThrowable/SingleUnusedThrowable.java.exact
@@ -1,0 +1,1 @@
+        throw new IllegalArgumentException();

--- a/src/test/resources/processor_test_files/3984_UnusedThrowable/SingleUnusedThrowable.java.expected
+++ b/src/test/resources/processor_test_files/3984_UnusedThrowable/SingleUnusedThrowable.java.expected
@@ -1,0 +1,9 @@
+/*
+Test case to repair a single unused throwable.
+ */
+
+public class SingleUnusedThrowable {
+    public void unusedThrowable() {
+        throw new IllegalArgumentException(); // Noncompliant
+    }
+}


### PR DESCRIPTION
Fix #554 

This PR fixes a problem where the `UnusedThrowableProcessor` always creates a fully qualified name for the throwable, even when a simply qualified name is used initially. I.e. the repair looks like so:

```java
-new IllegalArgumentException();
+throw new java.lang.IllegalArgumentException();
```

With this fix, the repair looks as intended:

```java
-new IllegalArgumentException();
+throw new IllegalArgumentException();
```

In doing the exact match test to check that the printed reference is indeed simply qualified, I also discovered that comments on the thrown expression must be moved to the `CtThrow`, otherwise they are printed like this before the semicolon:

```java
throw new IllegalArgumentException()// here's a comment
;
```

And that just looks very strange.