### PR TITLE
governance: Remove slarse as developer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,6 @@
     </licenses>
     <developers>
         <developer>
-            <id>slarse</id>
-            <name>Simon Larsén</name>
-            <email>slarse@kth.se</email>
-            <organization>KTH Royal Institute of Technology</organization>
-            <organizationUrl>https://www.kth.se</organizationUrl>
-        </developer>
-        <developer>
             <id>khaes-kth</id>
             <name>Khashayar Etemadi</name>
             <email>khaes@kth.se</email>

--- a/sorald-api/pom.xml
+++ b/sorald-api/pom.xml
@@ -26,13 +26,6 @@
 
     <developers>
         <developer>
-            <id>slarse</id>
-            <name>Simon Larsén</name>
-            <email>slarse@kth.se</email>
-            <organization>KTH Royal Institute of Technology</organization>
-            <organizationUrl>https://www.kth.se</organizationUrl>
-        </developer>
-        <developer>
             <id>khaes-kth</id>
             <name>Khashayar Etemadi</name>
             <email>khaes@kth.se</email>

--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -26,13 +26,6 @@
 
     <developers>
         <developer>
-            <id>slarse</id>
-            <name>Simon Larsén</name>
-            <email>slarse@kth.se</email>
-            <organization>KTH Royal Institute of Technology</organization>
-            <organizationUrl>https://www.kth.se</organizationUrl>
-        </developer>
-        <developer>
             <id>khaes-kth</id>
             <name>Khashayar Etemadi</name>
             <email>khaes@kth.se</email>


### PR DESCRIPTION
I haven't been actively involved in this project for along time, so I think removing my name from the list(s) of developers. These are to my understanding for those actively maintaining the project and should not act as a historical account of contributors.