### PR TITLE
refactor: Extract not method into Transformations utility class

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,6 +44,11 @@ When merging a PR, maintainers should take care to:
 
 For adding a new processor in Sorald, please, follow the instructions described below.
 
+0) Familiarize yourself with the [`sorald.util` utility package](#reusable-utility-classes-and-methods)
+
+This is to ensure that you do not recreate functionality that we already have a
+solution for.
+
 1) Find the name for the new processor
 
 The first step is to find the name for the new processor.
@@ -117,6 +122,14 @@ Transformation:
 ```
 
 And then you can submit your PR!
+
+### Reusable utility classes and methods
+
+In the [sorald.util](/src/main/sorald/util) package we collect utility classes
+and methods for use throughout Sorald. It's a good idea to have a look through
+it before writing a processor. For example, the
+[Transformations](/src/main/sorald/util/Transformations.java) class contains
+high-level transformations that may be of use to you.
 
 ### Guidelines for testing processors
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -125,10 +125,10 @@ And then you can submit your PR!
 
 ### Reusable utility classes and methods
 
-In the [sorald.util](/src/main/sorald/util) package we collect utility classes
+In the [sorald.util](/src/main/java/sorald/util) package we collect utility classes
 and methods for use throughout Sorald. It's a good idea to have a look through
 it before writing a processor. For example, the
-[Transformations](/src/main/sorald/util/Transformations.java) class contains
+[Transformations](/src/main/java/sorald/util/Transformations.java) class contains
 high-level transformations that may be of use to you.
 
 ### Guidelines for testing processors

--- a/src/main/java/sorald/processor/CollectionIsEmptyProcessor.java
+++ b/src/main/java/sorald/processor/CollectionIsEmptyProcessor.java
@@ -1,5 +1,7 @@
 package sorald.processor;
 
+import static sorald.util.Transformations.not;
+
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtMethod;
@@ -23,12 +25,5 @@ public class CollectionIsEmptyProcessor extends SoraldAbstractProcessor<CtBinary
         CtExpression<?> expression =
                 element.getKind() == BinaryOperatorKind.EQ ? newInvocation : not(newInvocation);
         element.replace(expression);
-    }
-
-    private <T> CtUnaryOperator<T> not(CtExpression<T> expr) {
-        CtUnaryOperator<T> operator = getFactory().createUnaryOperator();
-        operator.setKind(UnaryOperatorKind.NOT);
-        operator.setOperand(expr);
-        return operator;
     }
 }

--- a/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -1,12 +1,12 @@
 package sorald.processor;
 
+import static sorald.util.Transformations.not;
+
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtMethod;
 
 @ProcessorAnnotation(
@@ -29,12 +29,5 @@ public class CompareStringsBoxedTypesWithEqualsProcessor
         CtExpression<?> expr =
                 element.getKind() == BinaryOperatorKind.NE ? not(lhsEqualsRhs) : lhsEqualsRhs;
         element.replace(expr);
-    }
-
-    private <T> CtUnaryOperator<T> not(CtExpression<T> expr) {
-        CtUnaryOperator<T> op = getFactory().createUnaryOperator();
-        op.setKind(UnaryOperatorKind.NOT);
-        op.setOperand(expr);
-        return op;
     }
 }

--- a/src/main/java/sorald/util/Transformations.java
+++ b/src/main/java/sorald/util/Transformations.java
@@ -1,0 +1,25 @@
+package sorald.util;
+
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.UnaryOperatorKind;
+
+/** Reusable transformations for use across the entire project. */
+public class Transformations {
+
+    private Transformations() {}
+
+    /**
+     * Negate an expression, i.e. turn `expr` into `!expr`.
+     *
+     * @param expr Expression to negate
+     * @param <T> Type of the expression
+     * @return The negation of the input expression
+     */
+    public static <T> CtUnaryOperator<T> not(CtExpression<T> expr) {
+        CtUnaryOperator<T> operator = expr.getFactory().createUnaryOperator();
+        operator.setKind(UnaryOperatorKind.NOT);
+        operator.setOperand(expr);
+        return operator;
+    }
+}


### PR DESCRIPTION
Fix #572 

This PR adds a new `Transformations` utility class, which is meant to house reusable high-level transformation methods for use across the entire project. If we look through the project, I think we'll find many more recurring transformations that can be extracted into this class.

Note that this class is specifically for transformations. I think that if we want reusable Spoon-"something else", we should create another class with an appropriate name for that.