### PR TITLE
feat: use SPI for analyzer loading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>1.0.1</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.target>11</maven.compiler.target>

--- a/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/src/main/java/sorald/sonar/ProjectScanner.java
@@ -5,11 +5,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.Set;
 import sorald.Constants;
 import sorald.FileUtils;
 import sorald.rule.Rule;
 import sorald.rule.RuleViolation;
+import sorald.rule.StaticAnalyzer;
 
 /** Helper class that uses Sonar to scan projects for rule violations. */
 public class ProjectScanner {
@@ -61,10 +63,11 @@ public class ProjectScanner {
                 e.printStackTrace();
             }
         }
-
-        // TODO generalize to not directly use the SonarStaticAnalyzer
-        var violations =
-                new SonarStaticAnalyzer().findViolations(baseDir, filesToScan, rules, classpath);
+        ServiceLoader<StaticAnalyzer> analyzers = ServiceLoader.load(StaticAnalyzer.class);
+        Set<RuleViolation> violations = new HashSet<>();
+        for (StaticAnalyzer analyzer : analyzers) {
+            violations.addAll(analyzer.findViolations(baseDir, filesToScan, rules, classpath));
+        }
         return new HashSet<>(violations);
     }
 }

--- a/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
+++ b/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
@@ -1,5 +1,6 @@
 package sorald.sonar;
 
+import com.google.auto.service.AutoService;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,6 +15,7 @@ import sorald.rule.Rule;
 import sorald.rule.RuleViolation;
 import sorald.rule.StaticAnalyzer;
 
+@AutoService(StaticAnalyzer.class)
 public class SonarStaticAnalyzer implements StaticAnalyzer {
 
     @Override


### PR DESCRIPTION
This PR loads all classes implementing `StaticAnalyzer` and invokes them. Fixes more or less the to-do inside the code. We could change `StaticAnalyzer` from interface to abstract class to enforce a non-arg constructor or hope the programmer writes his code correct. Only `StaticAnalyzer` with a non-arg constructor are usable for SPI.