### PR TITLE
fix: return correct version of sorald

### DIFF
--- a/sorald/src/main/java/sorald/cli/MineCommand.java
+++ b/sorald/src/main/java/sorald/cli/MineCommand.java
@@ -138,7 +138,7 @@ class MineCommand extends BaseCommand {
                             StatsMetadataKeys.EXECUTION_INFO,
                             new ExecutionInfo(
                                     originalArgs,
-                                    SoraldVersionProvider.getVersionFromPropertiesResource(
+                                    SoraldVersionProvider.getVersionFromManifests(
                                             SoraldVersionProvider.DEFAULT_RESOURCE_NAME),
                                     System.getProperty(Constants.JAVA_VERSION_SYSTEM_PROPERTY),
                                     target));

--- a/sorald/src/main/java/sorald/cli/RepairCommand.java
+++ b/sorald/src/main/java/sorald/cli/RepairCommand.java
@@ -245,7 +245,7 @@ class RepairCommand extends BaseCommand {
         var executionInfo =
                 new ExecutionInfo(
                         originalArgs,
-                        SoraldVersionProvider.getVersionFromPropertiesResource(
+                        SoraldVersionProvider.getVersionFromManifests(
                                 SoraldVersionProvider.DEFAULT_RESOURCE_NAME),
                         System.getProperty(Constants.JAVA_VERSION_SYSTEM_PROPERTY),
                         target);

--- a/sorald/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/sorald/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -34,7 +34,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
     public static String getVersionFromManifests(String resourceName) throws JarException {
         try {
             Enumeration<URL> resources =
-                    SoraldVersionProvider.class.getClassLoader().getResources(resourceName);
+                    Thread.currentThread().getContextClassLoader().getResources(resourceName);
             while (resources.hasMoreElements()) {
                 Manifest jarManifest = new Manifest(resources.nextElement().openStream());
                 String mainClass = jarManifest.getMainAttributes().getValue(MAIN_CLASS);

--- a/sorald/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/sorald/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -1,12 +1,18 @@
 package sorald.cli;
 
-import java.util.Properties;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import picocli.CommandLine;
 
 /** Class for providing the CLI with the current version. */
 public class SoraldVersionProvider implements CommandLine.IVersionProvider {
     public static final String LOCAL_VERSION = "LOCAL";
 
+    static final String MAIN_CLASS = "Main-Class";
+    static final String MAIN_CLASS_NAME = "sorald.Main";
     static final String VERSION_KEY = "Implementation-Version";
     static final String COMMIT_KEY = "Implementation-SCM-Revision";
 
@@ -14,7 +20,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
 
     @Override
     public String[] getVersion() {
-        return new String[] {getVersionFromPropertiesResource(DEFAULT_RESOURCE_NAME)};
+        return new String[] {getVersionFromManifests(DEFAULT_RESOURCE_NAME)};
     }
 
     /**
@@ -24,24 +30,24 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
      * @param resourceName Name of the resource.
      * @return The resolved version.
      */
-    public static String getVersionFromPropertiesResource(String resourceName) {
-        Properties props = new Properties();
+    public static String getVersionFromManifests(String resourceName) {
         try {
-            props.load(SoraldVersionProvider.class.getResourceAsStream("/" + resourceName));
-        } catch (Exception e) {
+            Enumeration<URL> resources =
+                    SoraldVersionProvider.class.getClassLoader().getResources(resourceName);
+            while (resources.hasMoreElements()) {
+                Manifest jarManifest = new Manifest(resources.nextElement().openStream());
+                String mainClass = jarManifest.getMainAttributes().getValue(MAIN_CLASS);
+                if (mainClass != null && mainClass.equals(MAIN_CLASS_NAME)) {
+                    Attributes mainAttributes = jarManifest.getMainAttributes();
+                    String version = mainAttributes.getValue(VERSION_KEY);
+                    String commitSha = mainAttributes.getValue(COMMIT_KEY);
+
+                    return version.contains("SNAPSHOT") ? "commit: " + commitSha : version;
+                }
+            }
+        } catch (IOException e) {
             return LOCAL_VERSION;
         }
-        return getVersionFromProperties(props);
-    }
-
-    private static String getVersionFromProperties(Properties props) {
-        String version = props.getProperty(VERSION_KEY);
-        String commitSha = props.getProperty(COMMIT_KEY);
-
-        if (version == null || commitSha == null) {
-            return LOCAL_VERSION;
-        } else {
-            return version.contains("SNAPSHOT") ? "commit: " + commitSha : version;
-        }
+        return LOCAL_VERSION;
     }
 }

--- a/sorald/src/main/java/sorald/cli/SoraldVersionProvider.java
+++ b/sorald/src/main/java/sorald/cli/SoraldVersionProvider.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.jar.Attributes;
+import java.util.jar.JarException;
 import java.util.jar.Manifest;
 import picocli.CommandLine;
 
@@ -19,7 +20,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
     public static final String DEFAULT_RESOURCE_NAME = "META-INF/MANIFEST.MF";
 
     @Override
-    public String[] getVersion() {
+    public String[] getVersion() throws JarException {
         return new String[] {getVersionFromManifests(DEFAULT_RESOURCE_NAME)};
     }
 
@@ -30,7 +31,7 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
      * @param resourceName Name of the resource.
      * @return The resolved version.
      */
-    public static String getVersionFromManifests(String resourceName) {
+    public static String getVersionFromManifests(String resourceName) throws JarException {
         try {
             Enumeration<URL> resources =
                     SoraldVersionProvider.class.getClassLoader().getResources(resourceName);
@@ -38,16 +39,30 @@ public class SoraldVersionProvider implements CommandLine.IVersionProvider {
                 Manifest jarManifest = new Manifest(resources.nextElement().openStream());
                 String mainClass = jarManifest.getMainAttributes().getValue(MAIN_CLASS);
                 if (mainClass != null && mainClass.equals(MAIN_CLASS_NAME)) {
-                    Attributes mainAttributes = jarManifest.getMainAttributes();
-                    String version = mainAttributes.getValue(VERSION_KEY);
-                    String commitSha = mainAttributes.getValue(COMMIT_KEY);
-
-                    return version.contains("SNAPSHOT") ? "commit: " + commitSha : version;
+                    return getVersionFromSoraldManifest(jarManifest);
                 }
             }
+        } catch (JarException e) {
+            throw new JarException(e.getMessage());
         } catch (IOException e) {
             return LOCAL_VERSION;
         }
         return LOCAL_VERSION;
+    }
+
+    private static String getVersionFromSoraldManifest(Manifest manifest) throws JarException {
+        Attributes mainAttributes = manifest.getMainAttributes();
+        String version = mainAttributes.getValue(VERSION_KEY);
+        String commitSha = mainAttributes.getValue(COMMIT_KEY);
+
+        if (version == null) {
+            throw new JarException(String.format("%s not set in POM.", VERSION_KEY));
+        }
+
+        if (commitSha == null) {
+            throw new JarException(String.format("%s not set in POM.", COMMIT_KEY));
+        }
+
+        return version.contains("SNAPSHOT") ? "commit: " + commitSha : version;
     }
 }

--- a/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
+++ b/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
@@ -9,14 +9,14 @@ import java.nio.file.Paths;
 import java.util.jar.JarException;
 import org.junit.jupiter.api.Test;
 
-public class SoraldVersionProviderTest {
+class SoraldVersionProviderTest {
     private static final Path BOGUS_MANIFESTS = Paths.get("META-INF").resolve("bogus-manifests");
 
     private static final String VERSION_IN_MANIFESTS = "1.2.3";
     private static final String COMMIT_IN_MANIFESTS = "123456";
 
     @Test
-    public void getVersionFromPropertiesResource_returnsLocalVersion_whenResourceDoesNotExist()
+    void getVersionFromPropertiesResource_returnsLocalVersion_whenResourceDoesNotExist()
             throws JarException {
         assertThat(
                 SoraldVersionProvider.getVersionFromManifests("no/such/resource"),
@@ -24,8 +24,7 @@ public class SoraldVersionProviderTest {
     }
 
     @Test
-    public void getVersionFromPropertiesResource_returnsVersion_whenNonSnapshot()
-            throws JarException {
+    void getVersionFromPropertiesResource_returnsVersion_whenNonSnapshot() throws JarException {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-RELEASE-VERSION.MF").toString();
         assertThat(
                 SoraldVersionProvider.getVersionFromManifests(resourceName),
@@ -33,8 +32,7 @@ public class SoraldVersionProviderTest {
     }
 
     @Test
-    public void getVersionFromPropertiesResource_returnsCommitSha_whenSnapshot()
-            throws JarException {
+    void getVersionFromPropertiesResource_returnsCommitSha_whenSnapshot() throws JarException {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-SNAPSHOT-VERSION.MF").toString();
         assertThat(
                 SoraldVersionProvider.getVersionFromManifests(resourceName),
@@ -42,7 +40,7 @@ public class SoraldVersionProviderTest {
     }
 
     @Test
-    public void getVersionFromPropertiesResource_throwsJarException_whenResourceIsMissingVersion() {
+    void getVersionFromPropertiesResource_throwsJarException_whenResourceIsMissingVersion() {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-WITHOUT-VERSION.MF").toString();
         assertThrows(
                 JarException.class,

--- a/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
+++ b/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
@@ -48,4 +48,12 @@ public class SoraldVersionProviderTest {
                 JarException.class,
                 () -> SoraldVersionProvider.getVersionFromManifests(resourceName));
     }
+
+    @Test
+    void getVersionFromPropertiesResource_throwsJarException_whenResourceIsMissingCommitSha() {
+        String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-WITHOUT-COMMIT-SHA.MF").toString();
+        assertThrows(
+                JarException.class,
+                () -> SoraldVersionProvider.getVersionFromManifests(resourceName));
+    }
 }

--- a/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
+++ b/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
@@ -2,9 +2,11 @@ package sorald.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.jar.JarException;
 import org.junit.jupiter.api.Test;
 
 public class SoraldVersionProviderTest {
@@ -14,14 +16,16 @@ public class SoraldVersionProviderTest {
     private static final String COMMIT_IN_MANIFESTS = "123456";
 
     @Test
-    public void getVersionFromPropertiesResource_returnsLocalVersion_whenResourceDoesNotExist() {
+    public void getVersionFromPropertiesResource_returnsLocalVersion_whenResourceDoesNotExist()
+            throws JarException {
         assertThat(
                 SoraldVersionProvider.getVersionFromManifests("no/such/resource"),
                 equalTo(SoraldVersionProvider.LOCAL_VERSION));
     }
 
     @Test
-    public void getVersionFromPropertiesResource_returnsVersion_whenNonSnapshot() {
+    public void getVersionFromPropertiesResource_returnsVersion_whenNonSnapshot()
+            throws JarException {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-RELEASE-VERSION.MF").toString();
         assertThat(
                 SoraldVersionProvider.getVersionFromManifests(resourceName),
@@ -29,7 +33,8 @@ public class SoraldVersionProviderTest {
     }
 
     @Test
-    public void getVersionFromPropertiesResource_returnsCommitSha_whenSnapshot() {
+    public void getVersionFromPropertiesResource_returnsCommitSha_whenSnapshot()
+            throws JarException {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-SNAPSHOT-VERSION.MF").toString();
         assertThat(
                 SoraldVersionProvider.getVersionFromManifests(resourceName),
@@ -37,11 +42,10 @@ public class SoraldVersionProviderTest {
     }
 
     @Test
-    public void
-            getVersionFromPropertiesResource_returnsLocalVersion_whenResourceIsMissingVersion() {
+    public void getVersionFromPropertiesResource_throwsJarException_whenResourceIsMissingVersion() {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-WITHOUT-VERSION.MF").toString();
-        assertThat(
-                SoraldVersionProvider.getVersionFromManifests(resourceName),
-                equalTo(SoraldVersionProvider.LOCAL_VERSION));
+        assertThrows(
+                JarException.class,
+                () -> SoraldVersionProvider.getVersionFromManifests(resourceName));
     }
 }

--- a/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
+++ b/sorald/src/test/java/sorald/cli/SoraldVersionProviderTest.java
@@ -16,7 +16,7 @@ public class SoraldVersionProviderTest {
     @Test
     public void getVersionFromPropertiesResource_returnsLocalVersion_whenResourceDoesNotExist() {
         assertThat(
-                SoraldVersionProvider.getVersionFromPropertiesResource("no/such/resource"),
+                SoraldVersionProvider.getVersionFromManifests("no/such/resource"),
                 equalTo(SoraldVersionProvider.LOCAL_VERSION));
     }
 
@@ -24,7 +24,7 @@ public class SoraldVersionProviderTest {
     public void getVersionFromPropertiesResource_returnsVersion_whenNonSnapshot() {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-RELEASE-VERSION.MF").toString();
         assertThat(
-                SoraldVersionProvider.getVersionFromPropertiesResource(resourceName),
+                SoraldVersionProvider.getVersionFromManifests(resourceName),
                 equalTo(VERSION_IN_MANIFESTS));
     }
 
@@ -32,7 +32,7 @@ public class SoraldVersionProviderTest {
     public void getVersionFromPropertiesResource_returnsCommitSha_whenSnapshot() {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-SNAPSHOT-VERSION.MF").toString();
         assertThat(
-                SoraldVersionProvider.getVersionFromPropertiesResource(resourceName),
+                SoraldVersionProvider.getVersionFromManifests(resourceName),
                 equalTo("commit: " + COMMIT_IN_MANIFESTS));
     }
 
@@ -41,7 +41,7 @@ public class SoraldVersionProviderTest {
             getVersionFromPropertiesResource_returnsLocalVersion_whenResourceIsMissingVersion() {
         String resourceName = BOGUS_MANIFESTS.resolve("MANIFEST-WITHOUT-VERSION.MF").toString();
         assertThat(
-                SoraldVersionProvider.getVersionFromPropertiesResource(resourceName),
+                SoraldVersionProvider.getVersionFromManifests(resourceName),
                 equalTo(SoraldVersionProvider.LOCAL_VERSION));
     }
 }

--- a/sorald/src/test/java/sorald/miner/WarningMinerTest.java
+++ b/sorald/src/test/java/sorald/miner/WarningMinerTest.java
@@ -170,7 +170,7 @@ public class WarningMinerTest {
         assertThat(
                 executionInfo.get(StatsMetadataKeys.SORALD_VERSION),
                 equalTo(
-                        SoraldVersionProvider.getVersionFromPropertiesResource(
+                        SoraldVersionProvider.getVersionFromManifests(
                                 SoraldVersionProvider.DEFAULT_RESOURCE_NAME)));
         assertThat(
                 executionInfo.get(StatsMetadataKeys.JAVA_VERSION),

--- a/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-RELEASE-VERSION.MF
+++ b/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-RELEASE-VERSION.MF
@@ -1,3 +1,4 @@
 Manifest-Version: 1.0
 Implementation-Version: 1.2.3
 Implementation-SCM-Revision: 123456
+Main-Class: sorald.Main

--- a/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-SNAPSHOT-VERSION.MF
+++ b/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-SNAPSHOT-VERSION.MF
@@ -1,3 +1,4 @@
 Manifest-Version: 1.0
 Implementation-Version: 1.2.3-SNAPSHOT
 Implementation-SCM-Revision: 123456
+Main-Class: sorald.Main

--- a/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-WITHOUT-COMMIT-SHA.MF
+++ b/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-WITHOUT-COMMIT-SHA.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Implementation-Version: 1.2.3-SNAPSHOT
+Main-Class: sorald.Main

--- a/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-WITHOUT-VERSION.MF
+++ b/sorald/src/test/resources/META-INF/bogus-manifests/MANIFEST-WITHOUT-VERSION.MF
@@ -1,2 +1,3 @@
 Manifest-Version: 1.0
 Implementation-SCM-Revision: 123456
+Main-Class: sorald.Main


### PR DESCRIPTION
Fixes #895 

The CLI always returned `LOCAL` and did not return the actual version. The changes fix that. Now, the SNAPSHOT versions return the `commit sha` and the releases return the version number.