### PR TITLE
feat: abstract ruletype enum with IRuleType

### DIFF
--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -12,6 +12,7 @@ import sorald.event.models.ExecutionInfo;
 import sorald.miner.MineSonarWarnings;
 import sorald.rule.IRuleType;
 import sorald.rule.Rule;
+import sorald.rule.RuleType;
 import sorald.rule.Rules;
 import sorald.util.MavenUtils;
 
@@ -49,6 +50,7 @@ class MineCommand extends BaseCommand {
 
     @CommandLine.Option(
             names = {Constants.ARG_RULE_TYPES},
+            converter = IRuleTypeConverter.class,
             description =
                     "One or more types of rules to check for (use ',' to separate multiple types). Choices: ${COMPLETION-CANDIDATES}",
             split = ",")
@@ -109,6 +111,13 @@ class MineCommand extends BaseCommand {
                     String.format(
                             "%s is only supported for Maven projects, but %s has no pom.xml",
                             Constants.ARG_RESOLVE_CLASSPATH_FROM, source));
+        }
+    }
+
+    private static class IRuleTypeConverter implements CommandLine.ITypeConverter<IRuleType> {
+        @Override
+        public IRuleType convert(String value) {
+            return RuleType.valueOf(value.toUpperCase());
         }
     }
 }

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -12,8 +12,8 @@ import sorald.event.models.ExecutionInfo;
 import sorald.miner.MineSonarWarnings;
 import sorald.rule.IRuleType;
 import sorald.rule.Rule;
-import sorald.rule.RuleType;
 import sorald.rule.Rules;
+import sorald.sonar.SonarRuleType;
 import sorald.util.MavenUtils;
 
 /** CLI Command for Sorald's mining functionality. */
@@ -117,7 +117,7 @@ class MineCommand extends BaseCommand {
     private static class IRuleTypeConverter implements CommandLine.ITypeConverter<IRuleType> {
         @Override
         public IRuleType convert(String value) {
-            return RuleType.valueOf(value.toUpperCase());
+            return SonarRuleType.valueOf(value.toUpperCase());
         }
     }
 }

--- a/src/main/java/sorald/cli/MineCommand.java
+++ b/src/main/java/sorald/cli/MineCommand.java
@@ -10,8 +10,8 @@ import sorald.event.StatsMetadataKeys;
 import sorald.event.collectors.MinerStatisticsCollector;
 import sorald.event.models.ExecutionInfo;
 import sorald.miner.MineSonarWarnings;
+import sorald.rule.IRuleType;
 import sorald.rule.Rule;
-import sorald.rule.RuleType;
 import sorald.rule.Rules;
 import sorald.util.MavenUtils;
 
@@ -52,7 +52,7 @@ class MineCommand extends BaseCommand {
             description =
                     "One or more types of rules to check for (use ',' to separate multiple types). Choices: ${COMPLETION-CANDIDATES}",
             split = ",")
-    private List<RuleType> ruleTypes = new ArrayList<>();
+    private List<IRuleType> ruleTypes = new ArrayList<>();
 
     @CommandLine.Option(
             names = {Constants.ARG_HANDLED_RULES},

--- a/src/main/java/sorald/rule/IRuleType.java
+++ b/src/main/java/sorald/rule/IRuleType.java
@@ -1,0 +1,10 @@
+package sorald.rule;
+
+public interface IRuleType {
+
+    /**
+     * Returns the name of the rule type. A rule type is a category of rules, such as "Bug",
+     * "Vulnerability".
+     */
+    String getName();
+}

--- a/src/main/java/sorald/rule/Rule.java
+++ b/src/main/java/sorald/rule/Rule.java
@@ -12,7 +12,7 @@ public interface Rule {
     String getName();
 
     /** @return The type of this rule. */
-    RuleType getType();
+    IRuleType getType();
 
     /**
      * Create a rule based on the key.

--- a/src/main/java/sorald/rule/RuleType.java
+++ b/src/main/java/sorald/rule/RuleType.java
@@ -4,8 +4,8 @@ package sorald.rule;
 public enum RuleType implements IRuleType {
     BUG("Bug"),
     VULNERABILITY("Vulnerability"),
-    CODE_SMELL("Code Smell"),
-    SECURITY_HOTSPOT("Security Hotspot");
+    CODE_SMELL("Code_Smell"),
+    SECURITY_HOTSPOT("Security_Hotspot");
 
     private final String name;
 

--- a/src/main/java/sorald/rule/RuleType.java
+++ b/src/main/java/sorald/rule/RuleType.java
@@ -1,9 +1,20 @@
 package sorald.rule;
 
 /** Enumeration of Sonar rule types */
-public enum RuleType {
-    BUG,
-    VULNERABILITY,
-    CODE_SMELL,
-    SECURITY_HOTSPOT;
+public enum RuleType implements IRuleType {
+    BUG("Bug"),
+    VULNERABILITY("Vulnerability"),
+    CODE_SMELL("Code Smell"),
+    SECURITY_HOTSPOT("Security Hotspot");
+
+    private final String name;
+
+    RuleType(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/sorald/rule/Rules.java
+++ b/src/main/java/sorald/rule/Rules.java
@@ -27,7 +27,7 @@ public class Rules {
      * @param types Types to filter rules by.
      * @return All rules with any of the given types.
      */
-    public static Collection<Rule> getRulesByType(RuleType... types) {
+    public static Collection<Rule> getRulesByType(IRuleType... types) {
         var ruleTypes = Set.of(types);
         return getAllRules().stream()
                 .filter(rule -> ruleTypes.contains(rule.getType()))
@@ -40,15 +40,15 @@ public class Rules {
      * @param types Types to filter rules by.
      * @return All rules with any of the given types.
      */
-    public static Collection<Rule> getRulesByType(Collection<RuleType> types) {
-        return getRulesByType(types.toArray(RuleType[]::new));
+    public static Collection<Rule> getRulesByType(Collection<IRuleType> types) {
+        return getRulesByType(types.toArray(IRuleType[]::new));
     }
 
     /**
      * Infer which rules to use based on rule types specified (or left unspecified) on the command
      * line.
      */
-    public static List<Rule> inferRules(List<RuleType> ruleTypes, boolean handledRules) {
+    public static List<Rule> inferRules(List<IRuleType> ruleTypes, boolean handledRules) {
         List<Rule> rules =
                 List.copyOf(
                         ruleTypes.isEmpty()

--- a/src/main/java/sorald/sonar/SonarRule.java
+++ b/src/main/java/sorald/sonar/SonarRule.java
@@ -2,13 +2,14 @@ package sorald.sonar;
 
 import java.util.Objects;
 import org.sonarsource.sonarlint.core.rule.extractor.SonarLintRuleDefinition;
+import sorald.rule.IRuleType;
 import sorald.rule.Rule;
 import sorald.rule.RuleType;
 
 public class SonarRule implements Rule {
     private final String key;
     private final String name;
-    private final RuleType type;
+    private final IRuleType type;
 
     private static final String SONAR_JAVA_PREFIX = "java:";
 
@@ -46,7 +47,7 @@ public class SonarRule implements Rule {
     }
 
     @Override
-    public RuleType getType() {
+    public IRuleType getType() {
         return type;
     }
 

--- a/src/main/java/sorald/sonar/SonarRule.java
+++ b/src/main/java/sorald/sonar/SonarRule.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 import org.sonarsource.sonarlint.core.rule.extractor.SonarLintRuleDefinition;
 import sorald.rule.IRuleType;
 import sorald.rule.Rule;
-import sorald.rule.RuleType;
 
 public class SonarRule implements Rule {
     private final String key;
@@ -19,7 +18,7 @@ public class SonarRule implements Rule {
         SonarLintRuleDefinition ruleDefinition =
                 SonarLintEngine.getAllRulesDefinitionsByKey().get(withLanguage(key));
         this.name = ruleDefinition.getName();
-        this.type = RuleType.valueOf(ruleDefinition.getType());
+        this.type = SonarRuleType.valueOf(ruleDefinition.getType());
     }
 
     private static String withoutLanguage(String ruleKey) {

--- a/src/main/java/sorald/sonar/SonarRuleType.java
+++ b/src/main/java/sorald/sonar/SonarRuleType.java
@@ -1,7 +1,9 @@
-package sorald.rule;
+package sorald.sonar;
+
+import sorald.rule.IRuleType;
 
 /** Enumeration of Sonar rule types */
-public enum RuleType implements IRuleType {
+public enum SonarRuleType implements IRuleType {
     BUG("Bug"),
     VULNERABILITY("Vulnerability"),
     CODE_SMELL("Code_Smell"),
@@ -9,7 +11,7 @@ public enum RuleType implements IRuleType {
 
     private final String name;
 
-    RuleType(String name) {
+    SonarRuleType(String name) {
         this.name = name;
     }
 

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -30,8 +30,8 @@ import sorald.event.StatsMetadataKeys;
 import sorald.processor.CastArithmeticOperandProcessor;
 import sorald.rule.IRuleType;
 import sorald.rule.Rule;
-import sorald.rule.RuleType;
 import sorald.rule.Rules;
+import sorald.sonar.SonarRuleType;
 
 public class WarningMinerTest {
 
@@ -84,7 +84,7 @@ public class WarningMinerTest {
      */
     @Test
     public void warningsMiner_onlyScansForGivenTypes_whenRuleTypesGiven() throws Exception {
-        Set<IRuleType> ruleTypes = Set.of(RuleType.VULNERABILITY, RuleType.CODE_SMELL);
+        Set<IRuleType> ruleTypes = Set.of(SonarRuleType.VULNERABILITY, SonarRuleType.CODE_SMELL);
 
         File outputFile = File.createTempFile("warnings", null);
         File temp = Files.createTempDirectory("tempDir").toFile();

--- a/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/src/test/java/sorald/miner/WarningMinerTest.java
@@ -28,6 +28,7 @@ import sorald.*;
 import sorald.cli.SoraldVersionProvider;
 import sorald.event.StatsMetadataKeys;
 import sorald.processor.CastArithmeticOperandProcessor;
+import sorald.rule.IRuleType;
 import sorald.rule.Rule;
 import sorald.rule.RuleType;
 import sorald.rule.Rules;
@@ -83,7 +84,7 @@ public class WarningMinerTest {
      */
     @Test
     public void warningsMiner_onlyScansForGivenTypes_whenRuleTypesGiven() throws Exception {
-        Set<RuleType> ruleTypes = Set.of(RuleType.VULNERABILITY, RuleType.CODE_SMELL);
+        Set<IRuleType> ruleTypes = Set.of(RuleType.VULNERABILITY, RuleType.CODE_SMELL);
 
         File outputFile = File.createTempFile("warnings", null);
         File temp = Files.createTempDirectory("tempDir").toFile();
@@ -93,7 +94,7 @@ public class WarningMinerTest {
                 outputFile.getPath(),
                 temp.getPath(),
                 Constants.ARG_RULE_TYPES,
-                ruleTypes.stream().map(RuleType::name).collect(Collectors.joining(",")));
+                ruleTypes.stream().map(IRuleType::getName).collect(Collectors.joining(",")));
 
         List<String> expectedChecks =
                 Rules.getRulesByType(ruleTypes).stream()

--- a/src/test/java/sorald/sonar/SonarRulesTest.java
+++ b/src/test/java/sorald/sonar/SonarRulesTest.java
@@ -11,20 +11,19 @@ import org.junit.jupiter.api.Test;
 import sorald.Processors;
 import sorald.rule.IRuleType;
 import sorald.rule.Rule;
-import sorald.rule.RuleType;
 import sorald.rule.Rules;
 
 class SonarRulesTest {
     @Test
     void getRulesByType_subsetOfRulesShouldHaveCorrectRuleType() {
         // arrange
-        List<IRuleType> ruleTypes = List.of(RuleType.VULNERABILITY);
+        List<IRuleType> ruleTypes = List.of(SonarRuleType.VULNERABILITY);
 
         // act
         Collection<Rule> rules = Rules.getRulesByType(ruleTypes);
 
         // assert
-        rules.forEach(rule -> assertThat(rule.getType(), equalTo(RuleType.VULNERABILITY)));
+        rules.forEach(rule -> assertThat(rule.getType(), equalTo(SonarRuleType.VULNERABILITY)));
     }
 
     @Test

--- a/src/test/java/sorald/sonar/SonarRulesTest.java
+++ b/src/test/java/sorald/sonar/SonarRulesTest.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import sorald.Processors;
+import sorald.rule.IRuleType;
 import sorald.rule.Rule;
 import sorald.rule.RuleType;
 import sorald.rule.Rules;
@@ -17,7 +18,7 @@ class SonarRulesTest {
     @Test
     void getRulesByType_subsetOfRulesShouldHaveCorrectRuleType() {
         // arrange
-        List<RuleType> ruleTypes = List.of(RuleType.VULNERABILITY);
+        List<IRuleType> ruleTypes = List.of(RuleType.VULNERABILITY);
 
         // act
         Collection<Rule> rules = Rules.getRulesByType(ruleTypes);
@@ -29,7 +30,7 @@ class SonarRulesTest {
     @Test
     void inferRules_subsetOfRulesShouldHaveACorrespondingProcessor() {
         // arrange
-        List<RuleType> ruleTypes = List.of();
+        List<IRuleType> ruleTypes = List.of();
         boolean handledRules = true;
 
         // act


### PR DESCRIPTION
Currently, the RuleType enum is used in alot of places. But there could exist more categories of bad smells than the 3 sonar ones. Using an interface in the code allows adding new categories easier, e.g., from other analyzers, without constantly changing the enum. 