### PR TITLE
refactor: store excluded references in a set which wraps `IdentityHashMap`

### DIFF
--- a/src/main/java/sorald/SelectiveForceImport.java
+++ b/src/main/java/sorald/SelectiveForceImport.java
@@ -1,7 +1,9 @@
 package sorald;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Set;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.ForceImportProcessor;
@@ -12,20 +14,20 @@ import spoon.reflect.visitor.LexicalScope;
  * references.
  */
 public class SelectiveForceImport extends ForceImportProcessor {
-    // use identity rather than equality to identify existing references to avoid mistaking clones
-    // for originals
-    private final IdentityHashMap<CtTypeReference<?>, Boolean> excludedReferences;
+    private final Set<CtTypeReference<?>> excludedReferences;
 
     /** @param referencesToIgnore A collection of references to ignore when force-importing. */
     public SelectiveForceImport(Collection<CtTypeReference<?>> referencesToIgnore) {
-        excludedReferences = new IdentityHashMap<>();
-        referencesToIgnore.forEach(ref -> excludedReferences.put(ref, true));
+        // use identity rather than equality to identify existing references to avoid mistaking
+        // clones for originals
+        excludedReferences = Collections.newSetFromMap(new IdentityHashMap<>());
+        excludedReferences.addAll(referencesToIgnore);
     }
 
     @Override
     protected void handleTypeReference(
             CtTypeReference<?> reference, LexicalScope nameScope, CtRole role) {
-        if (!excludedReferences.containsKey(reference)) {
+        if (!excludedReferences.contains(reference)) {
             super.handleTypeReference(reference, nameScope, role);
         }
     }


### PR DESCRIPTION
Reference #602 

I thought I would refactor the code first as suggested by @slarse. 

> Just glancing at that code I would begin with wrapping that map in a set (with Collections.newSetFromMap), because the values aren't used :)

