### PR TITLE
test: Verify that compilable Java files still compile after repair

### DIFF
--- a/src/test/java/sorald/Assertions.java
+++ b/src/test/java/sorald/Assertions.java
@@ -1,0 +1,57 @@
+package sorald;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+import org.apache.commons.lang3.tuple.Pair;
+
+/** High-level assertions. */
+public class Assertions {
+
+    /**
+     * Assert that the given Java file compiles on its own.
+     *
+     * @param javaFile A Java source file.
+     */
+    public static void assertCompiles(File javaFile) {
+        var compileResults = compile(javaFile);
+        boolean compileSuccessful = compileResults.getLeft();
+        String diagnosticsOutput = compileResults.getRight();
+
+        assertTrue(compileSuccessful, diagnosticsOutput);
+    }
+
+    /** Returns a pair (compileSuccess, diagnosticsOutput) */
+    private static Pair<Boolean, String> compile(File javaFile) {
+        // inspired comment by user GETah on StackOverflow: https://stackoverflow.com/a/8364016
+
+        var compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(
+                "System does not have a Java compiler, please run test suite with a JDK",
+                compiler,
+                notNullValue());
+
+        var diagnostics = new DiagnosticCollector<JavaFileObject>();
+        var fileManager = compiler.getStandardFileManager(diagnostics, null, null);
+        var compilationUnits =
+                fileManager.getJavaFileObjectsFromStrings(List.of(javaFile.getAbsolutePath()));
+        var task = compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnits);
+
+        boolean success = task.call();
+
+        String diagnosticsOutput =
+                diagnostics.getDiagnostics().stream()
+                        .map(Diagnostic::toString)
+                        .collect(Collectors.joining(System.lineSeparator()));
+
+        return Pair.of(success, diagnosticsOutput);
+    }
+}

--- a/src/test/java/sorald/processor/ProcessorTest.java
+++ b/src/test/java/sorald/processor/ProcessorTest.java
@@ -3,6 +3,7 @@ package sorald.processor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static sorald.Assertions.assertCompiles;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
 import org.sonar.java.checks.DeadStoreCheck;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -114,6 +116,23 @@ public class ProcessorTest {
 
         assertEquals(expectedTypes, repairedTypes);
         assertEquals(expectedImports, repairedImports);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getCompilableProcessorTestCases")
+    void sorald_producesCompilableOutput_whenInputIsCompilable(
+            ProcessorTestHelper.ProcessorTestCase<?> compilableTestCase) throws Exception {
+        ProcessorTestHelper.runSorald(compilableTestCase);
+        assertCompiles(compilableTestCase.repairedFilePath().toFile());
+    }
+
+    private static Stream<Arguments> getCompilableProcessorTestCases() throws IOException {
+        return ProcessorTestHelper.getTestCaseStream()
+                .filter(
+                        tc ->
+                                ProcessorTestHelper.isStandaloneCompilableTestFile(
+                                        tc.nonCompliantFile))
+                .map(Arguments::of);
     }
 
     /**

--- a/src/test/java/sorald/processor/ProcessorTest.java
+++ b/src/test/java/sorald/processor/ProcessorTest.java
@@ -3,6 +3,7 @@ package sorald.processor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static sorald.Assertions.assertCompiles;
 
 import java.io.File;
@@ -11,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.json.JSONArray;
@@ -37,6 +39,9 @@ import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtType;
 
 public class ProcessorTest {
+
+    private static final Set<String> FILES_THAT_DONT_COMPILE_AFTER_REPAIR =
+            Set.of("MathOnFloat.java", "CastArithmeticOperand.java");
 
     /**
      * Parameterized test that processes a single Java file at a time with a single processor.
@@ -122,6 +127,11 @@ public class ProcessorTest {
     @MethodSource("getCompilableProcessorTestCases")
     void sorald_producesCompilableOutput_whenInputIsCompilable(
             ProcessorTestHelper.ProcessorTestCase<?> compilableTestCase) throws Exception {
+        assumeFalse(
+                FILES_THAT_DONT_COMPILE_AFTER_REPAIR.contains(
+                        compilableTestCase.nonCompliantFile.getName()),
+                "See https://github.com/SpoonLabs/sorald/issues/570");
+
         ProcessorTestHelper.runSorald(compilableTestCase);
         assertCompiles(compilableTestCase.repairedFilePath().toFile());
     }

--- a/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
+++ b/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
@@ -1,20 +1,11 @@
 package sorald.processor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static sorald.Assertions.assertCompiles;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.tools.Diagnostic;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaFileObject;
-import javax.tools.ToolProvider;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -25,8 +16,7 @@ class ProcessorTestFilesCompileTest {
 
     @ParameterizedTest
     @MethodSource("provideCompilableProcessorTestInputFile")
-    void processorTestCaseInputFile_notMarkedNOCOMPILE_shouldCompile(File testCaseJavaFile)
-            throws IOException {
+    void processorTestCaseInputFile_notMarkedNOCOMPILE_shouldCompile(File testCaseJavaFile) {
         assertCompiles(testCaseJavaFile);
     }
 
@@ -66,39 +56,5 @@ class ProcessorTestFilesCompileTest {
                         tc ->
                                 ProcessorTestHelper.isStandaloneCompilableTestFile(
                                         tc.nonCompliantFile));
-    }
-
-    private static void assertCompiles(File javaFile) throws IOException {
-        var compileResults = compile(javaFile);
-        boolean compileSuccessful = compileResults.getLeft();
-        String diagnosticsOutput = compileResults.getRight();
-
-        assertTrue(compileSuccessful, diagnosticsOutput);
-    }
-
-    /** Returns a pair (compileSuccess, diagnosticsOutput) */
-    private static Pair<Boolean, String> compile(File javaFile) {
-        // inspired comment by user GETah on StackOverflow: https://stackoverflow.com/a/8364016
-
-        var compiler = ToolProvider.getSystemJavaCompiler();
-        assertThat(
-                "System does not have a Java compiler, please run test suite with a JDK",
-                compiler,
-                notNullValue());
-
-        var diagnostics = new DiagnosticCollector<JavaFileObject>();
-        var fileManager = compiler.getStandardFileManager(diagnostics, null, null);
-        var compilationUnits =
-                fileManager.getJavaFileObjectsFromStrings(List.of(javaFile.getAbsolutePath()));
-        var task = compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnits);
-
-        boolean success = task.call();
-
-        String diagnosticsOutput =
-                diagnostics.getDiagnostics().stream()
-                        .map(Diagnostic::toString)
-                        .collect(Collectors.joining(System.lineSeparator()));
-
-        return Pair.of(success, diagnosticsOutput);
     }
 }


### PR DESCRIPTION
Fix #563 

This PR adds a test case that checks that files that are compilable before repair, are also compilable after. There are two test cases that fail, `CastArithmeticOperand.java` and `MathOnFloat.java`. Both fail due to "potentially lossy conversion from double to float".

[Link to failures](https://github.com/SpoonLabs/sorald/runs/2818084309?check_suite_focus=true#step:10:905).