### PR TITLE
tests: add configuration to verify that MathOnFloatProcessor does skip repairs for Incomplete cases

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -237,3 +237,12 @@ for an example.
 > capture formatting that's of absolute relevance to Sorald itself and its
 > transformations. Overspecifying exact matches leads to unnecessary work down
 > the line.
+
+#### Testing partially fixable rules
+
+Some processors cannot repair all cases of a violation, and they are called
+`IncompleteProcessor`. To keep track of which cases we do not attempt to
+repair, one can create test files prefixed with `INCOMPLETE`. The test suite
+will ensure that the violation persists after Sorald is run. See
+[INCOMPLETE_DoNotCastFloat.java](sorald/src/test/resources/processor_test_files/S2164_MathOnFloat/INCOMPLETE_DoNotCastFloat.java)
+for an example.

--- a/sorald/src/test/java/sorald/Assertions.java
+++ b/sorald/src/test/java/sorald/Assertions.java
@@ -72,18 +72,6 @@ public class Assertions {
     }
 
     /**
-     * Assert the exact amount of violations the file has.
-     *
-     * @param file A file to analyze.
-     * @param rule A rule to analyze for.
-     * @param expectedRuleViolations expected number of violations.
-     */
-    public static void assertHasRuleViolation(File file, Rule rule, int expectedRuleViolations) {
-        var violations = ProjectScanner.scanProject(file, file.getParentFile(), rule);
-        assertThat(violations.size(), is(expectedRuleViolations));
-    }
-
-    /**
      * Assert that the provided file has no violations of the rule.
      *
      * @param file A file to analyze.

--- a/sorald/src/test/java/sorald/Assertions.java
+++ b/sorald/src/test/java/sorald/Assertions.java
@@ -72,6 +72,18 @@ public class Assertions {
     }
 
     /**
+     * Assert the exact amount of violations the file has.
+     *
+     * @param file A file to analyze.
+     * @param rule A rule to analyze for.
+     * @param expectedRuleViolations expected number of violations.
+     */
+    public static void assertHasRuleViolation(File file, Rule rule, int expectedRuleViolations) {
+        var violations = ProjectScanner.scanProject(file, file.getParentFile(), rule);
+        assertThat(violations.size(), is(expectedRuleViolations));
+    }
+
+    /**
      * Assert that the provided file has no violations of the rule.
      *
      * @param file A file to analyze.

--- a/sorald/src/test/java/sorald/processor/ProcessorTest.java
+++ b/sorald/src/test/java/sorald/processor/ProcessorTest.java
@@ -91,6 +91,7 @@ public class ProcessorTest {
         ProcessorTestHelper.runSorald(testCase);
 
         assertHasRuleViolation(testCase.repairedFilePath().toFile(), testCase.getRule(), 1);
+        assertCompiles(testCase.repairedFilePath().toFile());
     }
 
     private static class IncompleteProcessorCaseFileProvider implements ArgumentsProvider {

--- a/sorald/src/test/java/sorald/processor/ProcessorTest.java
+++ b/sorald/src/test/java/sorald/processor/ProcessorTest.java
@@ -85,6 +85,10 @@ public class ProcessorTest {
         }
     }
 
+    /**
+     * Test cases that process non-repairable cases in partially fixable rules. This ensures that
+     * the violations exist even after the repair is performed.
+     */
     @ParameterizedTest
     @ArgumentsSource(IncompleteProcessorCaseFileProvider.class)
     void testProcessNonRepairableCases(ProcessorTestHelper.ProcessorTestCase testCase) {

--- a/sorald/src/test/java/sorald/processor/ProcessorTestHelper.java
+++ b/sorald/src/test/java/sorald/processor/ProcessorTestHelper.java
@@ -153,6 +153,10 @@ public class ProcessorTestHelper {
         return !testFile.getName().startsWith("NOCOMPILE");
     }
 
+    public static boolean hasCasesThatMakeProcessorIncomplete(ProcessorTestCase testCase) {
+        return testCase.nonCompliantFile.getName().startsWith("INCOMPLETE");
+    }
+
     /**
      * Return a stream of all valid test cases, based on the tests files in {@link
      * ProcessorTestHelper#TEST_FILES_ROOT}. The test case source files are put in a temporary
@@ -164,14 +168,13 @@ public class ProcessorTestHelper {
     }
 
     /** Run sorald on the given test case. */
-    public static void runSorald(ProcessorTestCase testCase, String... extraArgs) throws Exception {
+    public static void runSorald(ProcessorTestCase testCase, String... extraArgs) {
         Assertions.assertHasRuleViolation(testCase.nonCompliantFile, testCase.getRule());
         runSorald(testCase.nonCompliantFile, testCase.getRule(), extraArgs);
     }
 
     /** Run sorald on the given file with the given checkClass * */
-    public static void runSorald(File originaFilesPath, Rule rule, String... extraArgs)
-            throws Exception {
+    public static void runSorald(File originaFilesPath, Rule rule, String... extraArgs) {
         String originalFileAbspath = originaFilesPath.getAbsolutePath();
 
         boolean brokenWithSniper = BROKEN_WITH_SNIPER.contains(rule);

--- a/sorald/src/test/resources/processor_test_files/S2164_MathOnFloat/INCOMPLETE_DoNotCastFloat.java
+++ b/sorald/src/test/resources/processor_test_files/S2164_MathOnFloat/INCOMPLETE_DoNotCastFloat.java
@@ -1,0 +1,5 @@
+class DoNoCastFloat {
+    float a = 16777216.0f;
+    float b = 1.0f;
+    final float c = a + b;
+}


### PR DESCRIPTION
I felt the test was necessary so that we are sure that the violation is being detected, but we are intentionally not repairing it.