### PR TITLE
test: Verify that processor test resources compile

### DIFF
--- a/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
+++ b/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
@@ -1,0 +1,68 @@
+package sorald.processor;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Meta tests for verifying that the processor test files compile as expected. */
+class ProcessorTestFilesCompileTest {
+
+    @ParameterizedTest
+    @MethodSource("provideCompilableProcessorTestInputFile")
+    void processorTestCaseInputFile_notMarkedNOCOMPILE_shouldCompile(File testCaseJavaFile)
+            throws IOException {
+        assertCompiles(testCaseJavaFile);
+    }
+
+    private static Stream<Arguments> provideCompilableProcessorTestInputFile() {
+        return getCompilableProcessorTestCases().map(tc -> tc.nonCompliantFile).map(Arguments::of);
+    }
+
+    private static Stream<ProcessorTestHelper.ProcessorTestCase<?>>
+            getCompilableProcessorTestCases() {
+        return ProcessorTestHelper.getTestCaseStream(ProcessorTestHelper.TEST_FILES_ROOT.toFile())
+                .filter(
+                        tc ->
+                                ProcessorTestHelper.isStandaloneCompilableTestFile(
+                                        tc.nonCompliantFile));
+    }
+
+    private static void assertCompiles(File javaFile) throws IOException {
+        var compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(
+                "System does not have a Java compiler, please run test suite with a JDK",
+                compiler,
+                notNullValue());
+
+        var diagnostics = new DiagnosticCollector<JavaFileObject>();
+        var fileManager = compiler.getStandardFileManager(diagnostics, null, null);
+        var compilationUnits =
+                fileManager.getJavaFileObjectsFromStrings(List.of(javaFile.getAbsolutePath()));
+        var task = compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnits);
+
+        boolean success = task.call();
+
+        List<String> messages =
+                diagnostics.getDiagnostics().stream()
+                        .map(Diagnostic::toString)
+                        .collect(Collectors.toList());
+
+        fileManager.close();
+
+        assertTrue(success, String.join(System.lineSeparator(), messages));
+    }
+}

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureTransformerFactoryUsage.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureTransformerFactoryUsage.java.expected
@@ -8,7 +8,7 @@ import java.io.StringWriter;
 
 public class InsecureTransformerFactoryUsage {
     public static String transform(String xslt, String xml) throws TransformerException {
-        TransformerFactory transformerFactory = createTransformerFactory();
+        TransformerFactory transformerFactory = createTrnsformerFactory();
         Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
 
         StringWriter writer = new StringWriter();

--- a/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureTransformerFactoryUsage.java.expected
+++ b/src/test/resources/processor_test_files/2755_XxeProcessing/InsecureTransformerFactoryUsage.java.expected
@@ -8,7 +8,7 @@ import java.io.StringWriter;
 
 public class InsecureTransformerFactoryUsage {
     public static String transform(String xslt, String xml) throws TransformerException {
-        TransformerFactory transformerFactory = createTrnsformerFactory();
+        TransformerFactory transformerFactory = createTransformerFactory();
         Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
 
         StringWriter writer = new StringWriter();


### PR DESCRIPTION
Fix #565 

This PR adds a test that runs through all Java input files and `.expected` Java files in `src/test/resources/processor_test_files` that are not prefixed and with `NOCOMPILE` and tries to compile them. If compilation fails, the test reports output like so:

```java
org.opentest4j.AssertionFailedError: /tmp/junit5557181061285140448/InsecureTransformerFactoryUsage.java:11: error: cannot find symbol
        TransformerFactory transformerFactory = createTrnsformerFactory();
                                                ^
  symbol:   method createTrnsformerFactory()
  location: class InsecureTransformerFactoryUsage ==> 
Expected :true
Actual   :false
```

Previously, the only verification we had that test resources compiled like they should was one of the Maven mode tests, and that would fail with a pretty non-obvious error message. It also did not check the `.expected` files, only the input `.java` files.