### PR TITLE
fix(1854): Fix handling of unary operators in statement position

### DIFF
--- a/src/main/java/sorald/processor/DeadStoreProcessor.java
+++ b/src/main/java/sorald/processor/DeadStoreProcessor.java
@@ -257,6 +257,10 @@ public class DeadStoreProcessor extends SoraldAbstractProcessor<CtStatement> {
         if (element.getRoleInParent() != CtRole.STATEMENT) {
             safeDeleteDeadStoreInExpression(element);
             return;
+        } else if (element instanceof CtUnaryOperator) {
+            // unary operator in statement position: must be e.g. ++x, which we can just delete
+            element.delete();
+            return;
         }
 
         CtElement assignment =

--- a/src/test/resources/processor_test_files/1854_DeadStore/UnaryOpsInStatementPosition.java
+++ b/src/test/resources/processor_test_files/1854_DeadStore/UnaryOpsInStatementPosition.java
@@ -1,0 +1,26 @@
+/*
+Test case with unary prefix/suffix operators in statement position.
+ */
+
+public class UnaryOpsInStatementPosition {
+    public static void main(String[] args) {
+        int x = 2;
+        System.out.println(x);
+
+        x++; // Noncompliant
+        x = 3;
+        System.out.println(x);
+
+        ++x; // Noncompliant
+        x = 4;
+        System.out.println(x);
+
+        x--; // Noncompliant
+        x = 5;
+        System.out.println(x);
+
+        --x; // Noncompliant
+        x = 6;
+        System.out.println(x);
+    }
+}

--- a/src/test/resources/processor_test_files/1854_DeadStore/UnaryOpsInStatementPosition.java.expected
+++ b/src/test/resources/processor_test_files/1854_DeadStore/UnaryOpsInStatementPosition.java.expected
@@ -1,0 +1,22 @@
+/*
+Test case with unary prefix/suffix operators in statement position.
+ */
+
+public class UnaryOpsInStatementPosition {
+    public static void main(String[] args) {
+        int x = 2;
+        System.out.println(x);
+
+        x = 3;
+        System.out.println(x);
+
+        x = 4;
+        System.out.println(x);
+
+        x = 5;
+        System.out.println(x);
+
+        x = 6;
+        System.out.println(x);
+    }
+}


### PR DESCRIPTION
Fix #546 

This PR is a very minor extension to the `DeadStoreProcessor` that makes it just delete unary operators in statement position, as their return values can't possibly be read (because they're in statement position!).

When I opened #546 such unary operators were just ignored, but now the actually cause a crash. So this PR is doubly needed!