### PR TITLE
fix: Fix test errors caused by compile output in test resources

### DIFF
--- a/src/test/java/sorald/GatherStatsTest.java
+++ b/src/test/java/sorald/GatherStatsTest.java
@@ -31,7 +31,7 @@ public class GatherStatsTest {
     public void statisticsFile_containsExpectedStats(
             RepairStrategy repairStrategy, @TempDir File tempDir) throws Exception {
         ProcessorTestHelper.ProcessorTestCase<?> testCase =
-                ProcessorTestHelper.getTestCaseStream()
+                ProcessorTestHelper.getTestCasesInTemporaryDirectory()
                         .filter(tc -> tc.ruleKey.equals("2755"))
                         .findFirst()
                         .get();

--- a/src/test/java/sorald/processor/ProcessorTest.java
+++ b/src/test/java/sorald/processor/ProcessorTest.java
@@ -77,7 +77,7 @@ public class ProcessorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext)
                 throws IOException {
-            return ProcessorTestHelper.getTestCaseStream().map(Arguments::of);
+            return ProcessorTestHelper.getTestCasesInTemporaryDirectory().map(Arguments::of);
         }
     }
 
@@ -137,7 +137,7 @@ public class ProcessorTest {
     }
 
     private static Stream<Arguments> getCompilableProcessorTestCases() throws IOException {
-        return ProcessorTestHelper.getTestCaseStream()
+        return ProcessorTestHelper.getTestCasesInTemporaryDirectory()
                 .filter(
                         tc ->
                                 ProcessorTestHelper.isStandaloneCompilableTestFile(
@@ -192,7 +192,7 @@ public class ProcessorTest {
         // arrange
         // rule 2755 always adds new elements, among other things a method
         ProcessorTestHelper.ProcessorTestCase<?> testCase =
-                ProcessorTestHelper.getTestCaseStream()
+                ProcessorTestHelper.getTestCasesInTemporaryDirectory()
                         .filter(tc -> tc.ruleKey.equals("2755"))
                         .findFirst()
                         .get();
@@ -234,7 +234,7 @@ public class ProcessorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext)
                 throws IOException {
-            return ProcessorTestHelper.getTestCaseStream()
+            return ProcessorTestHelper.getTestCasesInTemporaryDirectory()
                     .filter(testCase -> testCase.expectedOutfile().isPresent())
                     .map(Arguments::of);
         }
@@ -246,7 +246,7 @@ public class ProcessorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context)
                 throws Exception {
-            return ProcessorTestHelper.getTestCaseStream()
+            return ProcessorTestHelper.getTestCasesInTemporaryDirectory()
                     .filter(testCase -> testCase.getExpectedExactMatches().size() > 0)
                     .map(Arguments::of);
         }

--- a/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
+++ b/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
@@ -52,7 +52,7 @@ class ProcessorTestFilesCompileTest {
 
     private static Stream<ProcessorTestHelper.ProcessorTestCase<?>>
             getCompilableProcessorTestCases() throws IOException {
-        return ProcessorTestHelper.getTestCaseStream()
+        return ProcessorTestHelper.getTestCasesInTemporaryDirectory()
                 .filter(
                         tc ->
                                 ProcessorTestHelper.isStandaloneCompilableTestFile(

--- a/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
+++ b/src/test/java/sorald/processor/ProcessorTestFilesCompileTest.java
@@ -20,7 +20,7 @@ class ProcessorTestFilesCompileTest {
         assertCompiles(testCaseJavaFile);
     }
 
-    private static Stream<Arguments> provideCompilableProcessorTestInputFile() {
+    private static Stream<Arguments> provideCompilableProcessorTestInputFile() throws IOException {
         return getCompilableProcessorTestCases().map(tc -> tc.nonCompliantFile).map(Arguments::of);
     }
 
@@ -32,7 +32,8 @@ class ProcessorTestFilesCompileTest {
         assertCompiles(javaFile);
     }
 
-    private static Stream<Arguments> provideCompilableProcessorTestExpectedFiles() {
+    private static Stream<Arguments> provideCompilableProcessorTestExpectedFiles()
+            throws IOException {
         return getCompilableProcessorTestCases()
                 .flatMap(tc -> tc.expectedOutfile().stream())
                 .map(Arguments::of);
@@ -50,8 +51,8 @@ class ProcessorTestFilesCompileTest {
     }
 
     private static Stream<ProcessorTestHelper.ProcessorTestCase<?>>
-            getCompilableProcessorTestCases() {
-        return ProcessorTestHelper.getTestCaseStream(ProcessorTestHelper.TEST_FILES_ROOT.toFile())
+            getCompilableProcessorTestCases() throws IOException {
+        return ProcessorTestHelper.getTestCaseStream()
                 .filter(
                         tc ->
                                 ProcessorTestHelper.isStandaloneCompilableTestFile(

--- a/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -160,9 +160,12 @@ public class ProcessorTestHelper {
 
     /**
      * Return a stream of all valid test cases, based on the tests files in {@link
-     * ProcessorTestHelper#TEST_FILES_ROOT}.
+     * ProcessorTestHelper#TEST_FILES_ROOT}. The test case source files are put in a temporary
+     * directory to facilitate tests that produce artifacts (e.g. compilation) or change the files
+     * (e.g. repairing).
      */
-    public static Stream<ProcessorTestCase<?>> getTestCaseStream() throws IOException {
+    public static Stream<ProcessorTestCase<?>> getTestCasesInTemporaryDirectory()
+            throws IOException {
         return getTestCaseStream(TestHelper.createTemporaryProcessorTestFilesWorkspace().toFile());
     }
 


### PR DESCRIPTION
Fix #573 

The cause of #573 was that the compile test introduced in #566 produced .class files in the test resources directory. These class files would then cause the surefire plugin to crash for some reason. I don't know why it crashes because of that, but the class files shouldn't be there either way.

This also explains why only the deploy job failed: it runs the tests twice, once when running `package` and once when running `deploy` (we should probably remove the `package` target). All of the other jobs run the tests only once, and thus don't encounter the problem.

The reason this happened was that there are two overloads of the `ProcessorTestHelper.getTestCaseStream()` method. One of them returns the test cases for the resources in a directory (this was the one that was used), and the other one copies all test resources to a temporary directory and then returns test cases based on that (this is the one that should have been used).

This PR changes the tests to use the method that copies the resources to a temporary directory first, and also renames that method and updates its documentation to avoid this confusion in the future.