### PR TITLE
chore: automate generation of subcommand's usage

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  generate-achievements-handled_rules-md:
+  generate-markdown-files:
     if: ${{ github.repository == 'SpoonLabs/sorald' }} # don't accidentally run on forks :)
     runs-on: ubuntu-latest
 
@@ -41,6 +41,32 @@ jobs:
           GENERATED_FILE=docs/HANDLED_RULES.md
           python -m sorald.${SCRIPT_NAME} -o ${GENERATED_FILE}
 
+          ./.github/submit-pr.sh \
+            --branch-prefix   ${SCRIPT_NAME} \
+            --generated-file  ${GENERATED_FILE} \
+            --gh-sha          ${{ github.sha }} \
+            --gh-token        ${{ secrets.GITHUB_TOKEN }} \
+            --gh-repository   ${{ github.repository }} \
+            --gh-workflow     ${{ github.workflow }}
+      - name: Generate usage/repair.md and submit a PR if modified
+        run: |
+          SCRIPT_NAME=usage
+          GENERATED_FILE=docs/usage/repair.md
+          python -m sorald.${SCRIPT_NAME} -s repair -o ${GENERATED_FILE}
+          
+          ./.github/submit-pr.sh \
+            --branch-prefix   ${SCRIPT_NAME} \
+            --generated-file  ${GENERATED_FILE} \
+            --gh-sha          ${{ github.sha }} \
+            --gh-token        ${{ secrets.GITHUB_TOKEN }} \
+            --gh-repository   ${{ github.repository }} \
+            --gh-workflow     ${{ github.workflow }}
+      - name: Generate usage/mine.md and submit a PR if modified
+        run: |
+          SCRIPT_NAME=usage
+          GENERATED_FILE=docs/usage/mine.md
+          python -m sorald.${SCRIPT_NAME} -s mine -o ${GENERATED_FILE}
+          
           ./.github/submit-pr.sh \
             --branch-prefix   ${SCRIPT_NAME} \
             --generated-file  ${GENERATED_FILE} \

--- a/experimentation/tools/README.md
+++ b/experimentation/tools/README.md
@@ -426,6 +426,18 @@ After these three command shave been executed, my `prs.json` looks like this:
 }
 ```
 
+### `sorald.usage`
+
+The usage script generates markdown file listing the detailed usage of the
+subcommand passed as a flag. The output in the markdown file can also be
+found by running `sorald <subcommand> --help`.
+
+One can execute the script like so:
+
+```bash
+$ python3 -m sorald.usage -s {repair|mine} -o path/to/usage.md
+```
+
 ### `sorald.warnings_extractor`
 The warnings extractor script can be used to extract warnings from individual
 commits in a given set of repositories. It's useful for finding projects that

--- a/experimentation/tools/sorald/_helpers/soraldwrapper.py
+++ b/experimentation/tools/sorald/_helpers/soraldwrapper.py
@@ -5,7 +5,16 @@ import pathlib
 import re
 import sys
 
+from enum import Enum
 from typing import List, Optional, Tuple
+
+
+class SUBCOMMAND(Enum):
+    REPAIR = "repair"
+    MINE = "mine"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 def _find_default_sorald_jar() -> pathlib.Path:
@@ -29,7 +38,7 @@ DEFAULT_SORALD_JAR_PATH = _find_default_sorald_jar()
 
 
 def sorald(
-    subcommand: str,
+    subcommand: SUBCOMMAND,
     *args,
     sorald_jar: pathlib.Path = DEFAULT_SORALD_JAR_PATH,
     timeout: Optional[int] = None,
@@ -54,7 +63,7 @@ def sorald(
         "java",
         "-jar",
         str(sorald_jar),
-        subcommand,
+        str(subcommand),
         *list(map(_to_cli_arg, args)),
         *list(
             itertools.chain.from_iterable(
@@ -81,7 +90,7 @@ def available_rule_keys(
     Returns:
         The available rule keys in the given jarfile.
     """
-    rc, stdout, _ = sorald("repair", "--help")
+    rc, stdout, _ = sorald(SUBCOMMAND.REPAIR, "--help")
     assert rc == 0
     output_lines = iter(stdout.decode(sys.getdefaultencoding()).split("\n"))
 

--- a/experimentation/tools/sorald/usage.py
+++ b/experimentation/tools/sorald/usage.py
@@ -1,0 +1,74 @@
+import argparse
+import pathlib
+import sys
+from typing import List
+
+import jinja2
+
+from sorald._helpers import soraldwrapper
+
+
+ENCODING = "utf8"
+TEMPLATE = r"""# `{{ subcommand }}`
+
+> This file is generated using [usage.py](/experimentation/tools/sorald/usage.py).
+> Please refrain from editing it manually.
+
+```bash
+{{ usage }}
+```
+
+"""
+
+SUBCOMMAND_ARG = "--subcommand"
+OUTPUT_ARG = "--output"
+
+
+def main(args: List[str]):
+    parsed_args = parse_args(args)
+    generate_usage(
+        subcommand=parsed_args.subcommand,
+        output_file=parsed_args.output,
+        template=TEMPLATE,
+    )
+
+
+def generate_usage(
+    subcommand: soraldwrapper.SUBCOMMAND, output_file: pathlib.Path, template: str
+):
+    (exit_code, stdout, _) = soraldwrapper.sorald(subcommand, "--help")
+    if exit_code == 0:
+        rendered_content = jinja2.Template(template).render(
+            subcommand=subcommand,
+            usage=stdout.decode(ENCODING),
+        )
+        output_file.write_text(rendered_content, encoding=ENCODING)
+    else:
+        raise Exception("Process took too long to run.")
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="usage",
+        description="Script for generating the usage file for Sorald's " "subcommands",
+    )
+    parser.add_argument(
+        "-s",
+        SUBCOMMAND_ARG,
+        help="subcommand whose usage needs to be generated",
+        type=soraldwrapper.SUBCOMMAND,
+        choices=list(soraldwrapper.SUBCOMMAND),
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        OUTPUT_ARG,
+        help="path to the output Markdown file",
+        type=pathlib.Path,
+        required=True,
+    )
+    return parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
No more updating of subcommand's usage in the README! This PR adds a script and integrates it to the CI for generating it whenever it has been modified or it is untracked (for the very first time).

I decided to add the usage in `docs/usage/{repair,mine}.md`. Once we merge this PR, the script will execute and generate two files, for the two subcommands, in the corresponding path. After that, I will submit another PR to delete the usage from `README.md` and add the required links there.