### PR TITLE
chore: configure `env.JAVA_DISTRIBUTION` in support.yml

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ master ]
 
+env:
+  JAVA_DISTRIBUTION: 'adopt'
+
 jobs:
   generate-achievements-handled_rules-md:
     if: ${{ github.repository == 'SpoonLabs/sorald' }} # don't accidentally run on forks :)


### PR DESCRIPTION
I did not configure `JAVA_DISTRIBUTION` in `support.yml` and that's why the workflow failed.