### PR TITLE
chore: remove `picocli-codegen`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,6 @@
             <artifactId>picocli</artifactId>
             <version>${picocli.version}</version>
         </dependency>
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli-codegen</artifactId>
-            <version>${picocli.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
I am unsure why this dependency is present in `pom.xml`. Without it, all tests are green so I thought to remove it. This was first pointed out by running `depclean` analysis.

Reference: https://github.com/castor-software/depclean/issues/108#issuecomment-983593761.