### PR TITLE
chore: release sorald 0.7.1

### DIFF
--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
     <artifactId>sorald</artifactId>
-    <version>0.7.1-SNAPSHOT</version>
+    <version>0.7.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Sorald</name>
@@ -393,7 +393,7 @@
         <connection>scm:git:https://github.com/SpoonLabs/sorald.git</connection>
         <developerConnection>scm:git:ssh://github.com/SpoonLabs/sorald.git</developerConnection>
         <url>https://github.com/SpoonLabs/sorald</url>
-        <tag>HEAD</tag>
+        <tag>sorald-0.7.1</tag>
     </scm>
 
     <distributionManagement>

--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
     <artifactId>sorald</artifactId>
-    <version>0.7.1</version>
+    <version>0.7.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Sorald</name>
@@ -393,7 +393,7 @@
         <connection>scm:git:https://github.com/SpoonLabs/sorald.git</connection>
         <developerConnection>scm:git:ssh://github.com/SpoonLabs/sorald.git</developerConnection>
         <url>https://github.com/SpoonLabs/sorald</url>
-        <tag>sorald-0.7.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/sorald/src/test/resources-its/sorald/it/MineMojoIT/pom_configured/pom.xml
+++ b/sorald/src/test/resources-its/sorald/it/MineMojoIT/pom_configured/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>se.kth.castor</groupId>
                 <artifactId>sorald</artifactId>
-                <version>0.7.1-SNAPSHOT</version>
+                <version>0.7.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/sorald/src/test/resources-its/sorald/it/MineMojoIT/pom_configured/pom.xml
+++ b/sorald/src/test/resources-its/sorald/it/MineMojoIT/pom_configured/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>se.kth.castor</groupId>
                 <artifactId>sorald</artifactId>
-                <version>0.7.1</version>
+                <version>0.7.2-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The maven plugin in previous release #910 did not work as expected because some of the dependencies were tagged to their `SNAPSHOTS` and that threw the following error.
```
[ERROR] Failed to execute goal se.kth.castor:sorald:0.7.0:mine (default-cli) on project gumtree-spoon-ast-diff: Execution default-cli of goal se.kth.castor:sorald:0.7.0:mine failed: Plugin se.kth.castor:sorald:0.7.0 or one of its dependencies could not be resolved: Failed to collect dependencies at se.kth.castor:sorald:jar:0.7.0 -> se.kth.castor:sorald-api:jar:0.0.2: Failed to read artifact descriptor for se.kth.castor:sorald-api:jar:0.0.2: Could not find artifact se.kth.castor:sorald-parent:pom:0.0.2-SNAPSHOT -> [Help 1]
```

#911 ensured that all versions are pinned so now I am releasing another version of `sorald` and hopefully that would make the `maven-plugin` work.