### PR TITLE
chore: fix failing tests

### DIFF
--- a/sorald/src/test/resources/scenario_test_files/classpath-dependent-project/pom.xml
+++ b/sorald/src/test/resources/scenario_test_files/classpath-dependent-project/pom.xml
@@ -17,6 +17,12 @@
       <groupId>fr.inria.gforge.spoon.labs</groupId>
       <artifactId>gumtree-spoon-ast-diff</artifactId>
       <version>1.24</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.osgi.service</groupId>
+          <artifactId>org.osgi.service.prefs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Apparently, maven launcher was failing to build the classpath due to an unresolvable dependency. For now, I ignored it from the test case's pom so that it is able to build the classpath. However, I am not sure how it works npw because that dependency, even though unresolvable, is a transitive dependency.