### PR TITLE
feat: Add Windows support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Check formatting with spotless
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: mvn spotless:check
       - name: Build project
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Disable Git's autocrlf on Windows
-        if: ${{ matix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: git config --global core.autocrlf false
 
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
+      - name: Disable Git's autocrlf on Windows
+        if: ${{ matix.os == 'windows-latest' }}
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
         with:
           fetch-depth: 0  # SonarCloud prefers non-shallow clones

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ If you use Sorald in an academic context, please cite:
 ### Prerequisites 
 
 Sorald supports macOS and Linux, with
-[support for Windows in the pipeline](https://github.com/spoonlabs/sorald/issues/273).
+[currently partial support for Windows (some features may not work
+yet)](https://github.com/spoonlabs/sorald/issues/273).
 
 For running Sorald, all you need is a Java 11+ runtime.
 

--- a/src/test/java/sorald/GatherStatsTest.java
+++ b/src/test/java/sorald/GatherStatsTest.java
@@ -12,6 +12,8 @@ import java.util.ArrayList;
 import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -23,6 +25,7 @@ import sorald.rule.RuleViolation;
 import sorald.sonar.ProjectScanner;
 import sorald.sonar.SonarRule;
 
+@DisabledOnOs(OS.WINDOWS) // FIXME make this test class pass on Windows
 public class GatherStatsTest {
 
     @ParameterizedTest

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import sorald.processor.ArrayHashCodeAndToStringProcessor;
 import sorald.processor.ProcessorTestHelper;
 import sorald.processor.SoraldAbstractProcessor;
@@ -82,6 +84,7 @@ public class SegmentStrategyTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS) // FIXME Make this test pass on Windows
     public void segmentStrategy_doesNotFail_onCrashInParsingSegment() throws IOException {
         // arrange
         Path workspace = TestHelper.createTemporaryProcessorTestFilesWorkspace();

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -99,15 +99,17 @@ public class TargetedRepairTest {
     public void targetedRepair_acceptsAbsoluteViolationPath() throws Exception {
         // arrange
         TargetedRepairWorkdirInfo workdirInfo = setupWorkdir();
-
-        // act
         Path rootDir = workdirInfo.workdir.toPath().getRoot();
-        String absoluteViolationId =
+        String[] violationIdParts =
                 workdirInfo
                         .targetViolation
                         .relativeSpecifier(rootDir)
-                        .replaceFirst(
-                                Constants.VIOLATION_SPECIFIER_SEP, File.pathSeparator + rootDir);
+                        .split(Constants.VIOLATION_SPECIFIER_SEP);
+        violationIdParts[1] = rootDir.resolve(violationIdParts[1]).toString();
+        String absoluteViolationId =
+                String.join(Constants.VIOLATION_SPECIFIER_SEP, violationIdParts);
+
+        // act
         Main.main(
                 new String[] {
                     Constants.REPAIR_COMMAND_NAME,

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import sorald.processor.BigDecimalDoubleConstructorProcessor;
 import sorald.processor.ProcessorTestHelper;
@@ -27,6 +29,7 @@ import sorald.sonar.ProjectScanner;
 import sorald.sonar.SonarRule;
 
 /** Tests for the targeted repair functionality of Sorald. */
+@DisabledOnOs(OS.WINDOWS) // FIXME Make this test class pass on Windows
 public class TargetedRepairTest {
 
     @Test


### PR DESCRIPTION
fix #589, fix #335

Partially addresses #273 

This PR adds _core_ support for Windows, along with a Windows build in the CI. Note that statistics gathering, targeted repair and segment mode tests are not passing: they are currently disabled on Windows.