### PR TITLE
chore: add factorypath to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ script.sh
 sorald-workspace/
 FileOutputStrategyTest/
 sonar-java/
+.factorypath


### PR DESCRIPTION
This was missing inside the `.gitignore`. The gitignore seems kinda small, have you thought about simply adding something like this https://www.toptal.com/developers/gitignore/api/java,visualstudiocode,eclipse,intellij,maven,gradle ?