### PR TITLE
fix(SynchronizationOnStringOrBoxedProcessor): enables Sorald to generate multiple similar fields in separate classes for synchronization

### DIFF
--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -85,11 +85,11 @@ public class SynchronizationOnStringOrBoxedProcessor
 
             c.addFieldAtTop(newField);
             old2NewFields.put(
-                    fieldRead.getVariable().getQualifiedName(), ((CtVariable) newField).getReference());
+                    fieldRead.getVariable().getQualifiedName(),
+                    ((CtVariable) newField).getReference());
             fieldRead.setVariable(((CtVariable) newField).getReference());
         } else {
             fieldRead.setVariable(old2NewFields.get(fieldRead.getVariable().getQualifiedName()));
         }
     }
-
 }

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -68,7 +68,7 @@ public class SynchronizationOnStringOrBoxedProcessor
     }
 
     private void updateFieldRead(CtFieldRead<?> fieldRead) {
-        if (!this.old2NewFields.containsKey(getFiledVariableUniqueId(fieldRead))) {
+        if (!this.old2NewFields.containsKey(fieldRead.getVariable().getQualifiedName())) {
             CtField<?> field = fieldRead.getVariable().getDeclaration();
             CtType<?> c = (CtType) field.getParent(CtType.class);
 
@@ -85,14 +85,11 @@ public class SynchronizationOnStringOrBoxedProcessor
 
             c.addFieldAtTop(newField);
             old2NewFields.put(
-                    getFiledVariableUniqueId(fieldRead), ((CtVariable) newField).getReference());
+                    fieldRead.getVariable().getQualifiedName(), ((CtVariable) newField).getReference());
             fieldRead.setVariable(((CtVariable) newField).getReference());
         } else {
-            fieldRead.setVariable(old2NewFields.get(getFiledVariableUniqueId(fieldRead)));
+            fieldRead.setVariable(old2NewFields.get(fieldRead.getVariable().getQualifiedName()));
         }
     }
 
-    private String getFiledVariableUniqueId(CtFieldRead<?> fieldRead) {
-        return fieldRead.getVariable().hashCode() + fieldRead.getVariable().getQualifiedName();
-    }
 }

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -24,7 +24,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
         description = "Synchronization should not be based on Strings or boxed primitives")
 public class SynchronizationOnStringOrBoxedProcessor
         extends SoraldAbstractProcessor<CtSynchronized> {
-    private Map<Integer, CtVariableReference> old2NewFields;
+    private Map<String, CtVariableReference> old2NewFields;
     private Map<Integer, CtExecutableReference> old2NewMethods;
 
     public SynchronizationOnStringOrBoxedProcessor() {
@@ -68,7 +68,7 @@ public class SynchronizationOnStringOrBoxedProcessor
     }
 
     private void updateFieldRead(CtFieldRead<?> fieldRead) {
-        if (!this.old2NewFields.containsKey(fieldRead.getVariable().hashCode())) {
+        if (!this.old2NewFields.containsKey(getFiledVariableUniqueId(fieldRead))) {
             CtField<?> field = fieldRead.getVariable().getDeclaration();
             CtType<?> c = (CtType) field.getParent(CtType.class);
 
@@ -85,10 +85,14 @@ public class SynchronizationOnStringOrBoxedProcessor
 
             c.addFieldAtTop(newField);
             old2NewFields.put(
-                    fieldRead.getVariable().hashCode(), ((CtVariable) newField).getReference());
+                    getFiledVariableUniqueId(fieldRead), ((CtVariable) newField).getReference());
             fieldRead.setVariable(((CtVariable) newField).getReference());
         } else {
-            fieldRead.setVariable(old2NewFields.get(fieldRead.getVariable().hashCode()));
+            fieldRead.setVariable(old2NewFields.get(getFiledVariableUniqueId(fieldRead)));
         }
+    }
+
+    private String getFiledVariableUniqueId(CtFieldRead<?> fieldRead){
+        return fieldRead.getVariable().hashCode() + fieldRead.getVariable().getQualifiedName();
     }
 }

--- a/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sorald/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -92,7 +92,7 @@ public class SynchronizationOnStringOrBoxedProcessor
         }
     }
 
-    private String getFiledVariableUniqueId(CtFieldRead<?> fieldRead){
+    private String getFiledVariableUniqueId(CtFieldRead<?> fieldRead) {
         return fieldRead.getVariable().hashCode() + fieldRead.getVariable().getQualifiedName();
     }
 }

--- a/src/test/resources/processor_test_files/S1860_SynchronizationOnStringOrBoxed/SynchronizationOnSimilarVariables.java
+++ b/src/test/resources/processor_test_files/S1860_SynchronizationOnStringOrBoxed/SynchronizationOnSimilarVariables.java
@@ -1,0 +1,22 @@
+class SynchronizationOnSimilarVariables {
+
+  class InnerClass1 {
+    public Boolean isStopped = false;
+
+    public void method() {
+      synchronized(isStopped) {  // Noncompliant
+        // ...
+      }
+    }
+  }
+
+  class InnerClass2 {
+    public Boolean isStopped = false;
+
+    public void method() {
+      synchronized(isStopped) {  // Noncompliant
+        // ...
+      }
+    }
+  }
+}

--- a/src/test/resources/processor_test_files/S1860_SynchronizationOnStringOrBoxed/SynchronizationOnSimilarVariables.java.expected
+++ b/src/test/resources/processor_test_files/S1860_SynchronizationOnStringOrBoxed/SynchronizationOnSimilarVariables.java.expected
@@ -1,0 +1,24 @@
+class SynchronizationOnSimilarVariables {
+
+  class InnerClass1 {
+    public Object isStoppedLegal = new Object();
+    public Boolean isStopped = false;
+
+    public void method() {
+      synchronized(isStoppedLegal) {  // Noncompliant
+        // ...
+      }
+    }
+  }
+
+  class InnerClass2 {
+    public Object isStoppedLegal = new Object();
+    public Boolean isStopped = false;
+
+    public void method() {
+      synchronized(isStoppedLegal) {  // Noncompliant
+        // ...
+      }
+    }
+  }
+}


### PR DESCRIPTION
Sorald does not generate multiple variables with the same hashcode in different classes, as it considers the hashcode to be the unique ID that represents a variable. As an example, see [this](https://github.com/khaes-kth/sorald/blob/fix/SyncronizationOnSimilarVariables/src/test/resources/processor_test_files/S1860_SynchronizationOnStringOrBoxed/SynchronizationOnSimilarVariables.java#L14).

This PR fixes this by adding the variable's qualified name to its unique ID.