### PR TITLE
refactor: Replace use of ImmutableList with List.copyOf

### DIFF
--- a/src/main/java/sorald/event/collectors/MinerStatisticsCollector.java
+++ b/src/main/java/sorald/event/collectors/MinerStatisticsCollector.java
@@ -1,6 +1,5 @@
 package sorald.event.collectors;
 
-import com.google.common.collect.ImmutableList;
 import java.util.*;
 import java.util.stream.Collectors;
 import sorald.event.SoraldEvent;
@@ -66,7 +65,7 @@ public class MinerStatisticsCollector implements SoraldEventHandler {
                                 new MinedRule(
                                         e.getKey().split(RULE_ID_SEPARATOR)[0],
                                         e.getKey().split(RULE_ID_SEPARATOR)[1],
-                                        ImmutableList.copyOf(e.getValue())))
+                                        e.getValue()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/sorald/event/models/miner/MinedRule.java
+++ b/src/main/java/sorald/event/models/miner/MinedRule.java
@@ -1,21 +1,20 @@
 package sorald.event.models.miner;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 import sorald.event.models.WarningLocation;
 
 public class MinedRule {
     private final String ruleKey;
     private final String ruleName;
-    private final ImmutableList<WarningLocation> warningLocations;
+    private final List<WarningLocation> warningLocations;
 
-    public MinedRule(
-            String ruleKey, String ruleName, ImmutableList<WarningLocation> warningLocations) {
+    public MinedRule(String ruleKey, String ruleName, List<WarningLocation> warningLocations) {
         this.ruleKey = ruleKey;
         this.ruleName = ruleName;
-        this.warningLocations = warningLocations;
+        this.warningLocations = List.copyOf(warningLocations);
     }
 
-    public ImmutableList<WarningLocation> getWarningLocations() {
+    public List<WarningLocation> getWarningLocations() {
         return warningLocations;
     }
 


### PR DESCRIPTION
#331 

The package containing `ImmutableList` is a transitive dependency of Sorald through SonarJava. It's not there anymore in SonarJava 7+, and so this PR removes the two uses of it. The same functionality is available as unmodifiable lists in the standard library, so I don't think it's a good idea to pull in a dependency just for this.