### PR TITLE
chore: Parse rule title from processor to keep HANDLED_RULES.md in sync with processors

### DIFF
--- a/experimentation/tools/tests/test_handled_rules.py
+++ b/experimentation/tools/tests/test_handled_rules.py
@@ -36,3 +36,28 @@ def test_get_rule_key_should_return_key(processor_path, expected):
 )
 def test_get_link_to_repair_description(heading_text, expected):
     assert handled_rules.get_link_to_repair_description(heading_text) == expected
+
+
+@pytest.mark.parametrize(
+    "processor_path,expected",
+    [
+        (
+            MOCK_PROCESSORS / "Processor.java",
+            'Unused "private" fields should be removed',
+        ),
+        (
+            MOCK_PROCESSORS / "IncompleteProcessor.java",
+            '"public static" fields should be constant',
+        ),
+        (
+            MOCK_PROCESSORS / "LineBreak.java",
+            '"equals(Object obj)" should test argument type',
+        ),
+        (
+            MOCK_PROCESSORS / "Inverse.java",
+            '"Iterator.next()" methods should throw "NoSuchElementException"',
+        ),
+    ],
+)
+def test_get_rule_title_should_return_title(processor_path, expected):
+    assert handled_rules.get_rule_title(processor_path) == expected


### PR DESCRIPTION
Fixes: #720 

We can now merge PRs without GHA submitting false-positive PRs - https://github.com/SpoonLabs/sorald/pull/721.

However, we should also open an issue for automatically updating the rule descriptions in the processors themselves.