### PR TITLE
docs: update tests files and description for S2111

### DIFF
--- a/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.md
+++ b/src/main/java/sorald/processor/BigDecimalDoubleConstructorProcessor.md
@@ -1,4 +1,4 @@
-Any constructor of `BigDecimal` that has a parameter of type `float` or `double` is replaced with an invocation of the `BigDecimal.valueOf(parameter)` method.
+Constructor of `BigDecimal` that has *exactly* one parameter of type, either `float` or `double`, is replaced with an invocation of the `BigDecimal.valueOf(parameter)` method.
 
 Example:
 ```diff
@@ -12,13 +12,13 @@ Example:
 +        BigDecimal bd3 = BigDecimal.valueOf(f);
 ```
 
-When the constructor of `BigDecimal` being called has two arguments, being the first one of type `float` or `double`, that argument is changed to `String`.
+When the constructor of `BigDecimal` is called with two or more arguments, the first argument is enclosed in a string if it is of type `float` or `double`.
 
 Example:
 ```diff
         MathContext mc;
--       BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
--       BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+-       BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Enclose the first argument in a string.}}
+-       BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Enclose the first argument in a string.}}
 +       BigDecimal bd4 = new BigDecimal("2.0", mc);
 +       BigDecimal bd6 = new BigDecimal("2.0", mc);
 ```

--- a/src/test/resources/processor_test_files/S2111_BigDecimalDoubleConstructor/BigDecimalDoubleConstructor.java
+++ b/src/test/resources/processor_test_files/S2111_BigDecimalDoubleConstructor/BigDecimalDoubleConstructor.java
@@ -17,9 +17,9 @@ public class BigDecimalDoubleConstructor {
         MathContext mc = null;
         BigDecimal bd1 = new BigDecimal("1");
         BigDecimal bd2 = new BigDecimal(2.0); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
-        BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+        BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Enclose the first argument in a string.}}
         BigDecimal bd5 = new BigDecimal(2.0f); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
-        BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+        BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Enclose the first argument in a string.}}
         BigDecimal bd3 = BigDecimal.valueOf(2.0);
     }
 


### PR DESCRIPTION
The processor for `S2111` already handled the case when `new BigDecimal` has more than two arguments, but it was not documented in the processor test file. The description of S2111 was also slightly misleading. Starting the description with "Any constructor ..." and then talking about a case where it has more than one argument defeats the purpose of generalising in the first statement.

P.S. This is the second time we will test the script `handled_rules.py`. I am really looking forward to it :)