### PR TITLE
fix(2095): Retain finally-block from try when converting to try-with-resources

### DIFF
--- a/src/test/resources/processor_test_files/2095_UnclosedResources/OneClosedOneUnclosed.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/OneClosedOneUnclosed.java
@@ -1,0 +1,31 @@
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
+
+class OneClosedOneUnclosed {
+    public static void saveTo(File file1, File file2) {
+        BufferedWriter bw1 = null;
+        BufferedWriter bw2 = null;
+        try {
+            bw1 = new BufferedWriter(new FileWriter(file1));
+            bw1.write("Write some stuff to file 1");
+
+            bw2 = new BufferedWriter(new FileWriter(file2)); // Noncompliant
+            bw2.write("Write some stuff to file 2");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            System.out.println("done");
+            try {
+                if (bw1 != null) {
+                    bw1.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/OneClosedOneUnclosed.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/OneClosedOneUnclosed.java.expected
@@ -1,0 +1,29 @@
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
+
+class OneClosedOneUnclosed {
+    public static void saveTo(File file1, File file2) {
+        BufferedWriter bw1 = null;
+        try (BufferedWriter bw2 = new BufferedWriter(new FileWriter(file2))) {
+            bw1 = new BufferedWriter(new FileWriter(file1));
+            bw1.write("Write some stuff to file 1");
+
+            bw2.write("Write some stuff to file 2");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            System.out.println("done");
+            try {
+                if (bw1 != null) {
+                    bw1.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #540 (this is actually supposed to fix #540, not a mistake this time!)

This PR changes the `UnclosedResourcesProcessor` to retain the finally block when converting a try to a try-with-resources. Previously, it would just drop the finally block.