### PR TITLE
fix: disable custom security manager for tests which indirectly look up the path of `mvn` executable

### DIFF
--- a/src/test/java/sorald/ClasspathModeTest.java
+++ b/src/test/java/sorald/ClasspathModeTest.java
@@ -19,6 +19,9 @@ class ClasspathModeTest {
     @Test
     void resolveClasspathFrom_enablesRepairOfViolation_thatRequiresClasspathToDetect(
             @TempDir File workdir) throws IOException {
+        // use the default security manager
+        System.setSecurityManager(null);
+
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
                 TestHelper.PATH_TO_RESOURCES_FOLDER

--- a/src/test/java/sorald/MavenLauncherTest.java
+++ b/src/test/java/sorald/MavenLauncherTest.java
@@ -22,6 +22,9 @@ public class MavenLauncherTest {
     @Test
     public void sorald_repairsProductionAndTestCode_inMavenProject(@TempDir File workdir)
             throws IOException {
+        // use the default security manager
+        System.setSecurityManager(null);
+
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
                 TestHelper.PATH_TO_RESOURCES_FOLDER
@@ -64,6 +67,9 @@ public class MavenLauncherTest {
     @Test
     void sorald_repairsRuleViolation_thatRequiresClasspathToDetect(@TempDir File workdir)
             throws IOException {
+        // use the default security manager
+        System.setSecurityManager(null);
+
         // arrange
         org.apache.commons.io.FileUtils.copyDirectory(
                 TestHelper.PATH_TO_RESOURCES_FOLDER

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -194,6 +194,9 @@ public class WarningMinerTest {
     @Test
     void canDetectRuleViolation_thatRequiresClasspath_whenResolvingClasspathInMavenProject(
             @TempDir File tempdir) throws Exception {
+        // use the default security manager
+        System.setSecurityManager(null);
+
         Path statsFile = tempdir.toPath().resolve("stats.json");
         Path projectRoot =
                 TestHelper.PATH_TO_RESOURCES_FOLDER


### PR DESCRIPTION
Fixes #612 

After a [long debugging session](https://github.com/INRIA/spoon/pull/4272) with @slarse , we finally decided to disable our custom security manager (`SystemExitHandler`) as that was causing problems. See [this comment](https://github.com/actions/virtual-environments/issues/4485#issuecomment-968115508) for explanation.