### PR TITLE
chore: install the plugin locally before deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           mvn -Prelease deploy -pl sorald
           mvn -Prelease deploy -pl sorald-api
-          mvn -Prelease deploy -pl se.kth.castor:sorald-parent
+          mvn -Prelease deploy -pl se.kth.castor:sorald-parent # Fully qualified artifact ID is required
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_CENTRAL_TOKEN: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Build
-        run: mvn -B package
+        run: mvn -B install
 
       - name: Get Sorald version
         id: get-sorald-version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,10 @@ jobs:
 
       - name: Publish to Maven Central
         if: ${{ contains(steps.get-sorald-version.outputs.version, 'SNAPSHOT') || github.event_name == 'release' }}
-        run: mvn -Prelease deploy -pl sorald
+        run: |
+          mvn -Prelease deploy -pl sorald
+          mvn -Prelease deploy -pl sorald-api
+          mvn -Prelease deploy -pl se.kth.castor:sorald-parent
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_CENTRAL_TOKEN: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
The step [here](https://github.com/SpoonLabs/sorald/actions/runs/3959123404/jobs/6781537470#step:7:3027) indicates that the SNAPSHOT version of maven-plugin was not found. `mvn install`ing it should fix the issue.