### PR TITLE
chore: update google-java-format to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
                             <include>src/test/java/**/*.java</include>
                         </includes>
                         <googleJavaFormat>
-                            <version>1.9</version>
+                            <version>1.15.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
                     </java>

--- a/sorald-api/pom.xml
+++ b/sorald-api/pom.xml
@@ -198,7 +198,7 @@
                             <include>src/test/java/**/*.java</include>
                         </includes>
                         <googleJavaFormat>
-                            <version>1.9</version>
+                            <version>1.15.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
                     </java>

--- a/sorald-api/src/main/java/sorald/annotations/IncompleteProcessor.java
+++ b/sorald-api/src/main/java/sorald/annotations/IncompleteProcessor.java
@@ -9,6 +9,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 /** Annotation to mark that a processor is only a partial fix for its associated rule. */
 public @interface IncompleteProcessor {
-    /** @return A description as to why and how the processor is incomplete. */
+    /**
+     * @return A description as to why and how the processor is incomplete.
+     */
     String description();
 }

--- a/sorald-api/src/main/java/sorald/event/SoraldEvent.java
+++ b/sorald-api/src/main/java/sorald/event/SoraldEvent.java
@@ -4,6 +4,8 @@ package sorald.event;
 @FunctionalInterface
 public interface SoraldEvent {
 
-    /** @return The type of this event */
+    /**
+     * @return The type of this event
+     */
     EventType type();
 }

--- a/sorald-api/src/main/java/sorald/processor/SoraldAbstractProcessor.java
+++ b/sorald-api/src/main/java/sorald/processor/SoraldAbstractProcessor.java
@@ -125,7 +125,9 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
      */
     protected abstract void repairInternal(E element);
 
-    /** @return Whether or not this processor is incomplete. */
+    /**
+     * @return Whether or not this processor is incomplete.
+     */
     public boolean isIncomplete() {
         return getClass().getAnnotation(IncompleteProcessor.class) != null;
     }
@@ -181,7 +183,9 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
         return getNbFixes() < maxFixes && bestFits.containsKey(element);
     }
 
-    /** @return The numerical identifier of the rule this processor is related to */
+    /**
+     * @return The numerical identifier of the rule this processor is related to
+     */
     public String getRuleKey() {
         return Arrays.stream(getClass().getAnnotationsByType(ProcessorAnnotation.class))
                 .map(ProcessorAnnotation::key)
@@ -193,7 +197,9 @@ public abstract class SoraldAbstractProcessor<E extends CtElement> extends Abstr
                 .toString();
     }
 
-    /** @return The concrete type that this processor accepts. */
+    /**
+     * @return The concrete type that this processor accepts.
+     */
     @SuppressWarnings("unchecked")
     public Class<E> getTargetType() {
         assert getProcessedElementTypes().size() == 1;

--- a/sorald-api/src/main/java/sorald/rule/Rule.java
+++ b/sorald-api/src/main/java/sorald/rule/Rule.java
@@ -3,12 +3,18 @@ package sorald.rule;
 /** A static analysis rule */
 public interface Rule {
 
-    /** @return A key that uniquely identifies this rule within Sorald. */
+    /**
+     * @return A key that uniquely identifies this rule within Sorald.
+     */
     String getKey();
 
-    /** @return The name of this rule. */
+    /**
+     * @return The name of this rule.
+     */
     String getName();
 
-    /** @return The type of this rule. */
+    /**
+     * @return The type of this rule.
+     */
     IRuleType getType();
 }

--- a/sorald-api/src/main/java/sorald/rule/RuleViolation.java
+++ b/sorald-api/src/main/java/sorald/rule/RuleViolation.java
@@ -9,25 +9,39 @@ import sorald.Constants;
 /** Representation of a violation of some Sonar rule */
 public abstract class RuleViolation implements Comparable<RuleViolation> {
 
-    /** @return The line the element that violates the rule starts on. */
+    /**
+     * @return The line the element that violates the rule starts on.
+     */
     public abstract int getStartLine();
 
-    /** @return The line the element that violates the rule ends on. */
+    /**
+     * @return The line the element that violates the rule ends on.
+     */
     public abstract int getEndLine();
 
-    /** @return The column the element that violates the rule starts on. */
+    /**
+     * @return The column the element that violates the rule starts on.
+     */
     public abstract int getStartCol();
 
-    /** @return The column the element that violates the rule ends on. */
+    /**
+     * @return The column the element that violates the rule ends on.
+     */
     public abstract int getEndCol();
 
-    /** @return Absolute and normalized path to the analyzed file. */
+    /**
+     * @return Absolute and normalized path to the analyzed file.
+     */
     public abstract Path getAbsolutePath();
 
-    /** @return The key of the violated rule. */
+    /**
+     * @return The key of the violated rule.
+     */
     public abstract String getRuleKey();
 
-    /** @return A message describing the problem. */
+    /**
+     * @return A message describing the problem.
+     */
     public String getMessage() {
         throw new UnsupportedOperationException(
                 "getMessage() should not be called on this instance");

--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -219,7 +219,7 @@
                             <include>src/test/java/**/*.java</include>
                         </includes>
                         <googleJavaFormat>
-                            <version>1.9</version>
+                            <version>1.15.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
                     </java>

--- a/sorald/src/main/java/sorald/Processors.java
+++ b/sorald/src/main/java/sorald/Processors.java
@@ -21,7 +21,9 @@ public class Processors {
                 .orElse(null);
     }
 
-    /** @return A list of all processors sorted by name. */
+    /**
+     * @return A list of all processors sorted by name.
+     */
     public static List<Class<? extends SoraldAbstractProcessor<?>>> getAllProcessors() {
         ServiceLoader<ProcessorRepository> loader = ServiceLoader.load(ProcessorRepository.class);
         return loader.stream()

--- a/sorald/src/main/java/sorald/SelectiveForceImport.java
+++ b/sorald/src/main/java/sorald/SelectiveForceImport.java
@@ -16,7 +16,9 @@ import spoon.reflect.visitor.LexicalScope;
 public class SelectiveForceImport extends ForceImportProcessor {
     private final Set<CtTypeReference<?>> excludedReferences;
 
-    /** @param referencesToIgnore A collection of references to ignore when force-importing. */
+    /**
+     * @param referencesToIgnore A collection of references to ignore when force-importing.
+     */
     public SelectiveForceImport(Collection<CtTypeReference<?>> referencesToIgnore) {
         // use identity rather than equality to identify existing references to avoid mistaking
         // clones for originals

--- a/sorald/src/main/java/sorald/cli/Cli.java
+++ b/sorald/src/main/java/sorald/cli/Cli.java
@@ -7,7 +7,9 @@ import picocli.CommandLine;
 public class Cli {
     private Cli() {}
 
-    /** @return Sorald's command line interface. */
+    /**
+     * @return Sorald's command line interface.
+     */
     public static CommandLine createCli() {
         return new CommandLine(new SoraldCLI());
     }

--- a/sorald/src/main/java/sorald/event/collectors/CompilationUnitCollector.java
+++ b/sorald/src/main/java/sorald/event/collectors/CompilationUnitCollector.java
@@ -29,7 +29,9 @@ public class CompilationUnitCollector implements SoraldEventHandler {
             collectCompilationUnit(((RepairEvent) event).getElement());
         }
     }
-    /** @return All unique compilation units that have been collected from repair events. */
+    /**
+     * @return All unique compilation units that have been collected from repair events.
+     */
     public Set<CtCompilationUnit> getCollectedCompilationUnits() {
         return newIdentityHashSet(pathToCu.values());
     }

--- a/sorald/src/main/java/sorald/event/collectors/MinerStatisticsCollector.java
+++ b/sorald/src/main/java/sorald/event/collectors/MinerStatisticsCollector.java
@@ -42,22 +42,30 @@ public class MinerStatisticsCollector implements SoraldEventHandler {
         }
     }
 
-    /** @return The start time of mining */
+    /**
+     * @return The start time of mining
+     */
     public Date getMiningStartTime() {
         return new Date(miningStartTime);
     }
 
-    /** @return The end time of mining */
+    /**
+     * @return The end time of mining
+     */
     public Date getMiningEndTime() {
         return new Date(miningEndTime);
     }
 
-    /** @return The duration of mining in millis */
+    /**
+     * @return The duration of mining in millis
+     */
     public long getTotalMiningTime() {
         return miningEndTime - miningStartTime;
     }
 
-    /** @return All mined rules data */
+    /**
+     * @return All mined rules data
+     */
     public List<MinedRule> getMinedRules() {
         return ruleToViolations.entrySet().stream()
                 .map(

--- a/sorald/src/main/java/sorald/event/collectors/RepairStatisticsCollector.java
+++ b/sorald/src/main/java/sorald/event/collectors/RepairStatisticsCollector.java
@@ -87,52 +87,72 @@ public class RepairStatisticsCollector implements SoraldEventHandler {
         eventsMap.get(key).add(event);
     }
 
-    /** @return All repair events that were performed without errors. */
+    /**
+     * @return All repair events that were performed without errors.
+     */
     public Map<String, List<RepairEvent>> performedRepairs() {
         return Collections.unmodifiableMap(keyToRepairs);
     }
 
-    /** @return All repair events that crashed during execution. */
+    /**
+     * @return All repair events that crashed during execution.
+     */
     public Map<String, List<RepairEvent>> crashedRepairs() {
         return Collections.unmodifiableMap(keyToFailures);
     }
 
-    /** @return Mapping from key to all warnings mined for that key before repairs. */
+    /**
+     * @return Mapping from key to all warnings mined for that key before repairs.
+     */
     public Map<String, List<MinedViolationEvent>> minedViolationsBefore() {
         return Collections.unmodifiableMap(minedViolationsBefore);
     }
 
-    /** @return Mapping from key to all warnings mined for that key after repairs. */
+    /**
+     * @return Mapping from key to all warnings mined for that key after repairs.
+     */
     public Map<String, List<MinedViolationEvent>> minedViolationsAfter() {
         return Collections.unmodifiableMap(minedViolationsAfter);
     }
 
-    /** @return All crash event data */
+    /**
+     * @return All crash event data
+     */
     public List<SoraldEvent> getCrashes() {
         return Collections.unmodifiableList(crashes);
     }
 
-    /** @return The total amount of time spent parsing */
+    /**
+     * @return The total amount of time spent parsing
+     */
     public long getParseTimeMs() {
         return parseTotal;
     }
 
-    /** @return The total amount of time spent repairing */
+    /**
+     * @return The total amount of time spent repairing
+     */
     public double getRepairTimeMs() {
         return repairTotal / Math.pow(10, 6);
     }
 
-    /** @return The total amount of execution time in milliseconds. */
+    /**
+     * @return The total amount of execution time in milliseconds.
+     */
     public long getTotalTimeMs() {
         return execEnd - execStart;
     }
 
-    /** @return The start time of execution in milliseconds from the unix epoch. */
+    /**
+     * @return The start time of execution in milliseconds from the unix epoch.
+     */
     public long getStartTimeMs() {
         return execStart;
     }
 
-    /** @return The end time of execution in milliseconds from the unix epoch. */
+    /**
+     * @return The end time of execution in milliseconds from the unix epoch.
+     */
     public long getEndTimeMs() {
         return execEnd;
     }

--- a/sorald/src/main/java/sorald/processor/XxeProcessingProcessor.java
+++ b/sorald/src/main/java/sorald/processor/XxeProcessingProcessor.java
@@ -145,7 +145,9 @@ public class XxeProcessingProcessor extends SoraldAbstractProcessor<CtInvocation
         return method;
     }
 
-    /** @return A local variable initialized to the given expression. */
+    /**
+     * @return A local variable initialized to the given expression.
+     */
     private <T> CtLocalVariable<T> createLocalVariable(String variableName, CtExpression<T> expr) {
         return getFactory().createLocalVariable(expr.getType().clone(), variableName, expr.clone());
     }


### PR DESCRIPTION
Same reason as https://github.com/algomaster99/collector-sahab/pull/107.

The formatting change is due to an update.
> The basic form is always acceptable. The single-line form may be substituted when the entirety of the Javadoc block (including comment markers) can fit on a single line. Note that this only applies when there are no block tags such as @return. Source: https://google.github.io/styleguide/javaguide.html#s7.1.1-javadoc-multi-line

The maven version is the CI is also 3.8.6 as confirmed [here](https://github.com/algomaster99/collector-sahab/pull/107/commits/6ce9beb3334f77a2017c2d3cede74e05e06f0e4b).