### PR TITLE
chore: fix sorald SNAPSHOT deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         id: get-sorald-version
         shell: bash
         run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -pl sorald)
           echo "::set-output name=version::$VERSION"
 
       - name: Setup Java for deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Publish to Maven Central
         if: ${{ contains(steps.get-sorald-version.outputs.version, 'SNAPSHOT') || github.event_name == 'release' }}
-        run: mvn -Prelease deploy
+        run: mvn -Prelease deploy -pl sorald
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_CENTRAL_TOKEN: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
The `deploy` workflow was not doing anything for a while because it used to fetch the version of `sorald-parent` and that is fixed since https://github.com/SpoonLabs/sorald/pull/911 so the workflow used to skip deployment of `sorald` as well. Adding `-pl sorald` would compute the version of `sorald` module and not `sorald-parent`.