### PR TITLE
fix(S4973): add null check to the overall expression

### DIFF
--- a/sorald/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.md
+++ b/sorald/src/main/java/sorald/processor/CompareStringsBoxedTypesWithEqualsProcessor.md
@@ -1,12 +1,13 @@
 Any comparison of strings or boxed types using `==` or `!=` is replaced by `equals`.
+By default, we use `equals` on the left operand, so we add a null check before comparison.
 
 Example:
 ```diff
 -        if (firstName == lastName) // Noncompliant
-+        if (firstName.equals(lastName))
++        if (firstName != null && firstName.equals(lastName))
 ...
 -        return b != a; // Noncompliant
-+        return !b.equals(a);
++        return b != null && !b.equals(a);
 ```
 
 Check out an accepted PR in [Apache Sling Discovery](https://github.com/apache/sling-org-apache-sling-discovery-impl/pull/1) that repairs one CompareStringsBoxedTypesWithEquals violation.

--- a/sorald/src/test/resources/processor_test_files/S4973_CompareStringsBoxedTypesWithEquals/CompareStringsBoxedTypesWithEquals.java.expected
+++ b/sorald/src/test/resources/processor_test_files/S4973_CompareStringsBoxedTypesWithEquals/CompareStringsBoxedTypesWithEquals.java.expected
@@ -8,7 +8,7 @@ public class CompareStringsBoxedTypesWithEquals {
         String firstName = getFirstName(); // String overrides equals
         String lastName = getLastName();
 
-        if (firstName.equals(lastName)) { } 
+        if (firstName != null && firstName.equals(lastName)) { }
     }
 
     // Aditional tests
@@ -26,7 +26,7 @@ public class CompareStringsBoxedTypesWithEquals {
     private boolean IntegerCompare() {
         Integer a = 5;
         Integer b = 5;
-        return !b.equals(a); 
+        return b != null && !b.equals(a);
     }
 
     // Int is primitive and can use ==
@@ -60,7 +60,7 @@ public class CompareStringsBoxedTypesWithEquals {
     private boolean stringCompare() {
         String firstName = getFirstName(); // String overrides equals
         String lastName = getLastName();
-        if (firstName.equals(lastName)) { 
+        if (firstName != null && firstName.equals(lastName)) {
             return true;
         }
         return false;


### PR DESCRIPTION
Fixes #915 

SonarSource has updated their [repair for S4973](https://rules.sonarsource.com/java/RSPEC-4973) and included a `null` check before comparison. Since we cannot know which operand is `null` while static analysing, we add a `null` check to the left operand.