### PR TITLE
chore: fix release script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
                         <artifactId>maven-scm-provider-gitexe</artifactId>
                         <version>1.12.2</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-api</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
                 </dependencies>
                 <executions>
                     <execution>


### PR DESCRIPTION
An error exactly like https://stackoverflow.com/questions/56664609/maven-releaseprepare-with-noclassdeffounderror-while-using-git was thrown when I ran the edit script. 