### PR TITLE
chore: Do not fail build if Codecov fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,8 +74,6 @@ jobs:
         run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27 # v1.5.0
-        with:
-          fail_ci_if_error: true
 
   test-support-scripts:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: no
 
 comment: false
 


### PR DESCRIPTION
Codecov fails sporadically, so we don't want to fail the build if it fails to upload.

Perhaps it's time to switch to Coveralls.