### PR TITLE
chore: fix release script

### DIFF
--- a/experimentation/tools/sorald/release.py
+++ b/experimentation/tools/sorald/release.py
@@ -62,7 +62,7 @@ def _prepare_release(release_version: Optional[str]) -> None:
     release_version_arg = (
         f"-DreleaseVersion={release_version}" if release_version is not None else ""
     )
-    _run_cmd(f"mvn -B clean release:prepare -DpushChanges=false {release_version_arg}")
+    _run_cmd(f"mvn release:prepare -DpushChanges=false {release_version_arg}")
     _sign_last_n_commits(2)
     _sign_release_tag()
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
                         <artifactId>maven-scm-provider-gitexe</artifactId>
                         <version>1.12.2</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-api</artifactId>
+                        <version>1.11.2</version>
+                    </dependency>
                 </dependencies>
                 <executions>
                     <execution>


### PR DESCRIPTION
`mvn clean` removes the `target` directory so the JAR cannot be pushed to a GitHub release. However, initially, this was not a problem. I am not sure what happened while refactoring to `SPI`.