### PR TITLE
chore: upgrade sonarlint-core to 8.14.0.63103

### DIFF
--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sonarsource.sonarlint.core</groupId>
             <artifactId>sonarlint-core</artifactId>
-            <version>8.11.0.56591</version>
+            <version>8.14.0.63103</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>


### PR DESCRIPTION
Continues #954.

The extra fixes were needed to prevent the plugin instance loader from being closed.