### PR TITLE
refactor: convert constructor args to method parameter and store `SonarLintEngine` as a local variable

### DIFF
--- a/src/main/java/sorald/rule/StaticAnalyzer.java
+++ b/src/main/java/sorald/rule/StaticAnalyzer.java
@@ -10,11 +10,12 @@ public interface StaticAnalyzer {
     /**
      * Scan files for violations of some rules.
      *
+     * @param projectRoot the root folder of the project.
      * @param files The files to analyze.
      * @param rule The rules to use.
      * @param classpath Classpath that includes any dependencies.
      * @return All violations of the rules found in the files.
      */
     Collection<RuleViolation> findViolations(
-            List<File> files, List<Rule> rule, List<String> classpath);
+            File projectRoot, List<File> files, List<Rule> rule, List<String> classpath);
 }

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -64,7 +64,7 @@ public class ProjectScanner {
 
         // TODO generalize to not directly use the SonarStaticAnalyzer
         var violations =
-                new SonarStaticAnalyzer(baseDir).findViolations(filesToScan, rules, classpath);
+                new SonarStaticAnalyzer().findViolations(baseDir,filesToScan, rules, classpath);
         return new HashSet<>(violations);
     }
 }

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -64,7 +64,7 @@ public class ProjectScanner {
 
         // TODO generalize to not directly use the SonarStaticAnalyzer
         var violations =
-                new SonarStaticAnalyzer().findViolations(baseDir,filesToScan, rules, classpath);
+                new SonarStaticAnalyzer().findViolations(baseDir, filesToScan, rules, classpath);
         return new HashSet<>(violations);
     }
 }

--- a/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
+++ b/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
@@ -16,15 +16,14 @@ import sorald.rule.StaticAnalyzer;
 
 public class SonarStaticAnalyzer implements StaticAnalyzer {
 
-
     @Override
-    public Collection<RuleViolation> findViolations(File projectRoot,
-            List<File> files, List<Rule> rules, List<String> classpath) {
+    public Collection<RuleViolation> findViolations(
+            File projectRoot, List<File> files, List<Rule> rules, List<String> classpath) {
         return analyze(projectRoot, files, rules, classpath);
     }
 
-    private Collection<RuleViolation> analyze(File projectRoot,
-            List<File> files, List<Rule> rules, List<String> classpath) {
+    private Collection<RuleViolation> analyze(
+            File projectRoot, List<File> files, List<Rule> rules, List<String> classpath) {
 
         List<JavaInputFile> inputFiles =
                 files.stream()

--- a/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
+++ b/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
@@ -15,21 +15,15 @@ import sorald.rule.RuleViolation;
 import sorald.rule.StaticAnalyzer;
 
 public class SonarStaticAnalyzer implements StaticAnalyzer {
-    private final File projectRoot;
-    private final SonarLintEngine sonarLint;
 
-    public SonarStaticAnalyzer(File projectRoot) {
-        this.projectRoot = projectRoot;
-        this.sonarLint = SonarLintEngine.getInstance();
-    }
 
     @Override
-    public Collection<RuleViolation> findViolations(
+    public Collection<RuleViolation> findViolations(File projectRoot,
             List<File> files, List<Rule> rules, List<String> classpath) {
-        return analyze(files, rules, classpath);
+        return analyze(projectRoot, files, rules, classpath);
     }
 
-    private Collection<RuleViolation> analyze(
+    private Collection<RuleViolation> analyze(File projectRoot,
             List<File> files, List<Rule> rules, List<String> classpath) {
 
         List<JavaInputFile> inputFiles =
@@ -52,6 +46,7 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
                         .addInputFiles(inputFiles)
                         .build();
 
+        SonarLintEngine sonarLint = SonarLintEngine.getInstance();
         var issueHandler = new IssueHandler();
         sonarLint.analyze(config, issueHandler, null, null);
         sonarLint.stop();


### PR DESCRIPTION
In #698 we had the discussion to add the `projectroot` as parameter for static analyzers because often they need it. This PR changes the interfaces and adds parameter to the interface. Furthermore, I would refactor the sonarlint-engine field to a local variable instead of a field, which is only used in a single method.