### PR TITLE
chore: release sorald 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.kth.castor</groupId>
     <artifactId>sorald</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 
     <name>Sorald</name>
     <description>An automatic repair system for static code analysis warnings from Sonar Java.</description>
@@ -372,7 +372,7 @@
         <connection>scm:git:https://github.com/SpoonLabs/sorald.git</connection>
         <developerConnection>scm:git:ssh://github.com/SpoonLabs/sorald.git</developerConnection>
         <url>https://github.com/SpoonLabs/sorald</url>
-        <tag>sorald-0.4.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.kth.castor</groupId>
     <artifactId>sorald</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
 
     <name>Sorald</name>
     <description>An automatic repair system for static code analysis warnings from Sonar Java.</description>
@@ -372,7 +372,7 @@
         <connection>scm:git:https://github.com/SpoonLabs/sorald.git</connection>
         <developerConnection>scm:git:ssh://github.com/SpoonLabs/sorald.git</developerConnection>
         <url>https://github.com/SpoonLabs/sorald</url>
-        <tag>HEAD</tag>
+        <tag>sorald-0.4.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Used the `tools/sorald/release.py` to perform a release. I generated the changelog automatically using GitHub's option for now. It is not very easy to understand given that we are releasing after too long. We should probably perform releases more frequently and for that we need to document how frequently and upon what changes we release.

I went with a minor version upgrade because now we report all sonar violations instead of what was defined by `Checks`. There are many more feature introductions, of course.