### PR TITLE
fix: Clean up out-of-scope references to auto-managed resource

### DIFF
--- a/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sorald/processor/UnclosedResourcesProcessor.java
@@ -36,12 +36,12 @@ public class UnclosedResourcesProcessor extends SoraldAbstractProcessor<CtConstr
 
     private void createCtTryWithResource(CtElement parent, CtLocalVariable<?> variable) {
         CtTryWithResource tryWithResource = getFactory().createTryWithResource();
-        tryWithResource.addResource(variable.clone());
+        tryWithResource.addResource(variable);
 
         CtBlock<?> enclosingBlock = parent.getParent(CtBlock.class);
         CtElement enclosingBlockParent = enclosingBlock.getParent();
         if (enclosingBlockParent instanceof CtTryWithResource) {
-            ((CtTryWithResource) enclosingBlockParent).addResource(variable.clone());
+            ((CtTryWithResource) enclosingBlockParent).addResource(variable);
             parent.delete();
         } else if (enclosingBlockParent instanceof CtTry) {
             CtTry enclosingTry = (CtTry) enclosingBlockParent;

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java
@@ -1,3 +1,10 @@
+/*
+Sometimes there is an "insufficient" close in the finalizer. In this example, bw1.close() might
+throw, so bw2.close() may not execute. In such cases, Sonar flags the bw2 initialization as an
+unclosed resource, but when we inline that into a resources block we must also make sure to clean
+out any references to the variable in the finalizer.
+ */
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java
@@ -1,0 +1,33 @@
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class BadCloseInFinally {
+
+    public static void saveTo(File file1, File file2) {
+        BufferedWriter bw1 = null;
+        BufferedWriter bw2 = null;
+        try {
+            bw1 = new BufferedWriter(new FileWriter(file1));
+            bw1.write("Write some stuff to file 1");
+
+            bw2 = new BufferedWriter(new FileWriter(file2)); // Noncompliant
+            bw2.write("Write some stuff to file 2");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            System.out.println("done");
+            try {
+                if (bw1 != null) {
+                    bw1.close();
+                }
+                if (bw2 != null) {
+                    bw2.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java.expected
@@ -1,0 +1,28 @@
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class BadCloseInFinally {
+
+    public static void saveTo(File file1, File file2) {
+        BufferedWriter bw1 = null;
+        try (BufferedWriter bw2 = new BufferedWriter(new FileWriter(file2))) {
+            bw1 = new BufferedWriter(new FileWriter(file1));
+            bw1.write("Write some stuff to file 1");
+
+            bw2.write("Write some stuff to file 2");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            System.out.println("done");
+            try {
+                if (bw1 != null) {
+                    bw1.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/BadCloseInFinally.java.expected
@@ -1,3 +1,10 @@
+/*
+Sometimes there is an "insufficient" close in the finalizer. In this example, bw1.close() might
+throw, so bw2.close() may not execute. In such cases, Sonar flags the bw2 initialization as an
+unclosed resource, but when we inline that into a resources block we must also make sure to clean
+out any references to the variable in the finalizer.
+ */
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 public class ReferenceInCatcher {
 
-    public static void saveTo(File file) {
+    public static void saveTo(File file) throws IOException {
         BufferedWriter bw = null;
         try {
             bw = new BufferedWriter(new FileWriter(file)); // Noncompliant

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java
@@ -1,0 +1,27 @@
+/*
+When an unclosed resource is referenced in a catcher, we must ensure that those references are
+removed when the resource is inlined into the resource list.
+ */
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ReferenceInCatcher {
+
+    public static void saveTo(File file) {
+        BufferedWriter bw = null;
+        try {
+            bw = new BufferedWriter(new FileWriter(file)); // Noncompliant
+            bw.write("Write some stuff to file");
+        } catch (IOException e) {
+            e.printStackTrace();
+            if (bw != null) {
+                bw.close();
+            }
+        } finally {
+            System.out.println("done");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java.expected
@@ -1,0 +1,22 @@
+/*
+When an unclosed resource is referenced in a catcher, we must ensure that those references are
+removed when the resource is inlined into the resource list.
+ */
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ReferenceInCatcher {
+
+    public static void saveTo(File file) {
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+            bw.write("Write some stuff to file");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            System.out.println("done");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcher.java.expected
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 public class ReferenceInCatcher {
 
-    public static void saveTo(File file) {
+    public static void saveTo(File file) throws IOException {
         try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
             bw.write("Write some stuff to file");
         } catch (IOException e) {

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java
@@ -1,0 +1,32 @@
+/*
+When the processor inlines a local variable declaration into the resources block, it also cleans
+up referenses to said variable in the catchers and finalizer. This test case includes a field
+with the same name as the inlined variable, and is meant to verify that we don't accidentally
+delete references to this unrelated field.
+ */
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource {
+    private int bw = 2;
+
+    public void saveTo(File file) {
+        BufferedWriter bw = null;
+        try {
+            bw = new BufferedWriter(new FileWriter(file)); // Noncompliant
+            bw.write("Write some stuff to file");
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.out.println(this.bw); // reference to field; should not be cleaned!
+            if (bw != null) { // reference to local variable; should be cleaned!
+                bw.close();
+            }
+        } finally {
+            System.out.println(this.bw); // reference to field; should not be cleaned!
+            System.out.println("done");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 public class ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource {
     private int bw = 2;
 
-    public void saveTo(File file) {
+    public void saveTo(File file) throws IOException {
         BufferedWriter bw = null;
         try {
             bw = new BufferedWriter(new FileWriter(file)); // Noncompliant

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java.expected
@@ -13,7 +13,7 @@ import java.io.IOException;
 public class ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource {
     private int bw = 2;
 
-    public void saveTo(File file) {
+    public void saveTo(File file) throws IOException {
         try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
             bw.write("Write some stuff to file");
         } catch (IOException e) {

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource.java.expected
@@ -1,0 +1,27 @@
+/*
+When the processor inlines a local variable declaration into the resources block, it also cleans
+up referenses to said variable in the catchers and finalizer. This test case includes a field
+with the same name as the inlined variable, and is meant to verify that we don't accidentally
+delete references to this unrelated field.
+ */
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource {
+    private int bw = 2;
+
+    public void saveTo(File file) {
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+            bw.write("Write some stuff to file");
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.out.println(this.bw); // reference to field; should not be cleaned!
+        } finally {
+            System.out.println(this.bw); // reference to field; should not be cleaned!
+            System.out.println("done");
+        }
+    }
+}

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
@@ -8,7 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class UnclosedResourceWithinTryWithResources {
-    public void readAndWrite() throws IOException {
+    public void readAndWrite() {
 
         try (FileInputStream is = new FileInputStream(new File("random/file/path"));
                 FileOutputStream os = new FileOutputStream(new File("some/other/file"))) {

--- a/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
+++ b/src/test/resources/processor_test_files/2095_UnclosedResources/UnclosedResourceWithinTryWithResources.java.expected
@@ -8,7 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class UnclosedResourceWithinTryWithResources {
-    public void readAndWrite() {
+    public void readAndWrite() throws IOException {
 
         try (FileInputStream is = new FileInputStream(new File("random/file/path"));
                 FileOutputStream os = new FileOutputStream(new File("some/other/file"))) {


### PR DESCRIPTION
Fix #561 

This PR makes the UnclosedResourcesProcessor clean up references to the variable that was inlined into the resource block. Previously, such left-over references were not cleaned up, causing compile errors.

Here's an example of the new-and-improved repair, note how it removes the `if` in the catcher:

```diff
 public class ReferenceInCatcherAndFinalizerToFieldWithSameNameAsResource {
     private int bw = 2;

     public void saveTo(File file) throws IOException {
-        BufferedWriter bw = null;
-        try {
-            bw = new BufferedWriter(new FileWriter(file)); // Noncompliant
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
             bw.write("Write some stuff to file");
         } catch (IOException e) {
             e.printStackTrace();
             System.out.println(this.bw); // reference to field; should not be cleaned!
-            if (bw != null) { // reference to local variable; should be cleaned!
-                bw.close(); // reference to local variable; should be cleaned!
-            }
         } finally {
             System.out.println(this.bw); // reference to field; should not be cleaned!
             System.out.println("done");

         }
     }
 }
```

It works by looking for references to the inlined variable inside the catchers and finalizer, and removing any statement containing a reference. It's possible that this could "over clean" for example by removing an `if` statement where the condition has a reference to the resource, but there's also unrelated stuff inside of the  then or else blocks. But I think we'll deal with that only if we actually find it happening, as I've said before, this processor will never be perfect.