### PR TITLE
refactor: reuse APIs defined in RuleRepository in RuleProvider

### DIFF
--- a/sorald/src/main/java/sorald/rule/RuleProvider.java
+++ b/sorald/src/main/java/sorald/rule/RuleProvider.java
@@ -1,12 +1,11 @@
 package sorald.rule;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
-import java.util.Set;
 import java.util.stream.Collectors;
-import sorald.Processors;
 import sorald.api.RuleRepository;
 
 /** Entrypoint for finding available rules. */
@@ -34,9 +33,10 @@ public class RuleProvider {
      * @return All rules with any of the given types.
      */
     public static Collection<Rule> getRulesByType(IRuleType... types) {
-        var ruleTypes = Set.of(types);
-        return getAllRules().stream()
-                .filter(rule -> ruleTypes.contains(rule.getType()))
+        return ServiceLoader.load(RuleRepository.class).stream()
+                .map(Provider::get)
+                .map(rr -> rr.getRulesByType(types))
+                .flatMap(Collection::stream)
                 .collect(Collectors.toList());
     }
 
@@ -51,20 +51,64 @@ public class RuleProvider {
     }
 
     /**
-     * Infer which rules to use based on rule types specified (or left unspecified) on the command
-     * line.
+     * Returns a collection of rules that are handled by Sorald.
+     *
+     * @return Handled rules.
+     */
+    public static Collection<Rule> getHandledRules() {
+        return ServiceLoader.load(RuleRepository.class).stream()
+                .map(Provider::get)
+                .map(RuleRepository::getHandledRules)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all handled rules matching one of the given types.
+     *
+     * @param types Types to filter rules by.
+     * @return Handled rules with any of the given types.
+     */
+    public static Collection<Rule> getHandledRulesByType(IRuleType... types) {
+        return ServiceLoader.load(RuleRepository.class).stream()
+                .map(Provider::get)
+                .map(rr -> rr.getHandledRulesByType(types))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all handled rules matching one of the given types.
+     *
+     * @param types Types to filter rules by.
+     * @return Handled rules with any of the given types.
+     */
+    public static Collection<Rule> getHandledRulesByType(Collection<IRuleType> types) {
+        return getHandledRulesByType(types.toArray(IRuleType[]::new));
+    }
+
+    /**
+     * Infer which rules to use based on rule types specified (or left unspecified) and their repair
+     * status by Sorald on the command line.
+     *
+     * @param ruleTypes Types to filter rules by.
+     * @param handledRules whether to fetch only handled rules.
+     * @return Subset of {@link RuleRepository##getAllRules()}.
      */
     public static List<Rule> inferRules(List<IRuleType> ruleTypes, boolean handledRules) {
-        List<Rule> rules =
-                List.copyOf(
-                        ruleTypes.isEmpty()
-                                ? RuleProvider.getAllRules()
-                                : RuleProvider.getRulesByType(ruleTypes));
-
-        return !handledRules
-                ? rules
-                : rules.stream()
-                        .filter(rule -> Processors.getProcessor(rule.getKey()) != null)
-                        .collect(Collectors.toList());
+        if (ruleTypes.isEmpty() && !handledRules) {
+            return new ArrayList<>(getAllRules());
+        }
+        // `handledRules` is redundant here, but I am leaving it for the sake of
+        // readability.
+        if (ruleTypes.isEmpty() && handledRules) {
+            return new ArrayList<>(getHandledRules());
+        }
+        // `ruleTypes` is redundant here, but I am leaving it for the sake of
+        // readability.
+        if (!ruleTypes.isEmpty() && !handledRules) {
+            return new ArrayList<>(getRulesByType(ruleTypes));
+        }
+        return new ArrayList<>(getHandledRulesByType(ruleTypes));
     }
 }

--- a/sorald/src/main/java/sorald/rule/RuleProvider.java
+++ b/sorald/src/main/java/sorald/rule/RuleProvider.java
@@ -93,7 +93,7 @@ public class RuleProvider {
      *
      * @param ruleTypes Types to filter rules by.
      * @param handledRules whether to fetch only handled rules.
-     * @return Subset of {@link RuleRepository##getAllRules()}.
+     * @return Subset of all rules in the static analyzer.
      */
     public static List<Rule> inferRules(List<IRuleType> ruleTypes, boolean handledRules) {
         if (ruleTypes.isEmpty() && !handledRules) {

--- a/sorald/src/test/java/sorald/sonar/SonarRulesTest.java
+++ b/sorald/src/test/java/sorald/sonar/SonarRulesTest.java
@@ -23,7 +23,7 @@ import sorald.rule.RuleProvider;
 
 class SonarRulesTest {
     @Nested
-    class InferSubsetOfRules {
+    class InferRules {
         @Test
         void shouldHaveAllHandledRules() {
             // arrange

--- a/sorald/src/test/java/sorald/sonar/SonarRulesTest.java
+++ b/sorald/src/test/java/sorald/sonar/SonarRulesTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import sorald.Processors;
 import sorald.rule.IRuleType;
@@ -21,31 +22,51 @@ import sorald.rule.Rule;
 import sorald.rule.RuleProvider;
 
 class SonarRulesTest {
-    @Test
-    void getRulesByType_subsetOfRulesShouldHaveCorrectRuleType() {
-        // arrange
-        List<IRuleType> ruleTypes = List.of(SonarRuleType.VULNERABILITY);
+    @Nested
+    class InferSubsetOfRules {
+        @Test
+        void shouldHaveAllHandledRules() {
+            // arrange
+            List<IRuleType> ruleTypes = List.of();
+            boolean handledRules = true;
 
-        // act
-        Collection<Rule> rules = RuleProvider.getRulesByType(ruleTypes);
+            // act
+            Collection<Rule> rules = RuleProvider.inferRules(ruleTypes, handledRules);
 
-        // assert
-        rules.forEach(rule -> assertThat(rule.getType(), equalTo(SonarRuleType.VULNERABILITY)));
-    }
+            // assert
+            assertThat(rules.size(), equalTo(Processors.getAllProcessors().size()));
+            rules.forEach(
+                    rule -> assertThat(Processors.getProcessor(rule.getKey()), is(notNullValue())));
+        }
 
-    @Test
-    void inferRules_subsetOfRulesShouldHaveACorrespondingProcessor() {
-        // arrange
-        List<IRuleType> ruleTypes = List.of();
-        boolean handledRules = true;
+        @Test
+        void shouldHaveAllRulesFilteredByRuleTypes() {
+            // arrange
+            List<IRuleType> ruleTypes = List.of(SonarRuleType.VULNERABILITY);
 
-        // act
-        Collection<Rule> rules = RuleProvider.inferRules(ruleTypes, handledRules);
+            // act
+            Collection<Rule> rules = RuleProvider.getRulesByType(ruleTypes);
 
-        // assert
-        assertThat(rules.size(), equalTo(Processors.getAllProcessors().size()));
-        rules.forEach(
-                rule -> assertThat(Processors.getProcessor(rule.getKey()), is(notNullValue())));
+            // assert
+            rules.forEach(rule -> assertThat(rule.getType(), equalTo(SonarRuleType.VULNERABILITY)));
+        }
+
+        @Test
+        void shouldHaveAllHandledRulesFilteredByRuleTypes() {
+            // arrange
+            List<IRuleType> ruleTypes = List.of(SonarRuleType.CODE_SMELL);
+            boolean handledRules = true;
+
+            // act
+            Collection<Rule> rules = RuleProvider.inferRules(ruleTypes, handledRules);
+
+            // assert
+            rules.forEach(
+                    rule -> {
+                        assertThat(Processors.getProcessor(rule.getKey()), is(notNullValue()));
+                        assertThat(rule.getType(), is(SonarRuleType.CODE_SMELL));
+                    });
+        }
     }
 
     /**


### PR DESCRIPTION
The APIs provided in `RuleProvider` were already implemented in `SonarRuleRepository` so I refactored the former class to use those implementations. This improves the code coverage and removed redundant code.

@MartinWitt could you please review it? I also had one question. `RuleProvider` is now a generic class - it can fetch rules for other static analyzers in future. Does this indicate that we put it inside `sorald-api`?