### PR TITLE
refactor: pass CLI context rather than individual parameter

### DIFF
--- a/sorald-api/src/main/java/sorald/cli/CLIConfigForStaticAnalyzer.java
+++ b/sorald-api/src/main/java/sorald/cli/CLIConfigForStaticAnalyzer.java
@@ -1,0 +1,9 @@
+package sorald.cli;
+
+import java.util.List;
+
+public interface CLIConfigForStaticAnalyzer {
+    List<String> getClasspath();
+
+    CLIConfigForStaticAnalyzer setClasspath(List<String> classpath);
+}

--- a/sorald-api/src/main/java/sorald/cli/CLIConfigForStaticAnalyzer.java
+++ b/sorald-api/src/main/java/sorald/cli/CLIConfigForStaticAnalyzer.java
@@ -2,6 +2,7 @@ package sorald.cli;
 
 import java.util.List;
 
+/** Stores CLI options that is needed by {@link sorald.rule.StaticAnalyzer}. */
 public interface CLIConfigForStaticAnalyzer {
     List<String> getClasspath();
 

--- a/sorald-api/src/main/java/sorald/rule/StaticAnalyzer.java
+++ b/sorald-api/src/main/java/sorald/rule/StaticAnalyzer.java
@@ -3,6 +3,7 @@ package sorald.rule;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import sorald.cli.CLIConfigForStaticAnalyzer;
 
 /** A static analyzer for Java source code */
 public interface StaticAnalyzer {
@@ -13,9 +14,9 @@ public interface StaticAnalyzer {
      * @param projectRoot the root folder of the project.
      * @param files The files to analyze.
      * @param rule The rules to use.
-     * @param classpath Classpath that includes any dependencies.
+     * @param cliOptions Options for the static analyzer.
      * @return All violations of the rules found in the files.
      */
     Collection<RuleViolation> findViolations(
-            File projectRoot, List<File> files, List<Rule> rule, List<String> classpath);
+            File projectRoot, List<File> files, List<Rule> rule, CLIConfigForStaticAnalyzer cliOptions);
 }

--- a/sorald-api/src/main/java/sorald/rule/StaticAnalyzer.java
+++ b/sorald-api/src/main/java/sorald/rule/StaticAnalyzer.java
@@ -18,5 +18,8 @@ public interface StaticAnalyzer {
      * @return All violations of the rules found in the files.
      */
     Collection<RuleViolation> findViolations(
-            File projectRoot, List<File> files, List<Rule> rule, CLIConfigForStaticAnalyzer cliOptions);
+            File projectRoot,
+            List<File> files,
+            List<Rule> rule,
+            CLIConfigForStaticAnalyzer cliOptions);
 }

--- a/sorald/src/main/java/sorald/SoraldConfig.java
+++ b/sorald/src/main/java/sorald/SoraldConfig.java
@@ -2,16 +2,19 @@ package sorald;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
+import sorald.cli.CLIConfigForStaticAnalyzer;
 
 /* All config settings of Sorald should be gathered here */
-public class SoraldConfig {
+public class SoraldConfig implements CLIConfigForStaticAnalyzer {
     private PrettyPrintingStrategy prettyPrintingStrategy;
     private RepairStrategy repairStrategy;
     private String source;
     private int maxFixesPerRule;
     private int maxFilesPerSegment;
     private File statsOutputFile;
+    private List<String> classpath;
 
     public SoraldConfig() {}
 
@@ -61,5 +64,14 @@ public class SoraldConfig {
 
     public Optional<File> getStatsOutputFile() {
         return Optional.ofNullable(statsOutputFile);
+    }
+
+    public CLIConfigForStaticAnalyzer setClasspath(List<String> classpath) {
+        this.classpath = classpath;
+        return this;
+    }
+
+    public List<String> getClasspath() {
+        return classpath;
     }
 }

--- a/sorald/src/main/java/sorald/cli/MineCommand.java
+++ b/sorald/src/main/java/sorald/cli/MineCommand.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import picocli.CommandLine;
 import sorald.Constants;
 import sorald.FileUtils;
+import sorald.SoraldConfig;
 import sorald.event.StatsMetadataKeys;
 import sorald.event.collectors.MinerStatisticsCollector;
 import sorald.event.models.ExecutionInfo;
@@ -71,14 +72,11 @@ class MineCommand extends BaseCommand {
         List<Rule> checks = RuleProvider.inferRules(ruleTypes, handledRules);
 
         var statsCollector = new MinerStatisticsCollector();
-        List<String> classpath =
-                resolveClasspathFrom != null
-                        ? MavenUtils.resolveClasspath(resolveClasspathFrom.toPath())
-                        : List.of();
 
         var miner =
                 new MineSonarWarnings(
-                        statsOutputFile == null ? List.of() : List.of(statsCollector), classpath);
+                        statsOutputFile == null ? List.of() : List.of(statsCollector),
+                        createConfig());
 
         if (statsOnGitRepos) {
             List<String> reposList = Files.readAllLines(this.reposList.toPath());
@@ -132,5 +130,17 @@ class MineCommand extends BaseCommand {
                             .map(Enum::toString)
                             .collect(Collectors.toList()));
         }
+    }
+
+    private List<String> resolveClasspath() {
+        return resolveClasspathFrom != null
+                ? MavenUtils.resolveClasspath(resolveClasspathFrom.toPath())
+                : List.of();
+    }
+
+    private CLIConfigForStaticAnalyzer createConfig() {
+        SoraldConfig config = new SoraldConfig();
+        config.setClasspath(resolveClasspath());
+        return config;
     }
 }

--- a/sorald/src/main/java/sorald/cli/RepairCommand.java
+++ b/sorald/src/main/java/sorald/cli/RepairCommand.java
@@ -10,13 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import picocli.CommandLine;
-import sorald.Constants;
-import sorald.FileUtils;
-import sorald.PrettyPrintingStrategy;
-import sorald.Processors;
-import sorald.Repair;
-import sorald.RepairStrategy;
-import sorald.SoraldConfig;
+import sorald.*;
 import sorald.event.EventHelper;
 import sorald.event.EventType;
 import sorald.event.SoraldEventHandler;
@@ -187,7 +181,7 @@ class RepairCommand extends BaseCommand {
      * @param classpath
      * @return All found warnings.
      */
-    private static Set<RuleViolation> mineViolations(
+    private Set<RuleViolation> mineViolations(
             File target,
             String ruleKey,
             List<SoraldEventHandler> eventHandlers,
@@ -196,7 +190,10 @@ class RepairCommand extends BaseCommand {
         Path projectPath = target.toPath().toAbsolutePath().normalize();
         Set<RuleViolation> violations =
                 ProjectScanner.scanProject(
-                        target, FileUtils.getClosestDirectory(target), List.of(rule), classpath);
+                        target,
+                        FileUtils.getClosestDirectory(target),
+                        List.of(rule),
+                        createConfig());
         violations.forEach(
                 warn ->
                         EventHelper.fireEvent(
@@ -307,6 +304,7 @@ class RepairCommand extends BaseCommand {
         config.setMaxFilesPerSegment(maxFilesPerSegment);
         config.setRepairStrategy(repairStrategy);
         config.setStatsOutputFile(statsOutputFile);
+        config.setClasspath(resolveClasspath());
         return config;
     }
 }

--- a/sorald/src/main/java/sorald/miner/MineSonarWarnings.java
+++ b/sorald/src/main/java/sorald/miner/MineSonarWarnings.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import org.eclipse.jgit.api.Git;
 import sorald.FileUtils;
+import sorald.cli.CLIConfigForStaticAnalyzer;
 import sorald.event.EventHelper;
 import sorald.event.EventType;
 import sorald.event.SoraldEventHandler;
@@ -17,12 +18,13 @@ import sorald.sonar.SonarRule;
 
 public class MineSonarWarnings {
     final List<SoraldEventHandler> eventHandlers;
-    private final List<String> classpath;
+    private final CLIConfigForStaticAnalyzer cliOptions;
 
     public MineSonarWarnings(
-            List<? extends SoraldEventHandler> eventHandlers, List<String> classpath) {
+            List<? extends SoraldEventHandler> eventHandlers,
+            CLIConfigForStaticAnalyzer cliOptions) {
         this.eventHandlers = Collections.unmodifiableList(eventHandlers);
-        this.classpath = classpath;
+        this.cliOptions = cliOptions;
     }
 
     public void mineGitRepos(
@@ -87,7 +89,7 @@ public class MineSonarWarnings {
         EventHelper.fireEvent(EventType.MINING_START, eventHandlers);
         Set<RuleViolation> ruleViolations =
                 ProjectScanner.scanProject(
-                        target, FileUtils.getClosestDirectory(target), rules, classpath);
+                        target, FileUtils.getClosestDirectory(target), rules, cliOptions);
         EventHelper.fireEvent(EventType.MINING_END, eventHandlers);
 
         ruleViolations.stream()

--- a/sorald/src/main/java/sorald/sonar/ProjectScanner.java
+++ b/sorald/src/main/java/sorald/sonar/ProjectScanner.java
@@ -9,6 +9,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import sorald.Constants;
 import sorald.FileUtils;
+import sorald.cli.CLIConfigForStaticAnalyzer;
 import sorald.rule.Rule;
 import sorald.rule.RuleViolation;
 import sorald.rule.StaticAnalyzer;
@@ -26,7 +27,7 @@ public class ProjectScanner {
      * @return All violations in the target.
      */
     public static Set<RuleViolation> scanProject(File target, File baseDir, Rule rule) {
-        return scanProject(target, baseDir, List.of(rule));
+        return scanProject(target, baseDir, List.of(rule), null);
     }
 
     /**
@@ -38,7 +39,7 @@ public class ProjectScanner {
      * @return All violations in the target.
      */
     public static Set<RuleViolation> scanProject(File target, File baseDir, List<Rule> rules) {
-        return scanProject(target, baseDir, rules, List.of());
+        return scanProject(target, baseDir, rules, null);
     }
 
     /**
@@ -48,11 +49,11 @@ public class ProjectScanner {
      * @param target Targeted file or directory of the project.
      * @param baseDir Base directory of the project.
      * @param rules Rules to scan for.
-     * @param classpath Classpath to fetch type information from.
+     * @param cliOptions Options for static analyzer.
      * @return All violations in the target.
      */
     public static Set<RuleViolation> scanProject(
-            File target, File baseDir, List<Rule> rules, List<String> classpath) {
+            File target, File baseDir, List<Rule> rules, CLIConfigForStaticAnalyzer cliOptions) {
         List<File> filesToScan = new ArrayList<>();
         if (target.isFile()) {
             filesToScan.add(target);
@@ -66,7 +67,7 @@ public class ProjectScanner {
         ServiceLoader<StaticAnalyzer> analyzers = ServiceLoader.load(StaticAnalyzer.class);
         Set<RuleViolation> violations = new HashSet<>();
         for (StaticAnalyzer analyzer : analyzers) {
-            violations.addAll(analyzer.findViolations(baseDir, filesToScan, rules, classpath));
+            violations.addAll(analyzer.findViolations(baseDir, filesToScan, rules, cliOptions));
         }
         return new HashSet<>(violations);
     }

--- a/sorald/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
+++ b/sorald/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
@@ -73,7 +73,7 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
                         "sonar.java.libraries", String.join(",", cliOptions.getClasspath()))
                 .addIncludedRules(
                         rules.stream()
-                                .map(rule -> RuleKey.parse("java:" + rule.getKey()))
+                                .map(rule -> RuleKey.parse(String.format("java:%s", rule.getKey())))
                                 .collect(Collectors.toList()))
                 .addInputFiles(inputFiles)
                 .build();
@@ -85,7 +85,7 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
                 .setBaseDir(projectRoot.toPath())
                 .addIncludedRules(
                         rules.stream()
-                                .map(rule -> RuleKey.parse("java:" + rule.getKey()))
+                                .map(rule -> RuleKey.parse(String.format("java:%s", rule.getKey())))
                                 .collect(Collectors.toList()))
                 .addInputFiles(inputFiles)
                 .build();

--- a/sorald/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
+++ b/sorald/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
@@ -42,9 +42,10 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
         StandaloneAnalysisConfiguration config;
         if (cliOptions != null) {
             config =
-                    analysisConfigurationWithCliOptions(projectRoot, inputFiles, rules, cliOptions);
+                    getAnalysisConfigurationWithCliOptions(
+                            projectRoot, inputFiles, rules, cliOptions);
         } else {
-            config = analysisConfigurationWithoutCliOptions(projectRoot, inputFiles, rules);
+            config = getAnalysisConfigurationWithoutCliOptions(projectRoot, inputFiles, rules);
         }
 
         SonarLintEngine sonarLint = SonarLintEngine.getInstance();
@@ -57,7 +58,7 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
                 .collect(Collectors.toList());
     }
 
-    private static StandaloneAnalysisConfiguration analysisConfigurationWithCliOptions(
+    private static StandaloneAnalysisConfiguration getAnalysisConfigurationWithCliOptions(
             File projectRoot,
             List<JavaInputFile> inputFiles,
             List<Rule> rules,
@@ -78,7 +79,7 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
                 .build();
     }
 
-    private static StandaloneAnalysisConfiguration analysisConfigurationWithoutCliOptions(
+    private static StandaloneAnalysisConfiguration getAnalysisConfigurationWithoutCliOptions(
             File projectRoot, List<JavaInputFile> inputFiles, List<Rule> rules) {
         return StandaloneAnalysisConfiguration.builder()
                 .setBaseDir(projectRoot.toPath())

--- a/sorald/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
+++ b/sorald/src/main/java/sorald/sonar/SonarStaticAnalyzer.java
@@ -40,12 +40,12 @@ public class SonarStaticAnalyzer implements StaticAnalyzer {
                         .map(JavaInputFile::new)
                         .collect(Collectors.toList());
         StandaloneAnalysisConfiguration config;
-        if (cliOptions != null) {
+        if (cliOptions == null) {
+            config = getAnalysisConfigurationWithoutCliOptions(projectRoot, inputFiles, rules);
+        } else {
             config =
                     getAnalysisConfigurationWithCliOptions(
                             projectRoot, inputFiles, rules, cliOptions);
-        } else {
-            config = getAnalysisConfigurationWithoutCliOptions(projectRoot, inputFiles, rules);
         }
 
         SonarLintEngine sonarLint = SonarLintEngine.getInstance();


### PR DESCRIPTION
These changes modify how options from CLI are passed through the program. As of now, each option, like `classpath`, was passed individually as an argument to the concerned methods. However, upon the addition of new options in the CLI, we would have to modify all those methods. This is not good coding practice. Thus, I refactored the methods to use a generic CLI option store to contain all the arguments passed to the program.