### PR TITLE
Support *BSD - in particular FreeBSD

### DIFF
--- a/sorald/src/main/java/sorald/FileUtils.java
+++ b/sorald/src/main/java/sorald/FileUtils.java
@@ -132,7 +132,7 @@ public class FileUtils {
             File cacheDir = new File(home + "\\Cache\\sorald\\");
             cacheDir.mkdirs();
             return cacheDir;
-        } else if (os.contains("Linux")) {
+        } else if (os.contains("Linux") || os.contains("BSD")) {
             File cacheDir = new File(home + "/.cache/sorald/");
             cacheDir.mkdirs();
             return cacheDir;


### PR DESCRIPTION
Caused by: java.lang.RuntimeException: FreeBSD not supported
	at sorald.FileUtils.getCacheDir(FileUtils.java:144)
	at sorald.sonar.SonarLintEngine.getOrDownloadSonarJavaPlugin(SonarLintEngine.java:76)
	at sorald.sonar.SonarLintEngine.<clinit>(SonarLintEngine.java:52)
	... 14 more