### PR TITLE
fix: repair of S2142 should not induce S1193 violation

### DIFF
--- a/src/main/java/sorald/processor/InterruptedExceptionProcessor.md
+++ b/src/main/java/sorald/processor/InterruptedExceptionProcessor.md
@@ -16,3 +16,28 @@ Example:
 ```
 
 Sorald places the interrupt as late as possible in the catch block, but before any throws or returns.
+
+If there are multiple exceptions handled in a single catch block, a new catch block is added.
+
+Example:
+
+```diff
+public static void method() {
+    try {
+        if (1 < 2) {
+            throw new ExecutionException(new RuntimeException());
+        } else {
+            throw new InterruptedException();
+        }
+    }
+    // Noncompliant
+-   catch (InterruptedException | ExecutionException e) {
++   catch (ExecutionException e) {
+        throw new RuntimeException(e);
+    }
++   catch (InterruptedException e) {
++       Thread.currentThread().interrupt();
++       throw new RuntimeException(e);
++   }
+}
+```

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java
@@ -12,7 +12,9 @@ public class CatchMultipleTypes {
             } else {
                 throw new InterruptedException();
             }
-        } catch (InterruptedException | ExecutionException e) { // Noncompliant
+        }
+        // Noncompliant
+        catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.exact
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.exact
@@ -1,3 +1,3 @@
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.exact
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.exact
@@ -1,3 +1,4 @@
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
         }

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.expected
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.expected
@@ -16,6 +16,7 @@ public class CatchMultipleTypes {
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.expected
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/CatchMultipleTypes.java.expected
@@ -12,11 +12,10 @@ public class CatchMultipleTypes {
             } else {
                 throw new InterruptedException();
             }
-        } catch (InterruptedException | ExecutionException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (ExecutionException e) {
             throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/InterruptedExceptionForTesting.java.expected
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/InterruptedExceptionForTesting.java.expected
@@ -47,10 +47,9 @@ class InterruptedExceptionForTesting {
 			} else {
 				throw new IOException();
 			}
-		} catch (InterruptedException | IOException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
-			if (e instanceof InterruptedException) {
-				Thread.currentThread().interrupt();
-			}
+		} catch (IOException e) { // Noncompliant {{Either re-interrupt this method or rethrow the "InterruptedException".}}
+		} catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
 		}
 	}
 

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/NOCOMPILE_RepairAndFieldTypePrint.java.exact
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/NOCOMPILE_RepairAndFieldTypePrint.java.exact
@@ -153,10 +153,20 @@
                     return;
                 }
                 consecutiveRetriableErrors = 0;
-            } catch (WakeupException | InterruptedException e) {
+            } catch (WakeupException e) {
                 // Assume we've been woken or interrupted to shutdown, so continue on to checking the
                 // shutDownLatch next iteration.
                 logger.debug("KafkaMonitor woken up, checking if shutdown requested...");
-                if (e instanceof InterruptedException) {
-                    Thread.currentThread().interrupt();
-                }
+            } catch (RetriableException e) {
+                consecutiveRetriableErrors += 1;
+                logger.warn(
+                        "Retriable exception encountered ({} consecutive), continuing processing...",
+                        consecutiveRetriableErrors,
+                        e);
+                exponentialBackoffWait(consecutiveRetriableErrors);
+            } catch (Exception e) {
+                logger.error("Raising exception to connect runtime", e);
+                context.raiseError(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }

--- a/src/test/resources/processor_test_files/S2142_InterruptedException/NOCOMPILE_RepairAndFieldTypePrint.java.exact
+++ b/src/test/resources/processor_test_files/S2142_InterruptedException/NOCOMPILE_RepairAndFieldTypePrint.java.exact
@@ -168,5 +168,8 @@
                 logger.error("Raising exception to connect runtime", e);
                 context.raiseError(e);
             } catch (InterruptedException e) {
+                // Assume we've been woken or interrupted to shutdown, so continue on to checking the
+                // shutDownLatch next iteration.
+                logger.debug("KafkaMonitor woken up, checking if shutdown requested...");
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
Fixes #697 

Before this gets merged, there is one thing we need to discuss. Consider the following case.
```java
catch (IOException | InterruptedException e) {
     logger.error("Raising exception to connect runtime", e);
     context.raiseError(e);
}
```
When we create another catch block for `InterruptedException`, should we or should we not copy the statements inside the original one? In this case, do we also need to copy `logger.error` and `context.raiseError` inside the new catch block we create? In my opinion, we should copy them as those statements, would be related to both the exception classes.

ToDo:
- [x] Include statements in the newly created catch block
- [x] Modify the processor description