### PR TITLE
chore: update maven-plugin test extension

### DIFF
--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -106,13 +106,13 @@
         <dependency>
             <groupId>com.soebes.itf.jupiter.extension</groupId>
             <artifactId>itf-assertj</artifactId>
-            <version>0.11.0</version>
+            <version>0.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.soebes.itf.jupiter.extension</groupId>
             <artifactId>itf-jupiter-extension</artifactId>
-            <version>0.11.0</version>
+            <version>0.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sorald/src/test/java/sorald/it/MineMojoIT.java
+++ b/sorald/src/test/java/sorald/it/MineMojoIT.java
@@ -79,8 +79,8 @@ public class MineMojoIT {
     @MavenTest
     @DisplayName("Mine respects stats output file parameter and generates a JSON file")
     void stats_output_file(MavenExecutionResult result) {
-        File projectRoot = result.getMavenProjectResult().getTargetProjectDirectory();
-        File statsOutputFile = new File(projectRoot, "stats.json");
+        Path projectRoot = result.getMavenProjectResult().getTargetProjectDirectory();
+        File statsOutputFile = new File(projectRoot.toFile(), "stats.json");
 
         org.hamcrest.MatcherAssert.assertThat(statsOutputFile, anExistingFile());
     }

--- a/sorald/src/test/java/sorald/it/RepairMojoIT.java
+++ b/sorald/src/test/java/sorald/it/RepairMojoIT.java
@@ -9,6 +9,7 @@ import com.soebes.itf.jupiter.extension.MavenOption;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 import java.io.File;
+import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 
 @MavenJupiterExtension
@@ -67,8 +68,8 @@ public class RepairMojoIT {
     @MavenTest
     @DisplayName("Repair respects stats output file parameter and generates a JSON file")
     void stats_output_file(MavenExecutionResult result) {
-        File projectRoot = result.getMavenProjectResult().getTargetProjectDirectory();
-        File statsOutputFile = new File(projectRoot, "stats.json");
+        Path projectRoot = result.getMavenProjectResult().getTargetProjectDirectory();
+        File statsOutputFile = new File(projectRoot.toFile(), "stats.json");
 
         org.hamcrest.MatcherAssert.assertThat(statsOutputFile, anExistingFile());
     }


### PR DESCRIPTION
Reference: https://github.com/SpoonLabs/sorald/pull/970 https://github.com/SpoonLabs/sorald/pull/971

This dependency upgrade caused [breaking changes](https://github.com/khmarbaise/maven-it-extension/blob/12d9354c7f75d7a17f82bac5ccbc70cc00e327d4/itf-documentation/src/main/asciidoc/release-notes/_release-notes-0.12.0.adoc) so needed to deal with them in a separate PR. @cesarsotovalero, you might require it too. Do take a look when you plan to upgrade it.