### PR TITLE
tests: use latest release for pom_configured test

### DIFF
--- a/sorald/src/test/resources-its/sorald/it/MineMojoIT/pom_configured/pom.xml
+++ b/sorald/src/test/resources-its/sorald/it/MineMojoIT/pom_configured/pom.xml
@@ -21,7 +21,6 @@
             <plugin>
                 <groupId>se.kth.castor</groupId>
                 <artifactId>sorald</artifactId>
-                <version>0.7.4-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
I removed the version tag from this test to avoid changing [it every time I release `sorald`](https://github.com/SpoonLabs/sorald/pull/927/files). One downside to this change is that we won't be testing this specific test with the latest SNAPSHOT, instead, we would be testing it with the latest release on maven central. I think it is a fine compromise to make because it is _very unlikely_ that other integration tests will pass, but this specific test will fail.

Initially, maven had an option `<version>LATEST</version>` to fetch the latest SNAPSHOT at build time and use it. However, it has been deprecated in maven `3.x` in favour of reproducibility.