### PR TITLE
chore: remove sorald-api dependence on sonarlint-core

### DIFF
--- a/sorald-api/pom.xml
+++ b/sorald-api/pom.xml
@@ -41,13 +41,6 @@
         </developer>
     </developers>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.sonarsource.sonarlint.core</groupId>
-            <artifactId>sonarlint-core</artifactId>
-            <version>8.11.0.56591</version>
-        </dependency>
-    </dependencies>
     <properties>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Thanks to my SBOM analysis and then confirmation via depclean.