### PR TITLE
doc: Add badge and text on platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sorald [![Travis Build Status](https://travis-ci.com/SpoonLabs/sorald.svg?branch=master)](https://travis-ci.com/SpoonLabs/sorald) [![Code Coverage](https://codecov.io/gh/SpoonLabs/sorald/branch/master/graph/badge.svg)](https://codecov.io/gh/SpoonLabs/sorald)
+# Sorald [![Travis Build Status](https://travis-ci.com/SpoonLabs/sorald.svg?branch=master)](https://travis-ci.com/SpoonLabs/sorald) [![Code Coverage](https://codecov.io/gh/SpoonLabs/sorald/branch/master/graph/badge.svg)](https://codecov.io/gh/SpoonLabs/sorald) ![Supported Platforms](https://img.shields.io/badge/platforms-Linux%2C%20macOS-blue.svg)
 Sorald is a tool to automatically repair violations of static analysis rules checked with [SonarQube](https://rules.sonarsource.com).
 It can currently repair violations of [25+ rules](/docs/HANDLED_RULES.md) based on the design described [Sorald: Automatic Patch Suggestions for SonarQube Static Analysis Violations](http://arxiv.org/pdf/2103.12033).
 
@@ -18,6 +18,9 @@ If you use Sorald in an academic context, please cite:
 ## Getting started
 
 ### Prerequisites 
+
+Sorald supports macOS and Linux, with
+[support for Windows in the pipeline](https://github.com/spoonlabs/sorald/issues/273).
 
 For running Sorald, all you need is a Java 11+ runtime.
 


### PR DESCRIPTION
As noted in #273, we currently don't support Windows, but there's really no mention of that anywhere other than the issue tracker. In the past year, two Windows users have reported problems, see #335 and #589.

This PR adds a badge at the top of the README with the supported platforms, as well as some text in the `Prerequisites` section.