### PR TITLE
chore: remove org.reflections:reflections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.7.0.202003110725-r</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,11 +139,6 @@
             <version>5.7.0.202003110725-r</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.12</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.7.0.202003110725-r</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>


### PR DESCRIPTION
```
-------------------------------------------------------
 D E P C L E A N   A N A L Y S I S   R E S U L T S
-------------------------------------------------------
USED DIRECT DEPENDENCIES [7]: 
        org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r:compile (2 MB)
        org.sonarsource.java:java-checks:6.9.0.23563:compile (2 MB)
        fr.inria.gforge.spoon:spoon-core:10.0.1-SNAPSHOT:compile (1 MB)
        org.sonarsource.java:java-frontend:6.9.0.23563:compile (909 KB)
        info.picocli:picocli:4.5.2:compile (381 KB)
        commons-io:commons-io:2.7:compile (269 KB)
        org.json:json:20190722:compile (63 KB)
USED INHERITED DEPENDENCIES [0]: 
USED TRANSITIVE DEPENDENCIES [31]: 
        org.bouncycastle:bcprov-jdk15on:1.64:compile (4 MB)
        org.sonarsource.sonarqube:sonar-plugin-api:7.9:compile (3 MB)
        com.google.guava:guava:26.0-jre:compile (2 MB)
        com.fasterxml.jackson.core:jackson-databind:2.13.0:compile (1 MB)
        xerces:xercesImpl:2.12.0:compile (1 MB)
        org.apache.commons:commons-compress:1.21:compile (994 KB)
        org.apache.commons:commons-lang3:3.12.0:compile (573 KB)
        com.fasterxml.woodstox:woodstox-core:5.2.0:compile (506 KB)
        com.fasterxml.jackson.core:jackson-core:2.13.0:compile (365 KB)
        org.bouncycastle:bcpg-jdk15on:1.64:compile (321 KB)
        commons-lang:commons-lang:2.6:compile (277 KB)
        org.codehaus.plexus:plexus-utils:3.3.0:compile (257 KB)
        com.google.code.gson:gson:2.8.6:compile (234 KB)
        org.apache.maven:maven-model:3.8.4:compile (210 KB)
        org.sonarsource.sslr:sslr-core:1.23:compile (193 KB)
        org.checkerframework:checker-qual:2.5.2:compile (188 KB)
        org.codehaus.woodstox:stax2-api:4.1:compile (165 KB)
        com.googlecode.javaewah:JavaEWAH:1.1.7:compile (162 KB)
        org.apache.maven.shared:maven-shared-utils:3.3.3:compile (150 KB)
        com.fasterxml.jackson.core:jackson-annotations:2.13.0:compile (73 KB)
        org.sonarsource.analyzer-commons:sonar-analyzer-commons:1.12.0.632:compile (72 KB)
        com.martiansoftware:jsap:2.1:compile (67 KB)
        org.slf4j:slf4j-api:1.7.25:compile (40 KB)
        com.google.code.findbugs:jsr305:1.3.9:compile (32 KB)
        org.apache.maven.shared:maven-invoker:3.1.0:compile (31 KB)
        org.sonarsource.analyzer-commons:sonar-xml-parsing:1.12.0.632:compile (26 KB)
        com.google.errorprone:error_prone_annotations:2.1.3:compile (13 KB)
        org.sonarsource.analyzer-commons:sonar-analyzer-recognizers:1.12.0.632:compile (9 KB)
        com.google.j2objc:j2objc-annotations:1.1:compile (8 KB)
        javax.inject:javax.inject:1:compile (2 KB)
        org.sonarsource.java:jdt:shaded:6.9.0.23563 (size unknown)
POTENTIALLY UNUSED DIRECT DEPENDENCIES [2]: 
        org.reflections:reflections:0.9.12:compile (103 KB)
        org.sonarsource.java:java-checks-testkit:6.9.0.23563:compile (5 KB)
POTENTIALLY UNUSED INHERITED DEPENDENCIES [0]: 
POTENTIALLY UNUSED TRANSITIVE DEPENDENCIES [16]: 
        org.eclipse.jdt:org.eclipse.jdt.core:3.23.0:compile (6 MB)
        org.eclipse.platform:org.eclipse.osgi:3.17.0:compile (1 MB)
        org.eclipse.platform:org.eclipse.core.resources:3.15.100:compile (879 KB)
        org.bouncycastle:bcpkix-jdk15on:1.64:compile (857 KB)
        org.javassist:javassist:3.26.0-GA:compile (764 KB)
        cglib:cglib-nodep:3.2.5:compile (344 KB)
        org.eclipse.platform:org.eclipse.text:3.12.0:compile (288 KB)
        com.jcraft:jsch:0.1.55:compile (275 KB)
        org.eclipse.platform:org.eclipse.equinox.common:3.15.0:compile (139 KB)
        org.eclipse.platform:org.eclipse.equinox.preferences:3.9.0:compile (136 KB)
        org.eclipse.platform:org.eclipse.core.commands:3.10.100:compile (114 KB)
        org.eclipse.platform:org.eclipse.core.jobs:3.12.0:compile (108 KB)
        org.eclipse.platform:org.eclipse.core.contenttype:3.8.0:compile (100 KB)
        org.eclipse.platform:org.eclipse.core.runtime:3.23.0:compile (70 KB)
        com.jcraft:jzlib:1.1.1:compile (67 KB)
        org.codehaus.mojo:animal-sniffer-annotations:1.14:compile (3 KB)
```
I ran depclean v2.0.1 over sorald https://github.com/SpoonLabs/sorald/commit/8762596558e49be194e4033e3094cc702d6768fd and it generated the above report. This PR removes the **Unused direct dependency**. 

Thanks for the amazing tool, @cesarsotovalero and all its contributors!