### PR TITLE
chore: fix windows build failure

### DIFF
--- a/sorald/src/main/java/sorald/event/collectors/RepairStatisticsCollector.java
+++ b/sorald/src/main/java/sorald/event/collectors/RepairStatisticsCollector.java
@@ -118,8 +118,8 @@ public class RepairStatisticsCollector implements SoraldEventHandler {
     }
 
     /** @return The total amount of time spent repairing */
-    public long getRepairTimeMs() {
-        return repairTotal / (long) Math.pow(10, 6);
+    public double getRepairTimeMs() {
+        return repairTotal / Math.pow(10, 6);
     }
 
     /** @return The total amount of execution time in milliseconds. */

--- a/sorald/src/main/java/sorald/event/collectors/RepairStatisticsCollector.java
+++ b/sorald/src/main/java/sorald/event/collectors/RepairStatisticsCollector.java
@@ -48,11 +48,11 @@ public class RepairStatisticsCollector implements SoraldEventHandler {
                 parseStart = INVALID_TIME;
                 break;
             case REPAIR_START:
-                repairStart = System.currentTimeMillis();
+                repairStart = System.nanoTime();
                 break;
             case REPAIR_END:
                 assert repairStart != INVALID_TIME;
-                long repairEnd = System.currentTimeMillis();
+                long repairEnd = System.nanoTime();
                 repairTotal += repairEnd - repairStart;
                 repairStart = INVALID_TIME;
                 break;
@@ -119,7 +119,7 @@ public class RepairStatisticsCollector implements SoraldEventHandler {
 
     /** @return The total amount of time spent repairing */
     public long getRepairTimeMs() {
-        return repairTotal;
+        return repairTotal / (long) Math.pow(10, 6);
     }
 
     /** @return The total amount of execution time in milliseconds. */

--- a/sorald/src/test/java/sorald/GatherStatsTest.java
+++ b/sorald/src/test/java/sorald/GatherStatsTest.java
@@ -78,7 +78,7 @@ public class GatherStatsTest {
                 greaterThan(0));
 
         assertThat(jo.getLong(StatsMetadataKeys.PARSE_TIME_MS), greaterThan(0L));
-        assertThat(jo.getLong(StatsMetadataKeys.REPAIR_TIME_MS), greaterThan(0L));
+        assertThat(jo.getDouble(StatsMetadataKeys.REPAIR_TIME_MS), greaterThan(0d));
         assertThat(jo.getLong(StatsMetadataKeys.START_TIME_MS), greaterThan(0L));
         assertThat(jo.getLong(StatsMetadataKeys.END_TIME_MS), greaterThan(0L));
         assertThat(jo.getLong(StatsMetadataKeys.TOTAL_TIME_MS), greaterThan(0L));


### PR DESCRIPTION
Fixes #863 

Phew ... this took a while to debug. Playing around in #864 made me realise that the repair time for some test was being reported incorrectly. As you can see [here](https://github.com/SpoonLabs/sorald/runs/7897645976?check_suite_focus=true#step:10:228), the `repairTimeMs` for one of the repairs is `0ms`, and in the tests we want it to be [greater than `0`](https://github.com/SpoonLabs/sorald/blob/master/sorald/src/test/java/sorald/GatherStatsTest.java#L81). I draw upon the following conclusion from my analysis - the repairs were performed in less than a millisecond so the difference was not captured by `repairEnd` and `repairStart` as they both were not precise enough.

I am using `System.nanoTime` for computing time in the changes because 1) it is more precise and 2) it seems to be more reliable according to many online resources including this StackOverflow post [here](https://stackoverflow.com/a/2979239).