### PR TITLE
review: fix CI on windows

### DIFF
--- a/src/test/java/sorald/GatherStatsTest.java
+++ b/src/test/java/sorald/GatherStatsTest.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -25,7 +23,6 @@ import sorald.rule.RuleViolation;
 import sorald.sonar.ProjectScanner;
 import sorald.sonar.SonarRule;
 
-@DisabledOnOs(OS.WINDOWS) // FIXME make this test class pass on Windows
 public class GatherStatsTest {
 
     @ParameterizedTest

--- a/src/test/java/sorald/SegmentStrategyTest.java
+++ b/src/test/java/sorald/SegmentStrategyTest.java
@@ -17,8 +17,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import sorald.processor.ArrayHashCodeAndToStringProcessor;
 import sorald.processor.ProcessorTestHelper;
 import sorald.processor.SoraldAbstractProcessor;
@@ -84,7 +82,6 @@ public class SegmentStrategyTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // FIXME Make this test pass on Windows
     public void segmentStrategy_doesNotFail_onCrashInParsingSegment() throws IOException {
         // arrange
         Path workspace = TestHelper.createTemporaryProcessorTestFilesWorkspace();

--- a/src/test/java/sorald/TargetedRepairTest.java
+++ b/src/test/java/sorald/TargetedRepairTest.java
@@ -18,8 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import sorald.processor.BigDecimalDoubleConstructorProcessor;
 import sorald.processor.ProcessorTestHelper;
@@ -29,7 +27,6 @@ import sorald.sonar.ProjectScanner;
 import sorald.sonar.SonarRule;
 
 /** Tests for the targeted repair functionality of Sorald. */
-@DisabledOnOs(OS.WINDOWS) // FIXME Make this test class pass on Windows
 public class TargetedRepairTest {
 
     @Test


### PR DESCRIPTION
Classical first PR trying to fix the CI on Windows.  The problems seems that the filename is simply the absolute path and not the relative path. How on earth this works on Unix is unknown to me. 
Fixes #273