### PR TITLE
fix(S1068): delete field writes of violated field only

### DIFF
--- a/sorald/src/main/java/sorald/processor/UnusedPrivateFieldProcessor.java
+++ b/sorald/src/main/java/sorald/processor/UnusedPrivateFieldProcessor.java
@@ -1,6 +1,7 @@
 package sorald.processor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import sorald.annotations.ProcessorAnnotation;
 import spoon.reflect.code.CtFieldWrite;
 import spoon.reflect.code.CtStatement;
@@ -12,18 +13,22 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class UnusedPrivateFieldProcessor extends SoraldAbstractProcessor<CtField<?>> {
     @Override
     protected void repairInternal(CtField<?> element) {
-        removeAllUnusedPrivateFieldWrites(element);
-        element.delete();
-    }
+        List<CtFieldWrite> unusedFieldWrites = getFieldWritesOfSpecifiedField(element);
 
-    /** Removes all writes to the given field that are not read anywhere. */
-    private static void removeAllUnusedPrivateFieldWrites(CtField<?> field) {
-        CtClass<?> parentClass = field.getParent(CtClass.class);
-        List<CtFieldWrite<?>> unusedFieldWrites =
-                parentClass.filterChildren(new TypeFilter<>(CtFieldWrite.class)).list();
         for (CtFieldWrite<?> unusedFieldWrite : unusedFieldWrites) {
             CtStatement statement = unusedFieldWrite.getParent(CtStatement.class);
             statement.delete();
         }
+        element.delete();
+    }
+
+    private static List<CtFieldWrite> getFieldWritesOfSpecifiedField(CtField<?> field) {
+        CtClass<?> parentClass = field.getParent(CtClass.class);
+        return parentClass
+                .filterChildren(new TypeFilter<>(CtFieldWrite.class))
+                .list(CtFieldWrite.class)
+                .stream()
+                .filter(fw -> fw.getVariable().getSimpleName().equals(field.getSimpleName()))
+                .collect(Collectors.toList());
     }
 }

--- a/sorald/src/main/java/sorald/processor/UnusedPrivateFieldProcessor.java
+++ b/sorald/src/main/java/sorald/processor/UnusedPrivateFieldProcessor.java
@@ -13,13 +13,16 @@ import spoon.reflect.visitor.filter.TypeFilter;
 public class UnusedPrivateFieldProcessor extends SoraldAbstractProcessor<CtField<?>> {
     @Override
     protected void repairInternal(CtField<?> element) {
+        // Delete the field
+        element.delete();
+
+        // Delete its usage
         List<CtFieldWrite> unusedFieldWrites = getFieldWritesOfSpecifiedField(element);
 
         for (CtFieldWrite<?> unusedFieldWrite : unusedFieldWrites) {
             CtStatement statement = unusedFieldWrite.getParent(CtStatement.class);
             statement.delete();
         }
-        element.delete();
     }
 
     private static List<CtFieldWrite> getFieldWritesOfSpecifiedField(CtField<?> field) {

--- a/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java
+++ b/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java
@@ -3,11 +3,18 @@ public class PrivateFieldWrittenButNotRead {
 
     private String foo; // Noncompliant
 
+    private long used;
+
     public PrivateFieldWrittenButNotRead(int x, int y) {
         this.x = x + y;
     }
 
     public void initialize(String bar) {
         foo = bar;
+        used = 234324L;
+    }
+
+    public long getUsed() {
+        return used;
     }
 }

--- a/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java
+++ b/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java
@@ -3,7 +3,7 @@ public class PrivateFieldWrittenButNotRead {
 
     private String foo; // Noncompliant
 
-    private long used;
+    private long zhang;
 
     public PrivateFieldWrittenButNotRead(int x, int y) {
         this.x = x + y;
@@ -11,10 +11,10 @@ public class PrivateFieldWrittenButNotRead {
 
     public void initialize(String bar) {
         foo = bar;
-        used = 234324L;
+        zhang = 234324L;
     }
 
-    public long getUsed() {
-        return used;
+    public long getZhang() {
+        return zhang;
     }
 }

--- a/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java.expected
+++ b/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java.expected
@@ -1,13 +1,13 @@
 public class PrivateFieldWrittenButNotRead {
-    private long used;
+    private long zhang;
 
     public PrivateFieldWrittenButNotRead(int x, int y) { }
 
     public void initialize(String bar) {
-        used = 234324L;
+        zhang = 234324L;
     }
 
-    public long getUsed() {
-        return used;
+    public long getZhang() {
+        return zhang;
     }
 }

--- a/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java.expected
+++ b/sorald/src/test/resources/processor_test_files/S1068_UnusedPrivateField/PrivateFieldWrittenButNotRead.java.expected
@@ -1,6 +1,13 @@
 public class PrivateFieldWrittenButNotRead {
+    private long used;
 
     public PrivateFieldWrittenButNotRead(int x, int y) { }
 
-    public void initialize(String bar) { }
+    public void initialize(String bar) {
+        used = 234324L;
+    }
+
+    public long getUsed() {
+        return used;
+    }
 }


### PR DESCRIPTION
I forgot to add a filter to delete field writes of only those field which are unused in #917 . The changes ensure that all field writes are not deleted.