### PR TITLE
fix: Do not throw away stacktrace when downloading sonar java fails

### DIFF
--- a/sorald/src/main/java/sorald/sonar/SonarLintEngine.java
+++ b/sorald/src/main/java/sorald/sonar/SonarLintEngine.java
@@ -88,8 +88,8 @@ public final class SonarLintEngine extends AbstractSonarLintEngine {
                     Paths.get(sonarJavaPluginFileName),
                     StandardCopyOption.REPLACE_EXISTING);
             return new SonarJavaJarHolder(new File(sonarJavaPluginFileName).toPath(), true);
-        } catch (IOException ignore) {
-            throw new RuntimeException("Could not download Sonar Java plugin"); // NOSONAR:S112
+        } catch (IOException e) {
+            throw new RuntimeException("Could not download Sonar Java plugin", e); // NOSONAR:S112
         }
     }
 


### PR DESCRIPTION
This is causing some headaches as CI runs are failing without any clue as to *why*. The URL is reachable locally (but maybe not from the runner?) and the saving works (but maybe the runner has a permission or space issue?).

Was there a deliberate reason for swallowing the stacktrace here?